### PR TITLE
Do not fail on deleting the stack related to a key we do not have.

### DIFF
--- a/src/buildercore/keypair.py
+++ b/src/buildercore/keypair.py
@@ -65,10 +65,13 @@ def delete_keypair(stackname):
     # delete from fs
     # TODO: shift this into own func
     # just while debugging, move the deleted key to a 'deleted' dir
-    delete_path = join(config.KEYPAIR_PATH, "deleted")
-    utils.mkdir_p(delete_path)
-    shutil.copy2(expected_key, delete_path)
-    os.unlink(expected_key)
+    if os.path.exists(expected_key):
+        delete_path = join(config.KEYPAIR_PATH, "deleted")
+        utils.mkdir_p(delete_path)
+        shutil.copy2(expected_key, delete_path)
+        os.unlink(expected_key)
+    else:
+        LOG.info("private key %r not present on this machine" % expected_key)
     # TODO: this check needs to become part of a checklist of things after deletion
     if not os.path.exists(expected_key):
         LOG.warn("private key %r not deleted: found %r" % (stackname, expected_key))


### PR DESCRIPTION
The key may be missing because the current user is not the owner.

This check avoids errors like:
```
1468336116.496750 - INFO - MainProcess - buildercore.s3 - deleting key
Traceback (most recent call last):
  File "/home/giorgio/code/builder/venv/local/lib/python2.7/site-packages/fabric/main.py", line 745, in main
    *args, **kwargs
  File "/home/giorgio/code/builder/venv/local/lib/python2.7/site-packages/fabric/tasks.py", line 427, in execute
    results['<local-only>'] = task.run(*args, **new_kwargs)
  File "/home/giorgio/code/builder/venv/local/lib/python2.7/site-packages/fabric/tasks.py", line 174, in run
    return self.wrapped(*args, **kwargs)
  File "/home/giorgio/code/builder/src/decorators.py", line 101, in call
    return func(stackname, *args, **kwargs)
  File "/home/giorgio/code/builder/src/cfn.py", line 28, in delete
    return bootstrap.delete_stack(stackname)
  File "/home/giorgio/code/builder/src/buildercore/bootstrap.py", line 265, in delete_stack
    keypair.delete_keypair(stackname)
  File "/home/giorgio/code/builder/src/buildercore/keypair.py", line 70, in delete_keypair
    shutil.copy2(expected_key, delete_path)
  File "/usr/lib/python2.7/shutil.py", line 130, in copy2
    copyfile(src, dst)
  File "/usr/lib/python2.7/shutil.py", line 82, in copyfile
    with open(src, 'rb') as fsrc:
IOError: [Errno 2] No such file or directory: u'/home/giorgio/code/builder/.cfn/keypairs/api-gateway--2016-07-01.pem'
```