### PR TITLE
Adding Environment tag to EC2 and similar instances

### DIFF
--- a/src/buildercore/trop.py
+++ b/src/buildercore/trop.py
@@ -101,6 +101,7 @@ def _generic_tags(context):
     return {
         'Owner': context['author'],
         'Project': context['project_name'], # journal
+        'Environment': context['instance_id'], # stack instance id
         # the name AWS Console uses to label an instance
         'Name': context['stackname'] # ll: journal-prod
     }

--- a/src/tests/test_buildercore_trop.py
+++ b/src/tests/test_buildercore_trop.py
@@ -97,6 +97,13 @@ class TestBuildercoreTrop(base.BaseCase):
         )
         self.assertIn(
             {
+                'Key': 'Environment',
+                'Value': 'prod',
+            },
+            resources['EC2Instance1']['Properties']['Tags']
+        )
+        self.assertIn(
+            {
                 'Key': 'Cluster',
                 'Value': 'project-with-cluster--prod',
             },


### PR DESCRIPTION
This can be useful to filter which are prod or end2end or ci or demo instances