### PR TITLE
Build vars revamp

### DIFF
--- a/src/buildercore/trop.py
+++ b/src/buildercore/trop.py
@@ -135,15 +135,19 @@ def mkoutput(title, desc, val):
 #
 #
 
-def ec2instance(context, node):
-    lu = partial(utils.lu, context)
-    build_vars = dict(context)
-    del build_vars['project']
-    build_vars['node'] = node
-    build_vars['nodename'] = "%s--%s" % (context['stackname'], node)
+def build_vars(context, node):
+    buildvars = dict(context)
+    del buildvars['project']
+    buildvars['node'] = node
+    buildvars['nodename'] = "%s--%s" % (context['stackname'], node)
     # the above context will reside on the server at /etc/build-vars.json.b64
     # this gives Salt all (most) of the data that was available at template compile time.
-    build_vars_serialization = bvars.encode_bvars(build_vars)
+    return buildvars
+
+def ec2instance(context, node):
+    lu = partial(utils.lu, context)
+    buildvars = build_vars(context, node)
+    buildvars_serialization = bvars.encode_bvars(buildvars)
 
     project_ec2 = {
         "ImageId": lu('project.aws.ec2.ami'),
@@ -154,7 +158,7 @@ def ec2instance(context, node):
         "Tags": instance_tags(context, node),
 
         "UserData": Base64("""#!/bin/bash
-echo %s > /etc/build-vars.json.b64""" % build_vars_serialization),
+echo %s > /etc/build-vars.json.b64""" % buildvars_serialization),
     }
     return ec2.Instance(EC2_TITLE_NODE % node, **project_ec2)
 

--- a/src/buildvars.py
+++ b/src/buildvars.py
@@ -87,7 +87,7 @@ def fix(stackname):
 @requires_aws_stack
 def force(stackname, field, value):
     def _force_single_ec2_node():
-        buildvars = _validate()
+        buildvars = read_from_current_host()
 
         new_vars = buildvars.copy()
         new_vars[field] = value

--- a/src/integration_tests/test_provisioning.py
+++ b/src/integration_tests/test_provisioning.py
@@ -3,7 +3,7 @@ from subprocess import check_output
 from fabric.api import settings
 from tests import base
 from buildercore import bootstrap, cfngen, lifecycle
-#import buildvars
+import buildvars
 import cfn
 
 class TestProvisioning(base.BaseCase):
@@ -28,9 +28,8 @@ class TestProvisioning(base.BaseCase):
             cfngen.generate_stack(project, stackname=stackname)
             bootstrap.create_stack(stackname)
 
-            # TODO: hangs, not ready to test this. Will revisit in the future
-            #buildvars.switch_revision(stackname, 'master')
-            #buildvars.force(stackname, 'answer', 'forty-two')
+            buildvars.switch_revision(stackname, 'master')
+            buildvars.force(stackname, 'answer', 'forty-two')
 
             lifecycle.stop(stackname)
             lifecycle.start(stackname)


### PR DESCRIPTION
- Manipulating buildvars with the bootstrap users
- A small task to force/repair/change a buildvars value when needed
- `buildvars.fix` instead of writing just a couple of fields, fully regenerates them from
If you think about it, using the bootstrap users makes sense as EC2 instances have build vars right when they are created, without waiting for Salt to run. So we should be able to manipulate them at that level, without relying on the Salt update to deliver the `elife` user and access to it.
The keys of users configured in `pillar.elife` are added to both deploy and
bootstrap users, so this works for anyone who was running buildvars
commands (like Alfred) before.