### PR TITLE
Updating the template, but only with new resources

### DIFF
--- a/scripts/bootstrap.sh
+++ b/scripts/bootstrap.sh
@@ -40,7 +40,7 @@ upgrade_python=false
 install_git=false
 # Python is such a hard dependency of Salt that we have to upgrade it outside of it to avoid changing it while it is running
 python_version=$(dpkg-query -W --showformat='${Version}' python2.7) # e.g. 2.7.5-5ubuntu3
-if dpkg --compare-versions $python_version lt 2.7.12; then
+if dpkg --compare-versions "$python_version" lt 2.7.12; then
     sudo add-apt-repository -y ppa:fkrull/deadsnakes-python2.7
     upgrade_python=true
 fi
@@ -56,7 +56,7 @@ fi
 if $upgrade_python; then
     apt-get install python2.7 python2.7-dev -y
     # virtual envs have to be recreated
-    rm -rf `find /srv /opt -type d -name venv`
+    rm -rf "$(find /srv /opt -type d -name venv)"
 fi
 
 if $install_git; then

--- a/src/buildercore/bootstrap.py
+++ b/src/buildercore/bootstrap.py
@@ -300,6 +300,18 @@ def master(region, key):
 # bootstrap stack
 #
 
+def template(stackname):
+    conn = connect_aws_with_stack(stackname, 'cfn')
+    return json.loads(conn.get_template(stackname)['GetTemplateResponse']['GetTemplateResult']['TemplateBody'])
+
+def update_template(stackname, template):
+    conn = connect_aws_with_stack(stackname, 'cfn')
+    parameters = []
+    pdata = project_data_for_stackname(stackname)
+    if pdata['aws']['ec2']:
+        parameters.append(('KeyName', stackname))
+    conn.update_stack(stackname, json.dumps(template), parameters=parameters)
+
 @core.requires_active_stack
 def template_info(stackname):
     "returns some useful information about the given stackname as a map"

--- a/src/buildercore/bootstrap.py
+++ b/src/buildercore/bootstrap.py
@@ -10,8 +10,9 @@ from os.path import join
 from functools import partial
 from StringIO import StringIO
 from . import core, utils, config, keypair, bvars
+from collections import OrderedDict
 from .core import connect_aws_with_stack, stack_pem, stack_all_ec2_nodes, project_data_for_stackname
-from .utils import first, call_while
+from .utils import first, call_while, ensure, subdict
 from .config import BOOTSTRAP_USER
 from fabric.api import sudo, put, parallel
 import fabric.exceptions as fabric_exceptions
@@ -128,6 +129,8 @@ def setup_ec2(stackname, context_ec2):
 
 def update_sqs_stack(stackname):
     pdata = project_data_for_stackname(stackname)
+    if not pdata['aws']['sqs']:
+        return
     context = context_handler.load_context(stackname)
     setup_sqs(stackname, context['sqs'], pdata['aws']['region'])
 
@@ -269,6 +272,8 @@ def _sqs_notification_configuration(queue_arn, notification_specification):
 
 def update_s3_stack(stackname):
     pdata = project_data_for_stackname(stackname)
+    if not pdata['aws']['s3']:
+        return
     context = context_handler.load_context(stackname)
     setup_s3(stackname, context['s3'], pdata['aws']['region'], pdata['aws']['account_id'])
 
@@ -346,24 +351,20 @@ def write_environment_info(stackname, overwrite=False):
 #
 
 @core.requires_active_stack
-def update_stack(stackname, part_filter=None):
-    pdata = project_data_for_stackname(stackname)
+def update_stack(stackname, service_list=None):
+    """updates the given stack. if a list of services are provided (s3, ec2, sqs, etc)
+    then only those services will be updated"""
+    service_update_fns = OrderedDict([
+        ('ec2', update_ec2_stack),
+        ('s3', update_s3_stack),
+        ('sqs', update_sqs_stack)
+    ])
 
-    parts = {}
-    if pdata['aws']['ec2']:
-        parts['ec2'] = lambda: update_ec2_stack(stackname)
-    if pdata['aws']['s3']:
-        parts['s3'] = lambda: update_s3_stack(stackname)
+    if not service_list:
+        service_list = service_update_fns.keys()
+    ensure(utils.iterable(service_list), "cannot iterate over given service list %r" % service_list)
 
-    if pdata['aws']['sqs']:
-        parts['sqs'] = lambda: update_sqs_stack(stackname)
-
-    if part_filter:
-        parts[part_filter]()
-    else:
-        for part in parts:
-            parts[part]()
-
+    [fn(stackname) for fn in subdict(service_update_fns, service_list).values()]
 
 @core.requires_stack_file
 def create_update(stackname, part_filter=None):
@@ -383,6 +384,8 @@ def update_ec2_stack(stackname):
     installs it's own dependencies. Once Salt is installed we give it an ID
     (the given `stackname`), the address of the master server """
     pdata = project_data_for_stackname(stackname)
+    if not pdata['aws']['ec2']:
+        return
     region = pdata['aws']['region']
     is_master = core.is_master_server_stack(stackname)
 

--- a/src/buildercore/bootstrap.py
+++ b/src/buildercore/bootstrap.py
@@ -78,8 +78,6 @@ def _create_generic_stack(stackname, parameters=None, on_start=_noop, on_error=_
         context = context_handler.load_context(stackname)
         # setup various resources after creation, where necessary
         setup_ec2(stackname, context['ec2'])
-        # TODO: maybe we can move this in the update too
-        setup_sqs(stackname, context['sqs'], context['project']['aws']['region'])
 
         return True
     except BotoServerError as err:
@@ -127,6 +125,11 @@ def setup_ec2(stackname, context_ec2):
 
     stack_all_ec2_nodes(stackname, _setup_ec2_node, username=BOOTSTRAP_USER)
 
+
+def update_sqs_stack(stackname):
+    pdata = project_data_for_stackname(stackname)
+    context = context_handler.load_context(stackname)
+    setup_sqs(stackname, context['sqs'], pdata['aws']['region'])
 
 def setup_sqs(stackname, context_sqs, region):
     """
@@ -347,6 +350,9 @@ def update_stack(stackname, part_filter=None):
         parts['ec2'] = lambda: update_ec2_stack(stackname)
     if pdata['aws']['s3']:
         parts['s3'] = lambda: update_s3_stack(stackname)
+
+    if pdata['aws']['sqs']:
+        parts['sqs'] = lambda: update_sqs_stack(stackname)
 
     if part_filter:
         parts[part_filter]()

--- a/src/buildercore/bootstrap.py
+++ b/src/buildercore/bootstrap.py
@@ -300,7 +300,7 @@ def master(region, key):
 # bootstrap stack
 #
 
-def template(stackname):
+def current_template(stackname):
     conn = connect_aws_with_stack(stackname, 'cfn')
     return json.loads(conn.get_template(stackname)['GetTemplateResponse']['GetTemplateResult']['TemplateBody'])
 

--- a/src/buildercore/bootstrap.py
+++ b/src/buildercore/bootstrap.py
@@ -314,6 +314,7 @@ def update_template(stackname, template):
     if pdata['aws']['ec2']:
         parameters.append(('KeyName', stackname))
     conn.update_stack(stackname, json.dumps(template), parameters=parameters)
+
     def stack_is_updating():
         return not core.stack_is(stackname, ['UPDATE_COMPLETE'], terminal_states=['UPDATE_ROLLBACK_COMPLETE'])
     call_while(stack_is_updating, interval=2, update_msg="waiting for template of %s to be updated" % stackname, done_msg="template of %s is in state UPDATE_COMPLETE" % stackname)

--- a/src/buildercore/cfngen.py
+++ b/src/buildercore/cfngen.py
@@ -169,8 +169,8 @@ def write_template(stackname, contents):
 
 def read_template(stackname):
     output_fname = os.path.join(STACK_DIR, stackname + ".json")
-    with open(output_fname, 'r') as f:
-        return json.loads(f.read())
+    with open(output_fname, 'r') as template_file:
+        return json.loads(template_file.read())
 
 def validate_aws_template(pname, rendered_template):
     conn = core.connect_aws_with_pname(pname, 'cfn')
@@ -250,8 +250,8 @@ def template_delta(pname, **more_context):
     context = build_context(pname, **more_context)
     template = json.loads(render_template(context))
     return {
-        'Outputs': {title:o for (title, o) in template['Outputs'].iteritems() if title not in old_template['Outputs']},
-        'Resources': {title:r for (title, r) in template['Resources'].iteritems() if title not in old_template['Resources']}
+        'Outputs': {title: o for (title, o) in template['Outputs'].iteritems() if title not in old_template['Outputs']},
+        'Resources': {title: r for (title, r) in template['Resources'].iteritems() if title not in old_template['Resources']}
     }
 
 def merge_delta(stackname, delta):
@@ -259,8 +259,6 @@ def merge_delta(stackname, delta):
     template = read_template(stackname)
     for component in delta:
         assert component in ["Resources", "Outputs"]
-        for title in delta[component]:
-            template[component].update(delta[component])
+        template[component].update(delta[component])
     write_template(stackname, json.dumps(template))
     return template
-

--- a/src/buildercore/cfngen.py
+++ b/src/buildercore/cfngen.py
@@ -137,6 +137,19 @@ def build_context(pname, **more_context): # pylint: disable=too-many-locals
     return context
 
 
+def choose_config(stackname):
+    (pname, instance_id) = core.parse_stackname(stackname)
+    pdata = project.project_data(pname)
+    more_context = {
+        'stackname': stackname,
+    }
+    if instance_id in project.project_alt_config_names(pdata):
+        LOG.info("using alternate AWS configuration %r", instance_id)
+        # TODO there must be a single place where alt-config is switched in
+        # hopefully as deep in the stack as possible to hide it away
+        more_context['alt-config'] = instance_id
+
+    return more_context
 #
 #
 #

--- a/src/buildercore/cfngen.py
+++ b/src/buildercore/cfngen.py
@@ -19,6 +19,7 @@ A developer wants a temporary instance deployed for testing or debugging.
 import os, json, copy
 from slugify import slugify
 from . import utils, trop, core, project, context_handler
+from .utils import ensure
 from .config import STACK_DIR
 
 import logging
@@ -169,8 +170,7 @@ def write_template(stackname, contents):
 
 def read_template(stackname):
     output_fname = os.path.join(STACK_DIR, stackname + ".json")
-    with open(output_fname, 'r') as template_file:
-        return json.loads(template_file.read())
+    return json.load(open(output_fname, 'r'))
 
 def validate_aws_template(pname, rendered_template):
     conn = core.connect_aws_with_pname(pname, 'cfn')
@@ -258,7 +258,7 @@ def merge_delta(stackname, delta):
     """Merges the new resources in delta in the local copy of the Cloudformation  template"""
     template = read_template(stackname)
     for component in delta:
-        assert component in ["Resources", "Outputs"]
+        ensure(component in ["Resources", "Outputs"], "Template component %s not recognized", component)
         template[component].update(delta[component])
     write_template(stackname, json.dumps(template))
     return template

--- a/src/buildercore/core.py
+++ b/src/buildercore/core.py
@@ -360,7 +360,6 @@ def stack_is(stackname, acceptable_states, terminal_states=None):
         raise
 
 
-
 def stack_triple(aws_stack):
     "returns a triple of (name, status, data) of stacks."
     return (aws_stack.stack_name, aws_stack.stack_status, aws_stack)

--- a/src/buildercore/utils.py
+++ b/src/buildercore/utils.py
@@ -32,6 +32,9 @@ def dictfilter(func, ddict):
         return ddict
     return {k: v for k, v in ddict.items() if func(k, v)}
 
+def subdict(ddict, key_list):
+    return {k: v for k, v in ddict.items() if k in key_list}
+
 def exsubdict(ddict, key_list):
     "returns a version of the given dictionary excluding the keys specified"
     return {k: v for k, v in ddict.items() if k not in key_list}

--- a/src/cfn.py
+++ b/src/cfn.py
@@ -44,11 +44,11 @@ def ensure_destroyed(stackname):
 @task(alias='aws_update_stack')
 @requires_aws_stack
 @timeit
-def update(stackname):
+def update(stackname, part_filter=None):
     """Updates the environment within the stack's ec2 instance.
 
     does *not* call Cloudformation's `update` command on the stack"""
-    return bootstrap.update_stack(stackname)
+    return bootstrap.update_stack(stackname, part_filter)
 
 @task
 def update_template(stackname):

--- a/src/cfn.py
+++ b/src/cfn.py
@@ -57,7 +57,7 @@ def update_template(stackname):
     Resources can be added, but existing ones are immutable"""
 
     (pname, _) = core.parse_stackname(stackname)
-    current_template = bootstrap.template(stackname)
+    current_template = bootstrap.current_template(stackname)
     cfngen.write_template(stackname, json.dumps(current_template))
 
     more_context = cfngen.choose_config(stackname)

--- a/src/cfn.py
+++ b/src/cfn.py
@@ -55,22 +55,12 @@ def update_template(stackname):
     """Limited update of the Cloudformation template.
     
     Resources can be added, but existing ones are immutable"""
-    # delegate to buildercore.* the update of the template?
 
-    # TODO: extract this boilerplate code
-    (pname, instance_id) = core.parse_stackname(stackname)
-    pdata = project.project_data(pname)
-    more_context = {
-        'stackname': stackname,
-    }
-    if instance_id in project.project_alt_config_names(pdata):
-        LOG.info("using alternate AWS configuration %r", instance_id)
-        # TODO there must be a single place where alt-config is switched in
-        # hopefully as deep in the stack as possible to hide it away
-        more_context['alt-config'] = instance_id
-
+    (pname, _) = core.parse_stackname(stackname)
     current_template = bootstrap.template(stackname)
     cfngen.write_template(stackname, json.dumps(current_template))
+
+    more_context = cfngen.choose_config(stackname)
     delta = cfngen.template_delta(pname, **more_context)
     LOG.info("%s", pformat(delta))
 

--- a/src/cfn.py
+++ b/src/cfn.py
@@ -53,7 +53,7 @@ def update(stackname, part_filter=None):
 @task
 def update_template(stackname):
     """Limited update of the Cloudformation template.
-    
+
     Resources can be added, but existing ones are immutable"""
 
     (pname, _) = core.parse_stackname(stackname)

--- a/src/cfn.py
+++ b/src/cfn.py
@@ -44,11 +44,10 @@ def ensure_destroyed(stackname):
 @task(alias='aws_update_stack')
 @requires_aws_stack
 @timeit
-def update(stackname, part_filter=None):
+def update(stackname, *service_list):
     """Updates the environment within the stack's ec2 instance.
-
     does *not* call Cloudformation's `update` command on the stack"""
-    return bootstrap.update_stack(stackname, part_filter)
+    return bootstrap.update_stack(stackname, service_list)
 
 @task
 def update_template(stackname):

--- a/src/deploy.py
+++ b/src/deploy.py
@@ -38,16 +38,8 @@ def deploy(pname, instance_id=None, branch='master', part_filter=None):
         LOG.info("stack %r exists, skipping creation", stackname)
     else:
         LOG.info("stack %r doesn't exist, creating", stackname)
-        more_context = {
-            'stackname': stackname,
-            'branch': branch,
-        }
-        # optionally select alternate configurations if it matches the instance name
-        if instance_id in project.project_alt_config_names(pdata):
-            LOG.info("using alternate AWS configuration %r", instance_id)
-            # TODO there must be a single place where alt-config is switched in
-            # hopefully as deep in the stack as possible to hide it away
-            more_context['alt-config'] = instance_id
+        more_context = cfngen.choose_config(stackname)
+        more_context['branch'] = branch
         cfngen.generate_stack(pname, **more_context)
 
     bootstrap.create_update(stackname, part_filter)

--- a/src/tests/test_buildercore_cfngen.py
+++ b/src/tests/test_buildercore_cfngen.py
@@ -1,5 +1,5 @@
-from . import base
 from time import sleep
+from . import base
 from buildercore import cfngen, project
 
 import logging
@@ -35,3 +35,9 @@ class TestBuildercoreCfngen(base.BaseCase):
             sleep(0.25)
 
         self.switch_in_test_settings()
+
+    def test_empty_template_delta(self):
+        template = cfngen.quick_render('dummy1')
+        cfngen.write_template('dummy1--test', template)
+        delta = cfngen.template_delta('dummy1', stackname='dummy1--test')
+        self.assertEqual(delta, {'Outputs': {}, 'Resources': {}})


### PR DESCRIPTION
`Outputs` and `Resources` are compared with a newly generated template by this task. Only the newly appearing entities will be used as a change set against the current template.

The source of the current template is Cloudformation itself, but it is cached locally for the duration of the current task.