### PR TITLE
1-minute TTL for DNS entries by default

### DIFF
--- a/src/buildercore/trop.py
+++ b/src/buildercore/trop.py
@@ -235,7 +235,7 @@ def external_dns_ec2(context):
         Comment="External DNS record for EC2",
         Name=context['full_hostname'],
         Type="A",
-        TTL="900",
+        TTL="60",
         ResourceRecords=[GetAtt(EC2_TITLE, "PublicIp")],
     )
     return dns_record
@@ -249,7 +249,7 @@ def internal_dns(context):
         Comment="Internal DNS record for EC2",
         Name=context['int_full_hostname'],
         Type="A",
-        TTL="900",
+        TTL="60",
         ResourceRecords=[GetAtt(EC2_TITLE, "PrivateIp")],
     )
     return dns_record


### PR DESCRIPTION
This helps in various ways depending on the environment:
- in testing we can stop and start instances (operation that changes their public ip address) without fear that other projects will still try to talk to the old ip address, now belonging to some other AWS account
- in production we can quickly failover or restart an EC2 instance without necessarily introducing a 15-minute downtime while the DNS entry propagate