### PR TITLE
Updating some out-of-date information in README

### DIFF
--- a/.prerequisites.py
+++ b/.prerequisites.py
@@ -23,7 +23,7 @@ def dumb_version_check(cmd):
     return shs(cmd + ' --version')
 
 def osx():
-    return sh("test $(uname) == 'Darwin'")
+    return sh('[ "$(uname)" = "Darwin" ]')
 
 both_checks = [
     ('git',

--- a/README.md
+++ b/README.md
@@ -1,13 +1,11 @@
 # builder
 
-*TEMPORARY REPO WHILE ANY CREDENTIALS OR SENSITIVE INFORMATION IS CUT OUT*
-
 An attempt to centralize the configuration and building of application 
 environments, locally (Vagrant) and remotely (AWS).
 
 Test that you have the system prerequisites installed:
 
-    ./prerequisites.py
+    ./.prerequisites.py
     
 It's up to you to install/update/configure anything missing.
 


### PR DESCRIPTION
`test` for comparison fails when the shell used by Python is `sh`. `[ ... ]` should be more portable.
