### PR TITLE
Ability to specify only one DNS record

### DIFF
--- a/projects/elife.yaml
+++ b/projects/elife.yaml
@@ -332,6 +332,7 @@ jats4r:
             - 443
 
 medium:
+    domain: False
     subdomain: medium
     repo: https://github.com/elifesciences/medium
     formula-repo: https://github.com/elifesciences/medium-formula

--- a/src/buildercore/core.py
+++ b/src/buildercore/core.py
@@ -415,13 +415,16 @@ def hostname_struct(stackname):
 
     updates = {
         'hostname': hostname,
-
-        'project_hostname': subdomain + "." + domain,
-        'int_project_hostname': subdomain + "." + intdomain,
-
-        'full_hostname': hostname + "." + domain,
-        'int_full_hostname': hostname + "." + intdomain,
     }
+
+    if domain:
+        updates['project_hostname'] = subdomain + "." + domain
+        updates['full_hostname'] = hostname + "." + domain
+
+    if intdomain:
+        updates['int_project_hostname'] = subdomain + "." + intdomain
+        updates['int_full_hostname'] = hostname + "." + intdomain
+
     struct.update(updates)
     return struct
 

--- a/src/buildercore/trop.py
+++ b/src/buildercore/trop.py
@@ -243,12 +243,17 @@ def render(context):
     if context['project']['aws'].has_key('ext'):
         map(template.add_resource, ext_volume(context))
 
-    if context['hostname']: # None if one couldn't be generated
+    if context['full_hostname']:
         template.add_resource(external_dns(context))
-        template.add_resource(internal_dns(context))        
         cfn_outputs.extend([
             mkoutput("DomainName", "Domain name of the newly created EC2 instance", Ref(R53_EXT_TITLE)),
-            mkoutput("IntDomainName", "Domain name of the newly created EC2 instance", Ref(R53_INT_TITLE))])
+        ])
+
+    if context['int_full_hostname']:
+        template.add_resource(internal_dns(context))        
+        cfn_outputs.extend([
+            mkoutput("IntDomainName", "Domain name of the newly created EC2 instance", Ref(R53_INT_TITLE))
+        ])
 
     map(template.add_output, cfn_outputs)
     return template.to_json()


### PR DESCRIPTION
Useful for backends, where we don't want to expose them with a public DNS but only make them accessible from api-gateway