### PR TITLE
Cluster is supported in stack names but optional

### DIFF
--- a/src/aws.py
+++ b/src/aws.py
@@ -1,6 +1,5 @@
 import os
 from fabric.api import settings
-from fabfile import PROJECT_DIR
 from buildercore import core, config, project
 from buildercore.utils import lookup
 from buildercore.decorators import osissue, osissuefn

--- a/src/cfn.py
+++ b/src/cfn.py
@@ -1,6 +1,5 @@
 from fabric.api import task, local, cd, lcd, settings, run, sudo, put, get
 from fabric.contrib.files import exists
-from fabfile import PROJECT_DIR
 from fabric.contrib import files
 from fabric.contrib.console import confirm
 import aws, utils

--- a/src/tests/test_deploy.py
+++ b/src/tests/test_deploy.py
@@ -1,4 +1,5 @@
 from .base import BaseCase
+from deploy import build_stack_name
 
 class TestDeployTasks(BaseCase):
     def setUp(self):
@@ -9,4 +10,10 @@ class TestDeployTasks(BaseCase):
 
     def test_deploy_task(self):
         "a deploy task exists"
+
+    def test_building_stack_names(self):
+        self.assertEqual(build_stack_name('lax', 'master'), 'lax--master')
+        self.assertEqual(build_stack_name('lax', 'master', 'ci'), 'lax--master--ci')
+
+
         


### PR DESCRIPTION
```
$ PYTHONPATH=src green tests.test_deploy
..

Ran 2 tests in 0.119s

OK (passes=2)
```
