### PR TITLE
Unique filename for remotely executed scripts

### DIFF
--- a/src/buildercore/bootstrap.py
+++ b/src/buildercore/bootstrap.py
@@ -11,6 +11,7 @@ from functools import partial
 from StringIO import StringIO
 from . import core, utils, config, keypair, bvars
 from collections import OrderedDict
+from datetime import datetime
 from .core import connect_aws_with_stack, stack_pem, stack_all_ec2_nodes, project_data_for_stackname
 from .utils import first, call_while, ensure, subdict
 from .config import BOOTSTRAP_USER
@@ -33,7 +34,8 @@ def run_script(script_path, *script_params):
     """uploads a script for SCRIPTS_PATH and executes it in the /tmp dir with given params.
     ASSUMES YOU ARE CONNECTED TO A STACK"""
     local_script = join(config.SCRIPTS_PATH, script_path)
-    remote_script = join('/tmp', os.path.basename(script_path))
+    timestamp_marker = datetime.now().strftime("%Y%m%d%H%M%S")
+    remote_script = join('/tmp', os.path.basename(script_path) + '-' + timestamp_marker)
     put(local_script, remote_script)
     cmd = ["/bin/bash", remote_script] + map(str, list(script_params))
     retval = sudo(" ".join(cmd))

--- a/src/buildvars.py
+++ b/src/buildvars.py
@@ -81,7 +81,7 @@ def fix(stackname):
             new_vars = build_vars(context, node_id)
             _update_remote_bvars(stackname, new_vars)
 
-    stack_all_ec2_nodes(stackname, (_fix_single_ec2_node, {'stackname':stackname}), username=BOOTSTRAP_USER)
+    stack_all_ec2_nodes(stackname, (_fix_single_ec2_node, {'stackname': stackname}), username=BOOTSTRAP_USER)
 
 @debugtask
 @requires_aws_stack


### PR DESCRIPTION
They are cleaned up after they are run, but in case there is a hard interruption like a Salt crash or an immediate shutdown, old scripts won't interact with new ones that are being run.