### PR TITLE
Recovers from a command being passed a non-existent stackname on the cli

### DIFF
--- a/src/decorators.py
+++ b/src/decorators.py
@@ -98,8 +98,7 @@ def requires_aws_stack(func):
             return
         if not stackname or stackname not in asl:
             stackname = utils._pick("stack", asl, default_file=deffile('.active-stack'))
-        else:
-            args = args[1:]
+        args = args[1:]
         return func(stackname, *args, **kwargs)
     return call
 


### PR DESCRIPTION
After the `stackname` is not found in the list and asked to the user, the wrong value has to be removed from `args` to avoid passing it twice with two different values:
```
(venv) [09:51:39][giorgio@Newton:~/code/builder]$ ./bldr aws_update_stack:does_not_exist
1467967958.687872 - WARNING - MainProcess - buildercore.decorators - TODO: embarassing code. some of these constants should be pulled form project config or given better names.
1467967958.710811 - INFO - MainProcess - buildercore.config - using settings path u'/home/giorgio/code/builder/settings.yml'
1467967959.244435 - WARNING - MainProcess - buildercore.decorators - TODO: `raw_aws_stacks` duplicate code/unclear differences. .list_stacks with filter vs .describe_stacks with stackname
1467967964.498469 - WARNING - MainProcess - buildercore.decorators - TODO: `_pick` renamed from `_pick` to something. `choose` ?

please pick a known stack:
1 - api-gateway--2016-07-01
2 - api-gateway--end2end
3 - elife-bot--2016-07-05
4 - elife-metrics--2016-07-04
5 - journal--master
6 - journal-cms--master
7 - lax--2016-06-27
8 - master-server--temp
> ('api-gateway--end2end') 2
Traceback (most recent call last):
  File "/home/giorgio/code/builder/venv/local/lib/python2.7/site-packages/fabric/main.py", line 745, in main
    *args, **kwargs
  File "/home/giorgio/code/builder/venv/local/lib/python2.7/site-packages/fabric/tasks.py", line 427, in execute
    results['<local-only>'] = task.run(*args, **new_kwargs)
  File "/home/giorgio/code/builder/venv/local/lib/python2.7/site-packages/fabric/tasks.py", line 174, in run
    return self.wrapped(*args, **kwargs)
  File "/home/giorgio/code/builder/src/decorators.py", line 103, in call
    return func(stackname, *args, **kwargs)
TypeError: update() takes exactly 1 argument (2 given)
```