### PR TITLE
Option to use owner_ssh key for download_file

### DIFF
--- a/.lint.sh
+++ b/.lint.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
 set -e
 # E1129=doesn't like Fabric's context manager
-pylint -E src/* salt/salt/_modules/* --disable=E1129
+pylint -E src/* --disable=E1129 --rcfile=.pylintrc
 echo "* passed initial lint!"

--- a/.pylintrc
+++ b/.pylintrc
@@ -1,0 +1,5 @@
+[MESSAGES CONTROL]
+
+# when in a virtual env distutils is replaced by "black-magic":
+# https://github.com/PyCQA/pylint/issues/223
+ignored-modules=distutils


### PR DESCRIPTION
To use in extreme cases, like downloading the key of a failed master server to set it up for Github's builder-private repository