### PR TITLE
Avoid moment in time when build vars are not existent

### DIFF
--- a/src/buildvars.py
+++ b/src/buildvars.py
@@ -112,8 +112,6 @@ def _update_remote_bvars(stackname, bvars):
         cmds = [
             # make a backup
             'if [ -f /etc/build-vars.json.b64 ]; then cp /etc/build-vars.json.b64 /tmp/build-vars.json.b64.%s; fi;' % fid,
-            # purge any mention of build vars
-            'rm -f /etc/build*vars.*',
         ]
         map(sudo, cmds)
         put(StringIO(encoded), "/etc/build-vars.json.b64", use_sudo=True)


### PR DESCRIPTION
It happened to me to see some interrupted builds causing errors due to a missing build vars file. By overwriting it we should avoid leaving it missing in case this operation is interrupted.