### PR TITLE
An option can be passed to turn off ssh forwarding

### DIFF
--- a/src/cfn.py
+++ b/src/cfn.py
@@ -5,6 +5,7 @@ import aws, utils
 from decorators import requires_project, requires_aws_stack, requires_steady_stack, echo_output, setdefault, debugtask
 import os
 from os.path import join
+from distutils.util import strtobool
 from buildercore import core, cfngen, utils as core_utils, bootstrap, project, checks
 from buildercore.core import stack_conn, stack_pem
 from buildercore.config import DEPLOY_USER, BOOTSTRAP_USER
@@ -124,19 +125,24 @@ def aws_stack_list():
 
 @task
 @requires_aws_stack
-def ssh(stackname, username=DEPLOY_USER):
+def ssh(stackname, username=DEPLOY_USER, forward_agent=True):
     public_ip = core.stack_data(stackname)['instance']['ip_address']
-    # -A forwarding of authentication agent connection
-    local("ssh %s@%s -A" % (username, public_ip))
+    local("ssh %s@%s %s" % (username, public_ip, _ssh_flags(forward_agent)))
 
 @task
 @requires_aws_stack
-def owner_ssh(stackname):
+def owner_ssh(stackname, forward_agent=True):
     "maintainence ssh. uses the pem key and the bootstrap user to login."
     public_ip = core.stack_data(stackname)['instance']['ip_address']
-    # -i identify file
+    # -i identity file
+    local("ssh %s@%s -i %s %s" % (BOOTSTRAP_USER, public_ip, stack_pem(stackname), _ssh_flags(forward_agent)))
+
+def _ssh_flags(forward_agent):
     # -A forwarding of authentication agent connection
-    local("ssh %s@%s -i %s -A" % (BOOTSTRAP_USER, public_ip, stack_pem(stackname)))
+    if strtobool(forward_agent):
+        return "-A"
+    else:
+        return ""
         
 @task
 @requires_aws_stack

--- a/src/cfn.py
+++ b/src/cfn.py
@@ -125,13 +125,13 @@ def aws_stack_list():
 
 @task
 @requires_aws_stack
-def ssh(stackname, username=DEPLOY_USER, forward_agent=True):
+def ssh(stackname, username=DEPLOY_USER, forward_agent="True"):
     public_ip = core.stack_data(stackname)['instance']['ip_address']
     local("ssh %s@%s %s" % (username, public_ip, _ssh_flags(forward_agent)))
 
 @task
 @requires_aws_stack
-def owner_ssh(stackname, forward_agent=True):
+def owner_ssh(stackname, forward_agent="True"):
     "maintainence ssh. uses the pem key and the bootstrap user to login."
     public_ip = core.stack_data(stackname)['instance']['ip_address']
     # -i identity file

--- a/src/tasks.py
+++ b/src/tasks.py
@@ -96,10 +96,8 @@ def fetch_cert(stackname):
             is_prod = True
 
         hostname_data = core.hostname_struct(stackname)
-        #domain_names = ["%s.%s.elifesciences.org" % (instance_id, project_data['subdomain'])]
         domain_names = [hostname_data['full_hostname']]
         if is_prod:
-            #project_hostname = "%s.elifesciences.org" % project_data['subdomain']
             project_hostname = hostname_data['project_hostname']
             if acme_enabled(project_hostname):
                 domain_names.append(project_hostname)


### PR DESCRIPTION
This is useful to test what a remote machine does without polluting its keys with the developer's local stuff. Example:
```
./bldr ssh:elife-alfred--ci,forward_agent=False
```
The name of the option is the same as the one used by Fabric in its
settings, for consistency.