### PR TITLE
prep_stack should leave the stack without a Salt master key

### DIFF
--- a/scripts/prep-stack.sh
+++ b/scripts/prep-stack.sh
@@ -6,15 +6,17 @@ set -e # everything must pass
 set -u # no unbound variables
 set -xv  # output the scripts and interpolated steps
 
-rm -f \
-    /etc/cfn-info.json \
-    /etc/salt/pki/minion/minion_master.pub \
-    /root/.ssh/* \
-    /root/events.log
-
 if command -v salt-minion > /dev/null; then
     # salt is installed, probably using an AMI or creating an AMI
     # https://docs.saltstack.com/en/latest/ref/modules/all/salt.modules.saltutil.html#salt.modules.saltutil.clear_cache
-    salt-call saltutil.clear_cache
     service salt-minion stop
 fi
+
+# remove leftover files from AMIs
+rm -rf \
+    /etc/cfn-info.json \
+    /etc/salt/pki/minion/minion_master.pub \
+    /etc/salt/minion \
+    /root/.ssh/* \
+    /root/events.log \
+    /var/cache/salt/minion

--- a/src/buildercore/core.py
+++ b/src/buildercore/core.py
@@ -239,7 +239,9 @@ def stack_data(stackname):
         # gives us, we sometimes take it's instance-id and talk to the instance directly.
         #inst_id = data['indexed_output']['InstanceId']
         #inst = get_instance(inst_id)
-        inst = find_ec2_instance(stackname)[0]
+        stacks = find_ec2_instance(stackname)
+        assert len(stacks) == 1, ("while looking for %s, found these stacks: %s" % (stackname, stacks))
+        inst = stacks[0]
         data['instance'] = inst.__dict__
     except Exception:
         LOG.exception('caught an exception attempting to discover more information about this instance. The instance may not exist yet ...')


### PR DESCRIPTION
Deployed and delete `api-dummy--fakeenv` to test this, solves the problem of `/etc/salt/pki/minion/minion_master.pub` interrupting the setup phase.