### PR TITLE
Demonstrating support for parallelization of commands in Fabric/Builder

### DIFF
--- a/bldr
+++ b/bldr
@@ -17,4 +17,4 @@ fi
 # a wrapper around fabric that activates the elife-builder virtualenv
 
 fabric=$(which fab)
-$fabric "$@" -f src/fabfile.py
+$fabric "$*" -f src/fabfile.py

--- a/src/buildercore/bootstrap.py
+++ b/src/buildercore/bootstrap.py
@@ -114,7 +114,8 @@ def setup_ec2(stackname, context_ec2):
                 # - cloud-init has finished running
                 #       otherwise we may be missing /etc/apt/source.list, which is generated on boot
                 #       https://www.digitalocean.com/community/questions/how-to-make-sure-that-cloud-init-finished-running 
-                return not files.exists(join('/home', BOOTSTRAP_USER, ".ssh/authorized_keys")) or not files.exists('/var/lib/cloud/instance/boot-finished')
+                return not files.exists(join('/home', BOOTSTRAP_USER, ".ssh/authorized_keys")) \
+                  or not files.exists('/var/lib/cloud/instance/boot-finished')
             except fabric_exceptions.NetworkError:
                 LOG.debug("failed to connect to server ...")
                 return True

--- a/src/buildercore/core.py
+++ b/src/buildercore/core.py
@@ -178,17 +178,20 @@ def stack_conn(stackname, username=config.DEPLOY_USER, **kwargs):
     with settings(**params):
         yield
 
-def stack_all_ec2_nodes(stackname, work, username=config.DEPLOY_USER, **kwargs):
+def stack_all_ec2_nodes(stackname, work, username=config.DEPLOY_USER, arguments=None, **kwargs):
     """Executes work on all the EC2 nodes of stackname.    
-    Optionally connects with the specified username or with additional settings
-    from kwargs"""
+    Optionally connects with the specified username"""
+    if not arguments:
+        arguments={}
+
     public_ips = [ec2['instance']['ip_address'] for ec2 in stack_data(stackname)]
     params = _ec2_connection_params(stackname, username)
+    params.update(kwargs)
     LOG.info("Executing %s on all ec2 nodes (%s)", work, public_ips)
 
     with settings(**params):
         # TODO: decorate work to print what it is connecting only
-        execute(work, hosts=public_ips)
+        execute(work, hosts=public_ips, **arguments)
     
 
 

--- a/src/buildercore/core.py
+++ b/src/buildercore/core.py
@@ -178,20 +178,20 @@ def stack_conn(stackname, username=config.DEPLOY_USER, **kwargs):
     with settings(**params):
         yield
 
-def stack_all_ec2_nodes(stackname, work, username=config.DEPLOY_USER, arguments=None, **kwargs):
+def stack_all_ec2_nodes(stackname, workfn, username=config.DEPLOY_USER, **kwargs):
     """Executes work on all the EC2 nodes of stackname.    
     Optionally connects with the specified username"""
-    if not arguments:
-        arguments={}
+    if isinstance(workfn, tuple):
+        workfn, work_kwargs = workfn        
 
     public_ips = [ec2['instance']['ip_address'] for ec2 in stack_data(stackname)]
     params = _ec2_connection_params(stackname, username)
     params.update(kwargs)
-    LOG.info("Executing %s on all ec2 nodes (%s)", work, public_ips)
+    LOG.info("Executing %s on all ec2 nodes (%s)", workfn, public_ips)
 
     with settings(**params):
         # TODO: decorate work to print what it is connecting only
-        execute(work, hosts=public_ips, **arguments)
+        execute(workfn, hosts=public_ips, **work_kwargs)
     
 
 

--- a/src/buildercore/core.py
+++ b/src/buildercore/core.py
@@ -181,8 +181,9 @@ def stack_conn(stackname, username=config.DEPLOY_USER, **kwargs):
 def stack_all_ec2_nodes(stackname, workfn, username=config.DEPLOY_USER, **kwargs):
     """Executes work on all the EC2 nodes of stackname.    
     Optionally connects with the specified username"""
+    work_kwargs = {}
     if isinstance(workfn, tuple):
-        workfn, work_kwargs = workfn        
+        workfn, work_kwargs = workfn
 
     public_ips = [ec2['instance']['ip_address'] for ec2 in stack_data(stackname)]
     params = _ec2_connection_params(stackname, username)

--- a/src/cfn.py
+++ b/src/cfn.py
@@ -1,5 +1,5 @@
 from distutils.util import strtobool #pylint: disable=import-error,no-name-in-module
-from fabric.api import task, local, run, sudo, put, get, abort
+from fabric.api import task, local, run, sudo, put, get, abort, parallel
 from fabric.contrib import files
 import aws, utils
 from decorators import requires_project, requires_aws_stack, requires_steady_stack, echo_output, setdefault, debugtask
@@ -202,9 +202,15 @@ def cmd(stackname, command=None, username=DEPLOY_USER):
     print "Connecting to: %s" % stackname
     stack_all_ec2_nodes(
         stackname,
-        lambda: run(command),
+        cmd_parallel_subtask,
         username=username,
+        arguments={'command':command},
         abort_on_prompts=True)
+
+@parallel
+def cmd_parallel_subtask(command):
+    run(command)
+
         
 @task
 def project_list():

--- a/src/cfn.py
+++ b/src/cfn.py
@@ -202,7 +202,7 @@ def cmd(stackname, command=None, username=DEPLOY_USER):
     print "Connecting to: %s" % stackname
     stack_all_ec2_nodes(
         stackname,
-        (parallel(lambda command: run(command)), {'command': command}),
+        (parallel(run), {'command': command}),
         username=username,
         abort_on_prompts=True)
 

--- a/src/cfn.py
+++ b/src/cfn.py
@@ -202,16 +202,10 @@ def cmd(stackname, command=None, username=DEPLOY_USER):
     print "Connecting to: %s" % stackname
     stack_all_ec2_nodes(
         stackname,
-        cmd_parallel_subtask,
+        (parallel(lambda command: run(command)), {'command': command}),
         username=username,
-        arguments={'command':command},
         abort_on_prompts=True)
 
-@parallel
-def cmd_parallel_subtask(command):
-    run(command)
-
-        
 @task
 def project_list():
     for org, plist in project.org_project_map().items():


### PR DESCRIPTION
Two `sleep 20` tasks execute in parallel, taking 28s instead of > 40s.
```
]$ time bldr "cmd:journal--end2end,sleep 20"1474967367.030414 - WARNING - MainProcess - buildercore.decorators - TODO: embarassing code. some of these constants should be pulled form project config or given better names.
1474967367.033715 - INFO - MainProcess - buildercore.config - using settings path u'/home/giorgio/code/builder/settings.yml'
Connecting to: journal--end2end
connecting to a journal instance in region us-east-1
connecting to a journal instance in region us-east-1
1474967373.690452 - INFO - MainProcess - buildercore.core - Executing <function cmd_parallel_subtask at 0x7ff8a1282410> on all ec2 nodes ([u'54.227.6.72', u'52.91.22.168'])
[54.227.6.72] Executing task 'cmd_parallel_subtask'
[52.91.22.168] Executing task 'cmd_parallel_subtask'
[52.91.22.168] run: sleep 20
[54.227.6.72] run: sleep 20
1474967374.007130 - INFO - 52.91.22.168 - paramiko.transport - Connected (version 2.0, client OpenSSH_6.6.1p1)
1474967374.007157 - INFO - 54.227.6.72 - paramiko.transport - Connected (version 2.0, client OpenSSH_6.6.1p1)
1474967374.765575 - INFO - 54.227.6.72 - paramiko.transport - Authentication (publickey) successful!
1474967374.868573 - INFO - 52.91.22.168 - paramiko.transport - Authentication (publickey) successful!

Done.

real    0m28.862s
user    0m5.488s
sys     0m0.616s
```
The output is printed line-wise, without mixing up hosts.