### PR TITLE
optional shellcheck support and script linting

### DIFF
--- a/.activate-venv.sh
+++ b/.activate-venv.sh
@@ -21,5 +21,5 @@ fi
 # 'ARCHFLAGS' fixes a problem with OSX refusing to compile a dependency
 export ARCHFLAGS="-Wno-error=unused-command-line-argument-hard-error-in-future"
 
-source venv/bin/activate
+. ./venv/bin/activate
 pip install -r requirements.txt

--- a/.shell-lint.sh
+++ b/.shell-lint.sh
@@ -1,0 +1,22 @@
+#!/bin/bash
+# lint our scripts
+set -e
+if which shellcheck &> /dev/null; then
+    # shellcheck is installed! shellcheck is a shell script linter
+    
+    checkshell () {
+        shell=$1
+        echo "testing against $shell..."
+        shellcheck --shell=$shell ./scripts/*.sh -e SC1091
+        shellcheck --shell=$shell ./*.sh -e SC1091
+    }
+    
+    checkshell "bash"
+    checkshell "sh"
+    checkshell "dash"
+    checkshell "ksh"
+
+else
+    echo "shellcheck not found! scripts NOT linted"
+    echo "https://github.com/koalaman/shellcheck"
+fi

--- a/.shell-lint.sh
+++ b/.shell-lint.sh
@@ -7,6 +7,10 @@ if which shellcheck &> /dev/null; then
     checkshell () {
         shell=$1
         echo "testing against $shell..."
+        
+        # disabled:
+        # - SC1091: Not following: <script> was not specified as input (see shellcheck -x).
+        
         shellcheck --shell=$shell ./scripts/*.sh -e SC1091
         shellcheck --shell=$shell ./*.sh -e SC1091
     }

--- a/canary.sh
+++ b/canary.sh
@@ -1,9 +1,4 @@
 #!/bin/bash
-
 set -e # everything must pass
-
-# upgrade all deps to latest version
-source .upgrade-deps.sh
-
-# run the tests
-source .unittest.sh
+. .upgrade-deps.sh # upgrade all deps to latest version
+. .unittest.sh # run the tests

--- a/regenerate-fixtures.sh
+++ b/regenerate-fixtures.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 set -e
-source venv/bin/activate
+. venv/bin/activate
 ./.project.py dummy1 --format json > src/tests/fixtures/dummy1-project.json
 ./.project.py dummy2 --format json > src/tests/fixtures/dummy2-project.json
 ./.project.py dummy3 --format json > src/tests/fixtures/dummy3-project.json

--- a/scripts/bootstrap.sh
+++ b/scripts/bootstrap.sh
@@ -25,7 +25,7 @@ chmod -R 777 /tmp
 
 installing=false
 upgrading=false
-if ! which salt-minion; then
+if ! command -v salt-minion > /dev/null; then
     installing=true
 else
     if ! (salt-minion --version | grep "$version"); then
@@ -58,9 +58,9 @@ fi
 
 
 # salt-master
-if [ "$install_master" == "true" ]; then
+if [ "$install_master" = "true" ]; then
     # salt is not installed or the version installed is old
-    if ! (type salt-master && salt-master --version | grep "$version"); then
+    if ! (command -v salt-master > /dev/null && salt-master --version | grep "$version"); then
         # master not installed
         sh salt_bootstrap.sh -P -F -M -c /tmp stable "$version"
     else

--- a/scripts/init-master.sh
+++ b/scripts/init-master.sh
@@ -33,7 +33,7 @@ if [ ! -f "/etc/salt/pki/master/minions/$stackname" ]; then
     fi
     # minion keys for master should exist at this point
     mkdir -p /etc/salt/pki/master/minions/
-    cp /etc/salt/pki/minion/minion.pub /etc/salt/pki/master/minions/$stackname
+    cp /etc/salt/pki/minion/minion.pub "/etc/salt/pki/master/minions/$stackname"
 fi
 
 
@@ -41,7 +41,7 @@ fi
 # REQUIRES CREDENTIALS!
 if [ ! -d /opt/builder-private ]; then
     cd /opt
-    git clone $pillar_repo builder-private || {
+    git clone "$pillar_repo" builder-private || {
         set +xv
         pubkey=$(cat /root/.ssh/id_rsa.pub)
         echo "

--- a/scripts/kick-master.sh
+++ b/scripts/kick-master.sh
@@ -11,7 +11,7 @@ sudo killall salt-call   || true
 
 sleep 2
 
-ps aux | grep -i salt
+pgrep salt -l
 
 sudo killall salt-minion || true
 sudo killall salt-master || true

--- a/scripts/set-hostname.sh
+++ b/scripts/set-hostname.sh
@@ -1,3 +1,3 @@
 #!/bin/bash
-sudo hostname $PROJECT
+sudo hostname "$PROJECT"
 sudo sh -c "echo ${PROJECT} > /etc/hostname"

--- a/scripts/update-master-formula.sh
+++ b/scripts/update-master-formula.sh
@@ -9,11 +9,11 @@ formula=$2
 
 mkdir -p /opt/formulas
 if [ -d "/opt/formulas/$pname" ]; then
-    cd /opt/formulas/$pname
+    cd "/opt/formulas/$pname"
     git reset --hard
     git clean -d --force
     git pull --rebase
 else
     cd /opt/formulas/
-    git clone $formula $pname
+    git clone "$formula" "$pname"
 fi

--- a/test.sh
+++ b/test.sh
@@ -1,7 +1,8 @@
 #!/bin/bash
 set -e # causes script to exit immediately on error
 
-source .activate-venv.sh
-source .lint.sh
-source .unittest.sh
-#source .full-lint.sh
+. .activate-venv.sh
+. .lint.sh
+. .shell-lint.sh
+. .unittest.sh
+#./full-lint.sh

--- a/update.sh
+++ b/update.sh
@@ -2,12 +2,12 @@
 
 set -e # everything must pass
 
-python .prerequisites.py $@
+python .prerequisites.py "$@"
 
 # remove any old compiled python files
 find src/ -name '*.pyc' -delete
 
-if which vagrant; then
+if command -v vagrant > /dev/null; then
     # installs s3 auth plugin so we can pull boxes from a private s3 bucket
     if [ ! -f .no-vagrant-s3auth.flag ]; then
         # vagrant plugin update ... doesn't work apparently
@@ -31,18 +31,16 @@ chmod +x bldr
 # generate a settings file if one doesn't exist
 if [ ! -e settings.yml ]; then
     echo "* settings.yml not found, creating"
-    cat example.settings.yml | grep -Ev '\w*##' > settings.yml
+    grep -Ev '\w*##' example.settings.yml > settings.yml
 fi
 
 # activate the venv, recreating if neccessary
-source .activate-venv.sh
+. .activate-venv.sh
 
 # download the basebox from s3 if vagrant is installed
-if which vagrant; then
+if command -v vagrant > /dev/null; then
     if [ ! -f .no-install-basebox.flag ]; then
-        if [ type vagrant &> /dev/null ]; then
-            vagrant add box s3://elife-builder/boxes/ elifesciences/basebox
-        fi
+        vagrant add box s3://elife-builder/boxes/ elifesciences/basebox
     else
         echo "* the no-install-basebox flag is set. skipping check"
     fi


### PR DESCRIPTION
added optional dependency on 'shellcheck' that lints the scripts in and ./scripts. 
scripts linted.

I feel it could do a better job in some cases. I'm not sure of the benefits of supporting sh+bash+dash+ksh but the changes were minimal

