### PR TITLE
Defining build to run on Alfred

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,0 +1,10 @@
+elifePipeline {
+    stage 'Checkout'
+    checkout scm
+
+    stage 'Update'
+    sh './update.sh --exclude virtualbox vagrant'
+
+    stage 'Test'
+    sh './test.sh'
+}


### PR DESCRIPTION
Works, but at the end of the build http://ci.alfred.elifesciences.org/job/test-builder/2/console I get:
```
Coverage.py warning: No data was collected.
...
09:25:55 .unittest.sh: line 15: [: -le: unary operator expected
```