### PR TITLE
Slightly better error message in case of bad status of CloudFormation stack

### DIFF
--- a/src/buildercore/core.py
+++ b/src/buildercore/core.py
@@ -218,7 +218,11 @@ def stack_data(stackname):
 def stack_is_active(stackname):
     "returns True if the given stack is in a completed state"
     try:
-        return describe_stack(stackname).stack_status in ['CREATE_COMPLETE', 'UPDATE_COMPLETE']
+        description = describe_stack(stackname)
+        result = description.stack_status in ['CREATE_COMPLETE', 'UPDATE_COMPLETE']
+        if not result:
+            LOG.info("stack_status is '%s'\nDescription: %s", description.stack_status, vars(description))
+        return result
     except BotoServerError as err:
         if err.message.endswith('does not exist'):
             return False


### PR DESCRIPTION
I encountered a duplicate DNS entry (why is that will be another PR) and
that caused the failure of the instance creation. The error message
didn't tell anything about what was wrong, so I try to print the state
and some information about the stack.

```
1467991239.151267 - INFO - MainProcess - buildercore.core - stack_status
is 'ROLLBACK_COMPLETE'
Description: {'disable_rollback': False, 'description': None,
'parameters': [Parameter:"KeyName"="journal--develop--ci"], 'tags': {},
'stack_id':
u'arn:aws:cloudformation:eu-central-1:512686554592:stack/journal--develop--ci/20b4f5f0-451c-11e6-9e52-50a68ae71462',
'outputs': [], 'stack_status_reason': None, 'creation_time':
datetime.datetime(2016, 7, 8, 14, 56, 19, 159000), 'capabilities': [],
'stack_name': u'journal--develop--ci', 'connection':
CloudFormationConnection:cloudformation.eu-central-1.amazonaws.com,
'stack_status': u'ROLLBACK_COMPLETE', 'timeout_in_minutes': None,
'notification_arns': []}
```