### PR TITLE
No `project` key in build vars

### DIFF
--- a/src/buildercore/trop.py
+++ b/src/buildercore/trop.py
@@ -138,6 +138,7 @@ def mkoutput(title, desc, val):
 def ec2instance(context, node):
     lu = partial(utils.lu, context)
     build_vars = dict(context)
+    del build_vars['project']
     build_vars['node'] = node
     build_vars['nodename'] = "%s--%s" % (context['stackname'], node)
     # the above context will reside on the server at /etc/build-vars.json.b64

--- a/src/tests/test_buildercore_trop.py
+++ b/src/tests/test_buildercore_trop.py
@@ -19,7 +19,6 @@ class TestBuildercoreTrop(base.BaseCase):
         context = cfngen.build_context('dummy3', **extra)
         self.assertEqual(context['rds_dbname'], "dummy3test")
         self.assertEqual(context['rds_instance_id'], "dummy3-test")
-        self.assertTrue('rds' in context['project']['aws'])
         data = json.loads(trop.render(context))
         self.assertTrue(isinstance(utils.lu(data, 'Resources.AttachedDB'), dict))
 


### PR DESCRIPTION
Keeping
```
{
    "alt-config": "end2end",
    "author": "giorgio",
    "branch": "master",
    "cluster_id": null,
    "date_rendered": "2016-09-21",
    "domain": "elifesciences.org",
    "ec2": {
        "ami": "ami-aa15f6c7",
        "cluster-size": 2
    },
    "elb": {
        "certificate": "arn:aws:iam::512686554592:server-certificate/cloudfront/wildcard.elifesciences.org/wildcard.elifesciences.org",
        "idle_timeout": 60,
        "protocol": "https",
        "stickiness": true,
        "subnets": [
            "subnet-1d4eb46a",
            "subnet-7a31dd46"
        ]
    },
    "ext": null,
    "full_hostname": "end2end--journal.elifesciences.org",
    "hostname": "end2end--journal",
    "instance_id": "end2end",
    "int_domain": null,
    "int_full_hostname": null,
    "int_project_hostname": null,
    "is_prod_instance": false,
    "node": 2,
    "nodename": "journal--end2end--2",
```
but removing
```
   "project": {
        "aws": {
            "description": "end2end environment for journal. ELB on top of multiple EC2 instances",
            "ec2": {
                "ami": "ami-aa15f6c7",
                "cluster-size": 2
            },
            "elb": {
                "certificate": "arn:aws:iam::512686554592:server-certificate/cloudfront/wildcard.elifesciences.org/wildcard.elifesciences.org",
                "idle_timeout": 60,
                "protocol": "https",
                "stickiness": true,
                "subnets": [
                    "subnet-1d4eb46a",
                    "subnet-7a31dd46"
                ]
            },
            "ports": [
                22,
                443,
                80
            ],
            "redundant-subnet-cidr": "10.0.3.0/24",
            "redundant-subnet-id": "subnet-7a31dd46",
            "region": "us-east-1",
            "sns": [],
            "sqs": [],
            "subnet-cidr": "10.0.2.0/24",
            "subnet-id": "subnet-1d4eb46a",
            "type": "t2.small",
            "vpc-id": "vpc-78a2071d"
        },
        "aws-alt": {
            "end2end": {
                "description": "end2end environment for journal. ELB on top of multiple EC2 instances",
                "ec2": {
                    "ami": "ami-aa15f6c7",
                    "cluster-size": 2
                },
                "elb": {
                    "certificate": "arn:aws:iam::512686554592:server-certificate/cloudfront/wildcard.elifesciences.org/wildcard.elifesciences.org",
                    "idle_timeout": 60,
                    "protocol": "https",
                    "stickiness": true
                },
                "ports": [
                    22,
                    443,
                    80
                ],
                "redundant-subnet-cidr": "10.0.3.0/24",
                "redundant-subnet-id": "subnet-7a31dd46",
                "region": "us-east-1",
                "sns": [],
                "sqs": [],
                "subnet-cidr": "10.0.2.0/24",
                "subnet-id": "subnet-1d4eb46a",
                "type": "t2.small",
                "vpc-id": "vpc-78a2071d"
            },
            "fresh": {
                "description": "uses a plain Ubuntu basebox instead of an ami",
                "ec2": {
                    "ami": "ami-9eaa1cf6",
                    "cluster-size": 1
                },
                "ports": [
                    22,
                    443,
                    80
                ],
                "redundant-subnet-cidr": "10.0.3.0/24",
                "redundant-subnet-id": "subnet-7a31dd46",
                "region": "us-east-1",
                "sns": [],
                "sqs": [],
                "subnet-cidr": "10.0.2.0/24",
                "subnet-id": "subnet-1d4eb46a",
                "type": "t2.small",
                "vpc-id": "vpc-78a2071d"
            }
        },
        "default-branch": "master",
        "description": "defaults for all projects in this file",
        "domain": "elifesciences.org",
        "formula-dependencies": [
            "https://github.com/elifesciences/builder-base-formula"
        ],
        "formula-repo": "https://github.com/elifesciences/journal-formula",
        "intdomain": null,
        "private-repo": "ssh://git@github.com/elifesciences/builder-private",
        "repo": "https://github.com/elifesciences/journal",
        "salt": "2016.3",
        "subdomain": "journal",
        "vagrant": {
            "box": "ubuntu/trusty64",
            "box-url": null,
            "cpucap": 100,
            "cpus": 2,
            "ip": "192.168.33.44",
            "ports": {
                "1240": 80
            },
            "ram": 4096
        }
    },
```
and keeping
```
    "project_hostname": "journal.elifesciences.org",
    "project_name": "journal",
    "rds_dbname": null,
    "rds_instance_id": null,
    "rds_password": null,
    "rds_username": null,
    "revision": "8f1af4d2f26789eca7e0cb6444313d675fa421c4",
    "sns": [],
    "sqs": {},
    "stackname": "journal--end2end",
    "subdomain": "journal"
}
```

The `context` will be unchanged, but Salt formulas will be more constrained in what they can refer to.