### PR TITLE
Selecting aws-alt automatically using cluster name

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -2,9 +2,11 @@ elifePipeline {
     stage 'Checkout'
     checkout scm
 
-    stage 'Update'
-    sh './update.sh --exclude virtualbox vagrant'
+    lock('builder') {
+        stage 'Update'
+        sh './update.sh --exclude virtualbox vagrant'
 
-    stage 'Test'
-    sh './test.sh'
+        stage 'Test'
+        sh './test.sh'
+    }
 }

--- a/projects/elife.yaml
+++ b/projects/elife.yaml
@@ -96,7 +96,11 @@ lax:
             - 443
             - 80
     aws-alt:
-        master:
+        end2end:
+            description: RDS backed
+            rds:
+                storage: 5
+        prod:
             description: RDS backed
             rds:
                 storage: 5
@@ -201,7 +205,11 @@ elife-dashboard:
             - 80
             - 443
     aws-alt:
-        master:
+        end2end:
+            description: production-like environment. backed by RDS
+            rds:
+                storage: 5
+        prod:
             description: production environment. backed by RDS
             rds:
                 storage: 5

--- a/projects/elife.yaml
+++ b/projects/elife.yaml
@@ -297,6 +297,7 @@ elife-website:
         ports:
             - 22
             - 80
+            - 443
     aws-alt:
         large:
             description: intended to run temporarily

--- a/projects/elife.yaml
+++ b/projects/elife.yaml
@@ -309,3 +309,12 @@ elife-website:
             1326: 8983 # Solr web gui
             3307: 3306 # mysql
             6379: 6379 # redis
+
+anonymous:
+    formula-repo: https://github.com/elifesciences/anonymous-formula
+    aws:
+        type: t2.micro
+        ports:
+            - 22
+    vagrant:
+        ram: 1024

--- a/src/buildercore/cfngen.py
+++ b/src/buildercore/cfngen.py
@@ -48,13 +48,16 @@ def build_context(pname, **more_context):
         # when this was first introduced, instance_id was synonmous with stackname
         'instance_id': None, # must be provided by whatever is calling this
 
-        'rds_dbname': None, # generated from the instance_id
-        'rds_username': 'root', # could possibly live in the project data, but really no need.
-        'rds_password': utils.random_alphanumeric(length=32), # will be saved to buildvars.json
 
         'branch': project_data['default-branch'],
         'revision': None, # may be used in future to checkout a specific revision of project
     }
+
+    if 'rds' in project_data['aws']:
+        defaults['rds_dbname'] = None # generated from the instance_id
+        defaults['rds_username'] = 'root' # could possibly live in the project data, but really no need.
+        defaults['rds_password'] = utils.random_alphanumeric(length=32) # will be saved to buildvars.json
+
     context = copy.deepcopy(defaults)
     context.update(more_context)
 

--- a/src/buildercore/cfngen.py
+++ b/src/buildercore/cfngen.py
@@ -73,11 +73,13 @@ def build_context(pname, **more_context):
     
     # post-processing
     context.update({
-        'rds_dbname': context.get('rds_dbname') or default_rds_dbname, # *must* use 'or' here
-        'rds_instance_id': slugify(stackname), # *completely* different to database name
-        
         'is_prod_instance': core.is_prod_stack(stackname),
     })
+    if 'rds' in project_data['aws']:
+        context.update({
+            'rds_dbname': context.get('rds_dbname') or default_rds_dbname, # *must* use 'or' here
+            'rds_instance_id': slugify(stackname), # *completely* different to database name
+        })
 
     # the above context will reside on the server at /etc/build_vars.json.b64
     # this gives Salt all (most) of the data that was available at template compile time.

--- a/src/deploy.py
+++ b/src/deploy.py
@@ -43,11 +43,12 @@ def deploy(pname, cluster=None, branch='master'):
         more_context = {
             'instance_id': stackname,
             'branch': branch,
+            'cluster': cluster,
         }
-        # tie branch names to alternate configurations
-        if branch in project.project_alt_config_names(pdata):
-            LOG.info("using alternate AWS configuration %r", branch)
-            more_context['alt-config'] = branch
+        # optionally select alternate configurations if it matches the cluster name
+        if cluster in project.project_alt_config_names(pdata):
+            LOG.info("using alternate AWS configuration %r", cluster)
+            more_context['alt-config'] = cluster
         cfngen.generate_stack(pname, **more_context)
         bootstrap.create_stack(stackname)
     bootstrap.update_stack(stackname)

--- a/src/tasks.py
+++ b/src/tasks.py
@@ -79,8 +79,7 @@ def fetch_cert(stackname):
     try:    
         # replicates some logic in builder core
         pname = core.project_name_from_stackname(stackname)
-        all_project_data = project.project_data(pname)
-        project_data = all_project_data[pname]
+        project_data = project.project_data(pname)
 
         assert project_data.has_key('subdomain'), "project subdomain not found. quitting"
 


### PR DESCRIPTION
In the new builder formulas `master` is the default branch for every
project, so they come up by default with the alternate configuration
(including RDS), which is undesirable.

By selecting the alternate configuration using the cluster name instead,
we can specify to use RDS only in `end2end` and `prod`, for example.

Alternate configurations that do not match a cluster name, such as
`large`, can still be selected manually using `aws_launch_instance`
instead of `deploy`.