### PR TITLE
Adds stop, start and stop_if_next_hour_is_imminent tasks

### DIFF
--- a/src/buildercore/bakery.py
+++ b/src/buildercore/bakery.py
@@ -17,7 +17,7 @@ def create_ami(stackname):
     "creates an AMI from the running stack"
     with core.stack_conn(stackname):
         bootstrap.prep_ec2_instance()
-    ec2 = core.find_ec2_instance(stackname)[0]
+    ec2 = core.find_ec2_instances(stackname)[0]
     kwargs = {
         'instance_id': ec2.id,
         'name': core.ami_name(stackname),

--- a/src/buildercore/core.py
+++ b/src/buildercore/core.py
@@ -293,7 +293,7 @@ def stack_data(stackname, ensure_single_instance=False):
         ec2_instances = find_ec2_instance(stackname)
 
         if len(ec2_instances) < 1:
-            raise RuntimeError("found no ec2 instances for %r" % stackname)
+            raise RuntimeError("found no running ec2 instances for %r" % stackname)
         elif len(ec2_instances) > 1 and ensure_single_instance:
             raise RuntimeError("talking to multiple EC2 instances is not supported for this task yet: %r" % stackname)
 

--- a/src/buildercore/core.py
+++ b/src/buildercore/core.py
@@ -122,20 +122,25 @@ def connect_aws_with_stack(stackname, service):
     pname = project_name_from_stackname(stackname)
     return connect_aws_with_pname(pname, service)
 
-# TODO: rename to find_ec2_instances
-def find_ec2_instance(stackname):
+def find_ec2_instances(stackname, state='running', node_ids=None):
     "returns list of ec2 instances data for a *specific* stackname"
     # http://docs.aws.amazon.com/AWSEC2/latest/APIReference/API_DescribeInstances.html
-    filter_by_cluster = {
+    conn = connect_aws_with_stack(stackname, 'ec2')
+    return conn.get_only_instances(filters=_all_nodes_filter(stackname, state=state, node_ids=node_ids))
+
+def _all_nodes_filter(stackname, state, node_ids):
+    query = {
         'tag-key': ['Cluster', 'Name'],
         'tag-value': [stackname],
-        'instance-state-name': ['running'],
     }
-    conn = connect_aws_with_stack(stackname, 'ec2')
-    return conn.get_only_instances(filters=filter_by_cluster)
+    if state:
+        query['instance-state-name'] = [state]
+    if node_ids:
+        query['instance-id'] = node_ids
+    return query
 
 def find_ec2_volume(stackname):
-    ec2_data = find_ec2_instance(stackname)[0]
+    ec2_data = find_ec2_instances(stackname)[0]
     iid = ec2_data.id
     #http://docs.aws.amazon.com/AWSEC2/latest/APIReference/API_DescribeVolumes.html
     kwargs = {'filters': {'attachment.instance-id': iid}}
@@ -290,7 +295,7 @@ def stack_data(stackname, ensure_single_instance=False):
         # TODO: is there someway to go straight to the instance ID ?
         # a CloudFormation's outputs go stale! because we can't trust the data it
         # gives us, we sometimes take it's instance-id and talk to the instance directly.
-        ec2_instances = find_ec2_instance(stackname)
+        ec2_instances = find_ec2_instances(stackname)
 
         if len(ec2_instances) < 1:
             raise RuntimeError("found no running ec2 instances for %r" % stackname)

--- a/src/buildercore/core.py
+++ b/src/buildercore/core.py
@@ -122,6 +122,7 @@ def connect_aws_with_stack(stackname, service):
     pname = project_name_from_stackname(stackname)
     return connect_aws_with_pname(pname, service)
 
+# TODO: rename to find_ec2_instances
 def find_ec2_instance(stackname):
     "returns list of ec2 instances data for a *specific* stackname"
     # http://docs.aws.amazon.com/AWSEC2/latest/APIReference/API_DescribeInstances.html

--- a/src/buildercore/lifecycle.py
+++ b/src/buildercore/lifecycle.py
@@ -5,7 +5,7 @@ The primary reason for doing this is to save on costs."""
 from datetime import datetime
 import logging
 from .core import connect_aws_with_stack
-from .utils import call_while, die
+from .utils import call_while, ensure
 
 LOG = logging.getLogger(__name__)
 
@@ -69,7 +69,7 @@ def _wait_all_in_state(stackname, state, node_ids):
     call_while(some_node_is_still_not_compliant, interval=2, update_msg="waiting for states of nodes to be %s" % state, done_msg="all nodes in state %s" % state)
 
 def _ensure_valid_states(states, valid_states):
-    die(
+    ensure(
         set(states.values()).issubset(valid_states),
         "The states of EC2 nodes are not supported, manual recovery is needed: %s", states
     )

--- a/src/buildercore/lifecycle.py
+++ b/src/buildercore/lifecycle.py
@@ -2,6 +2,7 @@
 
 The primary reason for doing this is to save on costs."""
 
+from datetime import datetime
 import logging
 from .core import connect_aws_with_stack
 from .utils import call_while, die
@@ -21,7 +22,7 @@ def start(stackname):
 
     LOG.info("Nodes to be started: %s", to_be_started)
     _connection(stackname).start_instances(to_be_started)
-    _ensure_all_in_state('running', stackname)
+    _wait_all_in_state(stackname, 'running', to_be_started)
 
 def stop(stackname):
     "Puts all EC2 nodes of stackname into the 'stopped' state. Idempotent"
@@ -36,9 +37,32 @@ def stop(stackname):
 
     LOG.info("Nodes to be stopped: %s", to_be_stopped)
     _connection(stackname).stop_instances(to_be_stopped)
-    _ensure_all_in_state('stopped', stackname)
+    _wait_all_in_state(stackname, 'stopped', to_be_stopped)
 
-def _ensure_all_in_state(state, stackname):
+def last_start_time(stackname):
+    nodes = _nodes(stackname, state='running')
+    def _parse_datetime(value):
+        return datetime.strptime(value, "%Y-%m-%dT%H:%M:%S.%fZ")
+    return {node.id:_parse_datetime(node.launch_time) for node in nodes}
+
+def stop_if_next_hour_is_imminent(stackname, minimum_minutes=55):
+    maximum_minutes = 60
+    starting_times = last_start_time(stackname)
+    running_times = {node_id:int((datetime.utcnow() - launch_time).total_seconds()) % (maximum_minutes * 60) for (node_id, launch_time) in starting_times.iteritems()}
+    LOG.info("Hourly fraction running times: %s", running_times)
+
+    minimum_running_time = minimum_minutes * 60
+    maximum_running_time = maximum_minutes * 60
+    LOG.info("Interval to select nodes to stop: %s-%s", minimum_running_time, maximum_running_time)
+
+    to_be_stopped = [node_id for (node_id, running_time) in running_times.iteritems() if running_time >= minimum_running_time]
+    LOG.info("Selected for stopping: %s", to_be_stopped)
+    if to_be_stopped:
+        _connection(stackname).stop_instances(to_be_stopped) 
+        _wait_all_in_state(stackname, 'stopped', to_be_stopped)
+
+
+def _wait_all_in_state(stackname, state, node_ids):
     def some_node_is_still_not_compliant():
         return set(_nodes_states(stackname).values()) != {state}
     # TODO: timeout argument
@@ -54,22 +78,27 @@ def _select_nodes_with_state(interesting_state, states):
     return [instance_id for (instance_id, state) in states.iteritems() if state == interesting_state]
 
 
-def _nodes_states(stackname):
+def _nodes_states(stackname, node_ids=None):
     """dictionary from instance id to a string state.
     
     e.g. {'i-6f727961': 'stopped'}"""
-    return {node.id:node.state for node in _nodes(stackname)}
+    return {node.id:node.state for node in _nodes(stackname, node_ids=node_ids)}
 
-def _nodes(stackname):
+def _nodes(stackname, state=None, node_ids=None):
     "returns list of ec2 instances data for a *specific* stackname"
     conn = _connection(stackname)
-    return conn.get_only_instances(filters=_all_nodes_filter(stackname))
+    return conn.get_only_instances(filters=_all_nodes_filter(stackname, state=state, node_ids=node_ids))
 
-def _all_nodes_filter(stackname):
-    return {
+def _all_nodes_filter(stackname, state, node_ids):
+    query = {
         'tag-key': ['Cluster', 'Name'],
         'tag-value': [stackname],
     }
+    if state:
+        query['instance-state-name'] = [state]
+    if node_ids:
+        query['instance-id'] = node_ids
+    return query
 
 def _connection(stackname):
     return connect_aws_with_stack(stackname, 'ec2')

--- a/src/buildercore/lifecycle.py
+++ b/src/buildercore/lifecycle.py
@@ -1,0 +1,75 @@
+"""module for stopping and starting stacks but keeping their state, hence without destroying them.
+
+The primary reason for doing this is to save on costs."""
+
+import logging
+from .core import connect_aws_with_stack
+from .utils import call_while, die
+
+LOG = logging.getLogger(__name__)
+
+def start(stackname):
+    "Puts all EC2 nodes of stackname into the 'started' state. Idempotent"
+    
+    states = _nodes_states(stackname)
+    LOG.info("Current states: %s", states)
+    _ensure_valid_states(states, {'stopped', 'pending', 'running'})
+    to_be_started = _select_nodes_with_state('stopped', states)
+    if not to_be_started:
+        LOG.info("Nodes are all running")
+        return
+
+    LOG.info("Nodes to be started: %s", to_be_started)
+    _connection(stackname).start_instances(to_be_started)
+    _ensure_all_in_state('running', stackname)
+
+def stop(stackname):
+    "Puts all EC2 nodes of stackname into the 'stopped' state. Idempotent"
+    
+    states = _nodes_states(stackname)
+    LOG.info("Current states: %s", states)
+    _ensure_valid_states(states, {'running', 'stopping', 'stopped'})
+    to_be_stopped = _select_nodes_with_state('running', states)
+    if not to_be_stopped:
+        LOG.info("Nodes are all stopped")
+        return
+
+    LOG.info("Nodes to be stopped: %s", to_be_stopped)
+    _connection(stackname).stop_instances(to_be_stopped)
+    _ensure_all_in_state('stopped', stackname)
+
+def _ensure_all_in_state(state, stackname):
+    def some_node_is_still_not_compliant():
+        return set(_nodes_states(stackname).values()) != {state}
+    # TODO: timeout argument
+    call_while(some_node_is_still_not_compliant, interval=2, update_msg="waiting for states of nodes to be %s" % state, done_msg="all nodes in state %s" % state)
+
+def _ensure_valid_states(states, valid_states):
+    die(
+        set(states.values()).issubset(valid_states),
+        "The states of EC2 nodes are not supported, manual recovery is needed: %s", states
+    )
+
+def _select_nodes_with_state(interesting_state, states):
+    return [instance_id for (instance_id, state) in states.iteritems() if state == interesting_state]
+
+
+def _nodes_states(stackname):
+    """dictionary from instance id to a string state.
+    
+    e.g. {'i-6f727961': 'stopped'}"""
+    return {node.id:node.state for node in _nodes(stackname)}
+
+def _nodes(stackname):
+    "returns list of ec2 instances data for a *specific* stackname"
+    conn = _connection(stackname)
+    return conn.get_only_instances(filters=_all_nodes_filter(stackname))
+
+def _all_nodes_filter(stackname):
+    return {
+        'tag-key': ['Cluster', 'Name'],
+        'tag-value': [stackname],
+    }
+
+def _connection(stackname):
+    return connect_aws_with_stack(stackname, 'ec2')

--- a/src/buildercore/utils.py
+++ b/src/buildercore/utils.py
@@ -224,9 +224,7 @@ def ymd(dt=None, fmt="%Y-%m-%d"):
         dt = datetime.now() # TODO: replace this with a utcnow()
     return dt.strftime(fmt)
 
-# TODO: this name is the opposite of assert, assertions read like "die if 1 == 1"
-# I'd try ensure(assertion, msg)
-def die(assertion, msg, *args):
+def ensure(assertion, msg, *args):
     """intended as a convenient replacement for `assert` statements that 
     get compiled away with -O flags"""
     if not assertion:
@@ -234,8 +232,8 @@ def die(assertion, msg, *args):
 
 def mkdir_p(path):
     os.system("mkdir -p %s" % path)
-    die(os.path.isdir(path), "directory couldn't be created: %s" % path)
-    die(os.access(path, os.W_OK | os.X_OK), "directory isn't writable: %s" % path)
+    ensure(os.path.isdir(path), "directory couldn't be created: %s" % path)
+    ensure(os.access(path, os.W_OK | os.X_OK), "directory isn't writable: %s" % path)
     return path
 
 def json_dumps(obj, dangerous=False):

--- a/src/buildercore/utils.py
+++ b/src/buildercore/utils.py
@@ -117,11 +117,11 @@ def call_while(fn, interval=5, update_msg="waiting ...", done_msg="done."):
     "calls the given function `f` every `interval` until it returns False."
     while True:
         if fn():
-            print update_msg
+            LOG.info(update_msg)
             time.sleep(interval)
         else:
             break
-    print done_msg
+    LOG.info(done_msg)
 
 def call_while_example():
     "a simple example of how to use the `call_while` function. polls fs every two seconds until /tmp/foo is detected"
@@ -224,11 +224,13 @@ def ymd(dt=None, fmt="%Y-%m-%d"):
         dt = datetime.now() # TODO: replace this with a utcnow()
     return dt.strftime(fmt)
 
-def die(assertion, msg):
+# TODO: this name is the opposite of assert, assertions read like "die if 1 == 1"
+# I'd try ensure(assertion, msg)
+def die(assertion, msg, *args):
     """intended as a convenient replacement for `assert` statements that 
     get compiled away with -O flags"""
     if not assertion:
-        raise AssertionError(msg)
+        raise AssertionError(msg % args)
 
 def mkdir_p(path):
     os.system("mkdir -p %s" % path)

--- a/src/fabfile.py
+++ b/src/fabfile.py
@@ -22,3 +22,4 @@ import buildvars
 import remote_master
 import project
 from deploy import deploy, switch_revision_update_instance
+from lifecycle import start, stop

--- a/src/fabfile.py
+++ b/src/fabfile.py
@@ -22,4 +22,4 @@ import buildvars
 import remote_master
 import project
 from deploy import deploy, switch_revision_update_instance
-from lifecycle import start, stop
+from lifecycle import start, stop, last_start_time, stop_if_next_hour_is_imminent

--- a/src/integration_tests/test_provisioning.py
+++ b/src/integration_tests/test_provisioning.py
@@ -1,7 +1,7 @@
 from subprocess import check_output
 from fabric.api import settings
 from tests import base
-from buildercore import bootstrap, cfngen
+from buildercore import bootstrap, cfngen, lifecycle
 import cfn
 
 class TestProvisioning(base.BaseCase):
@@ -27,3 +27,7 @@ class TestProvisioning(base.BaseCase):
 
             # TODO: hangs, not ready to test this. Will revisit in the future
             #buildvars.switch_revision(stackname, 'master')
+        
+            lifecycle.stop(stackname)
+            lifecycle.start(stackname)
+

--- a/src/integration_tests/test_provisioning.py
+++ b/src/integration_tests/test_provisioning.py
@@ -1,3 +1,4 @@
+from datetime import datetime
 from subprocess import check_output
 from fabric.api import settings
 from tests import base
@@ -7,8 +8,9 @@ import cfn
 class TestProvisioning(base.BaseCase):
     def setUp(self):
         self.stacknames = []
-        # to avoid multiple people clashing while running their buils
-        self.environment = check_output('whoami').rstrip()
+        # to avoid multiple people clashing while running their builds
+        # and new builds clashing with older ones
+        self.environment = check_output('whoami').rstrip() + datetime.utcnow().strftime("%Y%m%d%H%M%S")
 
     def tearDown(self):
         for stackname in self.stacknames:

--- a/src/lifecycle.py
+++ b/src/lifecycle.py
@@ -1,6 +1,6 @@
 from fabric.api import task
 from buildercore import lifecycle
-from decorators import requires_aws_stack, timeit
+from decorators import requires_aws_stack, timeit, echo_output
 
 @task
 @requires_aws_stack
@@ -13,3 +13,19 @@ def start(stackname):
 @timeit
 def stop(stackname):
     lifecycle.stop(stackname)
+
+@task
+@requires_aws_stack
+@echo_output
+def last_start_time(stackname):
+    return lifecycle.last_start_time(stackname)
+
+@task
+@requires_aws_stack
+@timeit
+def stop_if_next_hour_is_imminent(stackname, minimum_minutes='55'):
+    # TODO: can we write a description of the @task somewhere?
+    """If a node has been running for a time between X:55:00 and X:59:59 hours, stops it to avoid incurring in a new charge for the next hour.
+    
+    The assumption is that stacks where this command is used are not needed for long parts of the day/week, and that who needs them will call the start task first."""
+    return lifecycle.stop_if_next_hour_is_imminent(stackname, int(minimum_minutes))

--- a/src/lifecycle.py
+++ b/src/lifecycle.py
@@ -6,12 +6,14 @@ from decorators import requires_aws_stack, timeit, echo_output
 @requires_aws_stack
 @timeit
 def start(stackname):
+    "Starts the nodes of 'stackname'. Idempotent"
     lifecycle.start(stackname)
 
 @task
 @requires_aws_stack
 @timeit
 def stop(stackname):
+    "Stops the nodes of 'stackname' without losing their state. Idempotent"
     lifecycle.stop(stackname)
 
 @task

--- a/src/lifecycle.py
+++ b/src/lifecycle.py
@@ -1,0 +1,15 @@
+from fabric.api import task
+from buildercore import lifecycle
+from decorators import requires_aws_stack, timeit
+
+@task
+@requires_aws_stack
+@timeit
+def start(stackname):
+    lifecycle.start(stackname)
+
+@task
+@requires_aws_stack
+@timeit
+def stop(stackname):
+    lifecycle.stop(stackname)

--- a/src/tests/test_buildercore_core.py
+++ b/src/tests/test_buildercore_core.py
@@ -123,8 +123,8 @@ class SimpleCases(base.BaseCase):
         except core.MultipleRegionsError as e:
             self.assertEqual(["us-east-1", "eu-central-1"], e.regions())
 
-    def test_find_ec2_instance(self):
-        self.assertEquals([], core.find_ec2_instance('dummy1--prod'))
+    def test_find_ec2_instances(self):
+        self.assertEquals([], core.find_ec2_instances('dummy1--prod'))
 
             
 class TestCoreNewProjectData(base.BaseCase):


### PR DESCRIPTION
Sample commands:
`./bldr start:elife-bot--end2end`
`./bldr stop:elife-bot--end2end`
`./bldr stop_if_next_hour_is_imminent:elife-bot--end2end`

The first two act on EC2 stop/state commands, bringing each node in the stack to the state `stopping` and then `stopped`; or to the state `pending` and then `running`.

The command `stop_if_next_hour_is_imminent` will be used by Alfred in a periodical task to stop nodes that have been running when they have outlived their usefulness. Nodes will be lazily started by builds when needed, but will not run for more than one hour (which is the minimum EC2 billing after a `stopped->running` transition.)
