### PR TITLE
Avoid additional unnecessary symlinks

### DIFF
--- a/scripts/bootstrap.sh
+++ b/scripts/bootstrap.sh
@@ -78,9 +78,9 @@ if [ -d /vagrant ]; then
     master_ipaddr=$(ifconfig eth0 | awk '/inet / { print $2 }' | sed 's/addr://')    
     # link up the project formula mounted at /project
     # NOTE: these links will be overwritten if this a master-server instance
-    ln -sf /project/salt /srv/salt
-    ln -sf /project/salt/pillar /srv/pillar
-    ln -sf /vagrant/custom-vagrant /srv/custom
+    ln -sfn /project/salt /srv/salt
+    ln -sfn /project/salt/pillar /srv/pillar
+    ln -sfn /vagrant/custom-vagrant /srv/custom
 fi
 echo "
 master: $master_ipaddr

--- a/scripts/init-vagrant-minion.sh
+++ b/scripts/init-vagrant-minion.sh
@@ -16,13 +16,15 @@ if [ ! -d /vagrant/cloned-projects/builder-base-formula/.git ]; then
     git clone ssh://git@github.com/elifesciences/builder-base-formula /vagrant/cloned-projects/builder-base-formula
 fi
 
-# project's `salt` file is mounted at `/srv/salt/` within the guest
+# project's `salt` file is mounted at `/project` and symlinked at `/srv/salt`
+# and `/srv/pillar` within the guest
 # by default the project's top.sls and pillar data is disabled by file naming.
 # hook that up now
 cd /srv/salt/ && ln -sf example.top top.sls
-if [ ! -e /srv/pillar ]; then 
-    ln -sf /srv/salt/pillar/ /srv/pillar
-fi
+# this seems redundant wrt bootstrap.sh, which creates /srv/pillar?
+#if [ ! -e /srv/pillar ]; then 
+#    ln -sf /srv/salt/pillar/ /srv/pillar
+#fi
 
 # TODO: CHECK ENVIRONMENT, FAIL NOISILY
 


### PR DESCRIPTION
At the first run:
```
/srv/salt -> /project/salt
```
but at the second run:
```
/srv/salt/salt -> /project/salt
```
gets created. Since `/srv/salt` is `/project/salt`, this created a
leftover file in the formula repo called `salt/salt`.

The same happens for `/srv/pillar -> /project/salt/pillar`, the leftover file is `salt/pillar/pillar`.

For the solution, see:
http://blog.endpoint.com/2009/09/using-ln-sf-to-replace-symlink-to.html
one never stops learning new Unix subleties.