### PR TITLE
Includes cluster in the hostname for DNS uniqueness

### DIFF
--- a/src/buildercore/core.py
+++ b/src/buildercore/core.py
@@ -330,7 +330,13 @@ def requires_stack_file(func):
 def hostname_struct(stackname):
     "returns a dictionary with convenient domain name information"
     # wrangle hostname data
-    pname, instance_id = instanceid_from_stackname(stackname)
+
+    triple = parse_stackname(stackname)
+    if len(triple) == 3:
+        pname, instance_id, cluster = triple
+    else:
+        pname, instance_id = triple
+        cluster = None
     pdata = project.project_data(pname)
     domain = pdata.get('domain')
     subdomain = pdata.get('subdomain')
@@ -348,7 +354,10 @@ def hostname_struct(stackname):
 
     # removes any non-alphanumeric or hyphen characters
     instance_id = re.sub(r'[^\w\-]', '', instance_id)
-    hostname = instance_id + "." + subdomain
+    if cluster:
+        hostname = instance_id + "--" + cluster + "." + subdomain
+    else:
+        hostname = instance_id + "." + subdomain
 
     struct['hostname'] = hostname
     struct['full_hostname'] = hostname + "." + pdata['domain']

--- a/src/tests/test_buildercore_core.py
+++ b/src/tests/test_buildercore_core.py
@@ -32,6 +32,17 @@ class SimpleCases(base.BaseCase):
         }
         stackname = 'dummy2--test'
         self.assertEqual(core.hostname_struct(stackname), expected)
+
+    def test_hostname_struct_with_cluster(self):
+        expected = {
+            'domain': "example.org",
+            'subdomain': 'dummy2',
+            'project_hostname': 'dummy2.example.org',
+            'hostname': 'develop--end2end.dummy2',
+            'full_hostname': 'develop--end2end.dummy2.example.org',
+        }
+        stackname = 'dummy2--develop--end2end'
+        self.assertEqual(core.hostname_struct(stackname), expected)
     
     def test_project_name_from_stackname(self):
         expected = [


### PR DESCRIPTION
This mimics what happens with the old builder, where we had
`develop--end2end.lax.elifesciences.org` and
`develop--ci.lax.elifesciences.org` available.

Before this change, the domain name would be
`develop.lax.elifesciences.org` and 2 machines will conflict with each
other.

After this is in, I would go on with simplifying deploy to only take
`stackname` and `cluster` (trying to leave the option of an additional `number` open for the future if we have multiple machines for failover/load balancing/etc).