### PR TITLE
HTTPS support in ELB

### DIFF
--- a/projects/elife.yaml
+++ b/projects/elife.yaml
@@ -158,7 +158,7 @@ journal:
                 cluster-size: 2
             elb:
                 stickiness: True
-                procotol: https
+                protocol: https
     vagrant:
         ram: 4096
         ports:

--- a/projects/elife.yaml
+++ b/projects/elife.yaml
@@ -63,6 +63,8 @@ defaults:
             # elb defaults only used if an 'elb' section present in project
             stickiness: False
             protocol: http
+            idle_timeout: 60
+            certificate: ASCAIRXYIRFBOR5QSDP5M
         sqs: []
         sns: []
     aws-alt:
@@ -141,6 +143,7 @@ api-gateway:
 
 journal:
     subdomain: journal # journal.elifesciences.org
+    intdomain: null
     repo: https://github.com/elifesciences/journal
     formula-repo: https://github.com/elifesciences/journal-formula
     aws:
@@ -428,7 +431,7 @@ bus:
     description: see https://github.com/elifesciences/bus
     default-branch: null
     domain: null
-    int_domain: null
+    intdomain: null
     aws:
         ec2: false
         sns:

--- a/projects/elife.yaml
+++ b/projects/elife.yaml
@@ -59,6 +59,10 @@ defaults:
             # external hdd
             size: 10 # GB
             device: /dev/sdh
+        elb:
+            # elb defaults only used if an 'elb' section present in project
+            stickiness: False
+            protocol: http
         sqs: []
         sns: []
     aws-alt:
@@ -144,6 +148,14 @@ journal:
             - 22
             - 443
             - 80
+    aws-alt:
+        end2end:
+            description: end2end environment for journal. ELB on top of multiple EC2 instances
+            ec2:
+                cluster-size: 2
+            elb:
+                stickiness: True
+                procotol: https
     vagrant:
         ram: 4096
         ports:
@@ -392,7 +404,8 @@ medium:
         clustered:
             ec2:
                 cluster-size: 2
-            elb: True
+            elb: 
+                protocol: http
 
 search:
     description: service for indexing all of Elife 2.0 content

--- a/projects/elife.yaml
+++ b/projects/elife.yaml
@@ -64,7 +64,7 @@ defaults:
             stickiness: False
             protocol: http
             idle_timeout: 60
-            certificate: ASCAIRXYIRFBOR5QSDP5M
+            certificate: arn:aws:iam::512686554592:server-certificate/cloudfront/wildcard.elifesciences.org/wildcard.elifesciences.org
         sqs: []
         sns: []
     aws-alt:

--- a/src/buildercore/cfngen.py
+++ b/src/buildercore/cfngen.py
@@ -38,7 +38,7 @@ def build_context(pname, **more_context): # pylint: disable=too-many-locals
 
     if 'alt-config' in more_context:
         project_data = project.set_project_alt(project_data, 'aws', more_context['alt-config'])
-    
+   
     defaults = {
         'project_name': pname,
         'project': project_data,
@@ -101,13 +101,18 @@ def build_context(pname, **more_context): # pylint: disable=too-many-locals
     })
 
     context['ec2'] = context['project']['aws'].get('ec2', True)
-    if context['project']['aws'].get('elb'):
-        context['elb'] = {
+
+    if context['project']['aws'].has_key('elb'):
+        if isinstance(context['project']['aws']['elb'], dict):
+            context['elb'] = context['project']['aws']['elb']
+        else:
+            context['elb'] = {}
+        context['elb'].update({
             'subnets': [
                 context['project']['aws']['subnet-id'],
                 context['project']['aws']['redundant-subnet-id']
             ]
-        }
+        })
 
     def _parameterize(string):
         return string.format(instance=context['instance_id'])

--- a/src/buildercore/project/files.py
+++ b/src/buildercore/project/files.py
@@ -72,7 +72,7 @@ def project_data(pname, project_file, snippets=0xDEADBEEF):
 
     # exceptions.
     # these values *shouldn't* be merged if they *don't* exist in the project
-    excluding = ['aws', 'vagrant', 'vagrant-alt', 'aws-alt', {'aws': ['rds', 'ext']}]
+    excluding = ['aws', 'vagrant', 'vagrant-alt', 'aws-alt', {'aws': ['rds', 'ext', 'elb']}]
     project_data = copy.deepcopy(global_defaults)
     utils.deepmerge(project_data, project_list[pname], excluding)
 
@@ -92,7 +92,7 @@ def project_data(pname, project_file, snippets=0xDEADBEEF):
         # merge this over top of original aws defaults
         orig_defaults = copy.deepcopy(global_defaults['aws'])
 
-        utils.deepmerge(orig_defaults, project_aws, ['rds', 'ext'])
+        utils.deepmerge(orig_defaults, project_aws, ['rds', 'ext', 'elb'])
         project_data['aws-alt'][altname] = orig_defaults
 
     for altname, altdata in project_data.get('vagrant-alt', {}).items():

--- a/src/buildercore/trop.py
+++ b/src/buildercore/trop.py
@@ -365,7 +365,7 @@ def render_elb(context, template, ec2_instances):
                 Protocol='HTTP',
             ),
         ]
-    elif context['elb']['protocol'] == 'http':
+    elif context['elb']['protocol'] == 'https':
         listeners=[
             elb.Listener(
                 InstanceProtocol='HTTP',
@@ -376,7 +376,7 @@ def render_elb(context, template, ec2_instances):
             ),
         ]
     else:
-        raise RuntimeError("Uknown procotol `%s`" % context['elb']['protocol'])
+        raise RuntimeError("Unknown procotol `%s`" % context['elb']['protocol'])
 
     template.add_resource(elb.LoadBalancer(
         ELB_TITLE,

--- a/src/buildercore/trop.py
+++ b/src/buildercore/trop.py
@@ -348,11 +348,13 @@ def render_elb(context, template, ec2_instances):
         "An ELB must have either an external or an internal DNS entry")
 
     elb_is_public = True if context['full_hostname'] else False
+    listeners_policy_names = []
 
     if context['elb']['stickiness']:
         cookie_stickiness = [elb.LBCookieStickinessPolicy(
             PolicyName="BrowserSessionLongCookieStickinessPolicy"
         )]
+        listeners_policy_names.append('BrowserSessionLongCookieStickinessPolicy')
     else:
         cookie_stickiness = []
 
@@ -362,6 +364,7 @@ def render_elb(context, template, ec2_instances):
                 InstanceProtocol='HTTP',
                 InstancePort='80',
                 LoadBalancerPort='80',
+                PolicyNames=listeners_policy_names,
                 Protocol='HTTP',
             ),
         ]
@@ -371,6 +374,7 @@ def render_elb(context, template, ec2_instances):
                 InstanceProtocol='HTTP',
                 InstancePort='80',
                 LoadBalancerPort='443',
+                PolicyNames=listeners_policy_names,
                 Protocol='HTTPS',
                 SSLCertificateId=context['elb']['certificate']
             ),

--- a/src/buildercore/trop.py
+++ b/src/buildercore/trop.py
@@ -372,6 +372,7 @@ def render_elb(context, template, ec2_instances):
                 InstancePort='80',
                 LoadBalancerPort='443',
                 Protocol='HTTPS',
+                SSLCertificateId=context['elb']['certificate']
             ),
         ]
     else:
@@ -382,6 +383,9 @@ def render_elb(context, template, ec2_instances):
         ConnectionDrainingPolicy=elb.ConnectionDrainingPolicy(
             Enabled=True,
             Timeout=60,
+        ),
+        ConnectionSettings=elb.ConnectionSettings(
+            IdleTimeout=context['elb']['idle_timeout']
         ),
         CrossZone=True,
         Instances=map(Ref, ec2_instances),

--- a/src/buildvars.py
+++ b/src/buildvars.py
@@ -1,9 +1,10 @@
 from buildercore.bvars import encode_bvars, read_from_current_host
 from fabric.api import sudo, put, hide
 from StringIO import StringIO
-from decorators import echo_output, requires_aws_stack, debugtask
-from buildercore.core import stack_conn
+from decorators import requires_aws_stack, debugtask
+from buildercore.core import stack_all_ec2_nodes
 from buildercore import utils as core_utils
+from pprint import pprint
 import utils
 import logging
 LOG = logging.getLogger(__name__)
@@ -13,33 +14,37 @@ OLD, ABBREV, FULL = 'old', 'abbrev', 'full'
 @debugtask
 @requires_aws_stack
 def switch_revision(stackname, revision=None):
-    buildvars = _retrieve_build_vars(stackname)
     if revision is None:
         revision = utils.uin('revision', None)
 
-    if 'revision' in buildvars and revision == buildvars['revision']:
-        print 'FYI, the instance is already on that revision!'
-        return
+    def _switch_revision_single_ec2_node():
+        buildvars = _retrieve_build_vars()
 
-    new_data = buildvars
-    new_data['revision'] = revision
-    _update_remote_bvars(stackname, new_data)    
+        if 'revision' in buildvars and revision == buildvars['revision']:
+            print 'FYI, the instance is already on that revision!'
+            return
+
+        new_data = buildvars
+        new_data['revision'] = revision
+        _update_remote_bvars(stackname, new_data)    
+
+    stack_all_ec2_nodes(stackname, _switch_revision_single_ec2_node)
 
 @debugtask
 @requires_aws_stack
-@echo_output
 def read(stackname):
     "returns the unencoded build variables found on given instance"
-    with stack_conn(stackname):
-        return read_from_current_host()
+    return stack_all_ec2_nodes(stackname, lambda: pprint(read_from_current_host()))
 
 @debugtask
 @requires_aws_stack
-@echo_output
 def valid(stackname):
+    return stack_all_ec2_nodes(stackname, lambda: pprint(_validate()))
+
+def _validate():
     "returns a pair of (type, build data) for the given instance. type is either 'old', 'abbrev' or 'full'"
     try:
-        buildvars = read(stackname)
+        buildvars = read_from_current_host()
         bvarst = _bvarstype(buildvars)
         assert bvarst in [None, OLD, ABBREV, FULL], \
           "the build vars found were structured unfamiliarly"
@@ -52,21 +57,22 @@ def valid(stackname):
 
 @debugtask
 @requires_aws_stack
-@echo_output
 def fix(stackname):
-    bvarst, _ = valid(stackname)
-    if bvarst is None:
-        LOG.info("no build vars found, adding defaults")
-        new_vars = {'branch': 'master', 'revision': None}
-        _update_remote_bvars(stackname, new_vars)
-    else:
-        LOG.info("valid bvars found (%s), no fix necessary", bvarst)
+    def _fix_single_ec2_node():
+        bvarst, _ = _validate()
+        if bvarst is None:
+            LOG.info("no build vars found, adding defaults")
+            new_vars = {'branch': 'master', 'revision': None}
+            _update_remote_bvars(stackname, new_vars)
+        else:
+            LOG.info("valid bvars found (%s), no fix necessary", bvarst)
 
-def _retrieve_build_vars(stackname):
-    #pdata = core.project_data_for_stackname(stackname)
+    stack_all_ec2_nodes(stackname, _fix_single_ec2_node)
+
+def _retrieve_build_vars():
     print 'looking for build vars ...'
     with hide('everything'):
-        bvarst, buildvars = valid(stackname)
+        bvarst, buildvars = _validate()
     assert bvarst in [ABBREV, FULL], \
       "the build-vars.json file for %r is not valid. use `./bldr buildvars.fix` to attempt to fix this."
     print 'found build vars'
@@ -76,16 +82,16 @@ def _retrieve_build_vars(stackname):
 def _update_remote_bvars(stackname, buildvars):
     LOG.info('updating %r with new vars %r',stackname, buildvars)
     assert core_utils.hasallkeys(buildvars, ['branch']) #, 'revision']) # we don't use 'revision'
-    with stack_conn(stackname):
-        encoded = encode_bvars(buildvars)
-        fid = core_utils.ymd(fmt='%Y%m%d%H%M%S')
-        cmds = [
-            # make a backup
-            'if [ -f /etc/build-vars.json.b64 ]; then cp /etc/build-vars.json.b64 /tmp/build-vars.json.b64.%s; fi;' % fid,
-        ]
-        map(sudo, cmds)
-        put(StringIO(encoded), "/etc/build-vars.json.b64", use_sudo=True)
-        LOG.info("%r updated", stackname)            
+
+    encoded = encode_bvars(buildvars)
+    fid = core_utils.ymd(fmt='%Y%m%d%H%M%S')
+    cmds = [
+        # make a backup
+        'if [ -f /etc/build-vars.json.b64 ]; then cp /etc/build-vars.json.b64 /tmp/build-vars.json.b64.%s; fi;' % fid,
+    ]
+    map(sudo, cmds)
+    put(StringIO(encoded), "/etc/build-vars.json.b64", use_sudo=True)
+    LOG.info("%r updated", stackname)
 
 
 def _bvarstype(bvars):

--- a/src/deploy.py
+++ b/src/deploy.py
@@ -54,5 +54,4 @@ def deploy(pname, instance_id=None, branch='master'):
 @requires_aws_stack
 def switch_revision_update_instance(stackname, revision=None):
     buildvars.switch_revision(stackname, revision)
-    with core.stack_conn(stackname):
-        return bootstrap.run_script('highstate.sh')
+    core.stack_all_ec2_nodes(stackname, lambda: bootstrap.run_script('highstate.sh'))

--- a/src/tests/fixtures/dummy1-project.json
+++ b/src/tests/fixtures/dummy1-project.json
@@ -16,7 +16,6 @@
             "cluster-size": 1,
             "ami": "ami-9eaa1cf6"
         },
-        "elb": false,
         "type": "t2.small", 
         "region": "us-east-1", 
         "sns": [],

--- a/src/tests/fixtures/dummy2-project.json
+++ b/src/tests/fixtures/dummy2-project.json
@@ -16,7 +16,6 @@
             "cluster-size": 1,
             "ami": "ami-111111"
         },
-        "elb": false,
         "type": "t2.small", 
         "region": "us-east-1", 
         "sns": [],
@@ -55,7 +54,6 @@
                 "cluster-size": 1,
                 "ami": "ami-9eaa1cf6"
             },
-            "elb": false,
             "type": "t2.small", 
             "region": "us-east-1", 
             "sns": [],
@@ -94,7 +92,6 @@
                 "cluster-size": 1,
                 "ami": "ami-22222"
             },
-            "elb": false,
             "type": "t2.small", 
             "region": "us-east-1", 
             "sns": [],

--- a/src/tests/fixtures/dummy3-project.json
+++ b/src/tests/fixtures/dummy3-project.json
@@ -16,7 +16,6 @@
             "cluster-size": 1,
             "ami": "ami-111111"
         },
-        "elb": false,
         "type": "t2.small", 
         "region": "us-east-1", 
         "sns": [],
@@ -36,7 +35,6 @@
                 "cluster-size": 1,
                 "ami": "ami-9eaa1cf6"
             },
-            "elb": false,
             "type": "t2.small", 
             "region": "us-east-1", 
             "sns": [],
@@ -56,7 +54,6 @@
                 "cluster-size": 1,
                 "ami": "ami-111111"
             },
-            "elb": false,
             "type": "t2.small", 
             "region": "us-east-1", 
             "sns": [],

--- a/src/tests/fixtures/projects/dummy-project.yaml
+++ b/src/tests/fixtures/projects/dummy-project.yaml
@@ -26,7 +26,6 @@ defaults:
             # find more here: http://cloud-images.ubuntu.com/releases/
             ami: ami-9eaa1cf6  # Ubuntu 14.04
         type: t2.small
-        elb: False
         region: us-east-1
         vpc-id: vpc-78a2071d  # vpc-id + subnet-id are peculiar to AWS account + region
         subnet-id: subnet-1d4eb46a # elife-public-subnet
@@ -55,6 +54,9 @@ defaults:
             # external hdd
             size: 10 # GB
             device: /dev/sdh
+        elb:
+            # elb defaults only used if an 'elb' section present in project
+            stickiness: False
         sns: []
         sqs: []
     aws-alt:
@@ -171,4 +173,5 @@ project-with-cluster:
             - 80
         ec2:
             cluster-size: 2
-        elb: True
+        elb: 
+            protocol: http

--- a/src/tests/fixtures/projects/dummy-project.yaml
+++ b/src/tests/fixtures/projects/dummy-project.yaml
@@ -57,6 +57,8 @@ defaults:
         elb:
             # elb defaults only used if an 'elb' section present in project
             stickiness: False
+            protocol: http
+            idle_timeout: 60
         sns: []
         sqs: []
     aws-alt:

--- a/src/tests/fixtures/projects/dummy-project2.yaml
+++ b/src/tests/fixtures/projects/dummy-project2.yaml
@@ -51,6 +51,9 @@ defaults:
             # external hdd
             size: 10 # GB
             device: /dev/sdh
+        elb:
+            # elb defaults only used if an 'elb' section present in project
+            stickiness: False
         sns: []
         sqs: []
     aws-alt:

--- a/src/tests/fixtures/projects/dummy-project2.yaml
+++ b/src/tests/fixtures/projects/dummy-project2.yaml
@@ -54,6 +54,8 @@ defaults:
         elb:
             # elb defaults only used if an 'elb' section present in project
             stickiness: False
+            protocol: http
+            idle_timeout: 60
         sns: []
         sqs: []
     aws-alt:

--- a/src/tests/test_buildercore_trop.py
+++ b/src/tests/test_buildercore_trop.py
@@ -125,6 +125,7 @@ class TestBuildercoreTrop(base.BaseCase):
             elb['Listeners'][0],
             {
                 'InstancePort': '80',
+                'InstanceProtocol': 'HTTP',
                 'LoadBalancerPort': '80',
                 'Protocol': 'HTTP',
             }

--- a/src/tests/test_buildercore_trop.py
+++ b/src/tests/test_buildercore_trop.py
@@ -127,6 +127,7 @@ class TestBuildercoreTrop(base.BaseCase):
                 'InstancePort': '80',
                 'InstanceProtocol': 'HTTP',
                 'LoadBalancerPort': '80',
+                'PolicyNames': [],
                 'Protocol': 'HTTP',
             }
         )


### PR DESCRIPTION
ELB support a certificate reference that points to our wildcard certificate being safely stored into AWS IAM.

Moreover, we configure other interesting parameters of the ELB like sticky sessions and the connection timeout, using them for `journal--end2end` which is currently being recreated.