### PR TITLE
Destroying leftover DNS entries

### DIFF
--- a/src/buildercore/bootstrap.py
+++ b/src/buildercore/bootstrap.py
@@ -14,6 +14,7 @@ from collections import OrderedDict
 from datetime import datetime
 from .core import connect_aws_with_stack, stack_pem, stack_all_ec2_nodes, project_data_for_stackname
 from .utils import first, call_while, ensure, subdict
+from .lifecycle import delete_dns
 from .config import BOOTSTRAP_USER
 from fabric.api import sudo, put, parallel
 import fabric.exceptions as fabric_exceptions
@@ -467,6 +468,8 @@ def delete_stack(stackname):
         utils.call_while(partial(is_deleting, stackname), update_msg='Waiting for AWS to finish deleting stack ...')
         keypair.delete_keypair(stackname)
         delete_stack_file(stackname)
+        delete_dns(stackname)
+
         LOG.info("stack %r deleted", stackname)
     except BotoServerError as err:
         LOG.exception("[%s: %s] %s (request-id: %s)", err.status, err.reason, err.message, err.request_id)

--- a/src/buildercore/lifecycle.py
+++ b/src/buildercore/lifecycle.py
@@ -120,11 +120,24 @@ def update_dns(stackname):
         for node in nodes:
             _update_dns_a_record(stackname, context['int_domain'], context['int_full_hostname'], node.private_ip_address)
 
+def delete_dns(stackname):
+    context = load_context(stackname)
+    LOG.info("Deleting external full hostname: %s", context['full_hostname'])
+    _delete_dns_a_record(stackname, context['domain'], context['full_hostname'])
+    LOG.info("Deleting internal full hostname: %s", context['int_full_hostname'])
+    _delete_dns_a_record(stackname, context['int_domain'], context['int_full_hostname'])
+
 def _update_dns_a_record(stackname, zone_name, name, value):
     route53 = connect_aws_with_stack(stackname, 'route53')
     zone = route53.get_zone(zone_name)
     LOG.info("Updating DNS record %s to %s", name, value)
     zone.update_a(name, value)
+
+def _delete_dns_a_record(stackname, zone_name, name):
+    route53 = connect_aws_with_stack(stackname, 'route53')
+    zone = route53.get_zone(zone_name)
+    LOG.info("Deleting DNS record %s", name)
+    zone.delete_a(name)
 
 def _select_nodes_with_state(interesting_state, states):
     return [instance_id for (instance_id, state) in states.iteritems() if state == interesting_state]

--- a/src/buildercore/lifecycle.py
+++ b/src/buildercore/lifecycle.py
@@ -143,8 +143,11 @@ def _update_dns_a_record(stackname, zone_name, name, value):
 def _delete_dns_a_record(stackname, zone_name, name):
     route53 = connect_aws_with_stack(stackname, 'route53')
     zone = route53.get_zone(zone_name)
-    LOG.info("Deleting DNS record %s", name)
-    zone.delete_a(name)
+    if zone.get_a(name):
+        LOG.info("Deleting DNS record %s", name)
+        zone.delete_a(name)
+    else:
+        LOG.info("No DNS record to delete")
 
 def _select_nodes_with_state(interesting_state, states):
     return [instance_id for (instance_id, state) in states.iteritems() if state == interesting_state]

--- a/src/buildercore/lifecycle.py
+++ b/src/buildercore/lifecycle.py
@@ -122,10 +122,17 @@ def update_dns(stackname):
 
 def delete_dns(stackname):
     context = load_context(stackname)
-    LOG.info("Deleting external full hostname: %s", context['full_hostname'])
-    _delete_dns_a_record(stackname, context['domain'], context['full_hostname'])
-    LOG.info("Deleting internal full hostname: %s", context['int_full_hostname'])
-    _delete_dns_a_record(stackname, context['int_domain'], context['int_full_hostname'])
+    if context['full_hostname']:
+        LOG.info("Deleting external full hostname: %s", context['full_hostname'])
+        _delete_dns_a_record(stackname, context['domain'], context['full_hostname'])
+    else:
+        LOG.info("No external full hostname to delete")
+
+    if context['int_full_hostname']:
+        LOG.info("Deleting internal full hostname: %s", context['int_full_hostname'])
+        _delete_dns_a_record(stackname, context['int_domain'], context['int_full_hostname'])
+    else:
+        LOG.info("No internal full hostname to delete")
 
 def _update_dns_a_record(stackname, zone_name, name, value):
     route53 = connect_aws_with_stack(stackname, 'route53')

--- a/src/cfn.py
+++ b/src/cfn.py
@@ -28,12 +28,11 @@ def destroy(stackname):
         print 'got:'
         print '\n'.join(difflib.ndiff([stackname], [uin]))
         exit(1)
-    return bootstrap.delete_stack(stackname) and core_lifecycle.delete_dns(stackname)
-
+    return bootstrap.delete_stack(stackname)
 @task
 def ensure_destroyed(stackname):
     try:
-        return bootstrap.delete_stack(stackname) and core_lifecycle.delete_dns(stackname)
+        return bootstrap.delete_stack(stackname)
     except PredicateException as e:
         if "I couldn't find a cloudformation stack" in str(e):
             print "Not even the CloudFormation template exists anymore, exiting idempotently"

--- a/src/cfn.py
+++ b/src/cfn.py
@@ -4,7 +4,7 @@ from fabric.api import task, local, run, sudo, put, get, abort, parallel
 from fabric.contrib import files
 import aws, utils
 from decorators import requires_project, requires_aws_stack, requires_steady_stack, echo_output, setdefault, debugtask, timeit
-from buildercore import core, cfngen, utils as core_utils, bootstrap, project, checks
+from buildercore import core, cfngen, utils as core_utils, bootstrap, project, checks, lifecycle as core_lifecycle
 from buildercore.core import stack_conn, stack_pem, stack_all_ec2_nodes
 from buildercore.decorators import PredicateException
 from buildercore.config import DEPLOY_USER, BOOTSTRAP_USER, FabricException
@@ -28,12 +28,12 @@ def destroy(stackname):
         print 'got:'
         print '\n'.join(difflib.ndiff([stackname], [uin]))
         exit(1)
-    return bootstrap.delete_stack(stackname)
+    return bootstrap.delete_stack(stackname) and core_lifecycle.delete_dns(stackname)
 
 @task
 def ensure_destroyed(stackname):
     try:
-        return bootstrap.delete_stack(stackname)
+        return bootstrap.delete_stack(stackname) and core_lifecycle.delete_dns(stackname)
     except PredicateException as e:
         if "I couldn't find a cloudformation stack" in str(e):
             print "Not even the CloudFormation template exists anymore, exiting idempotently"
@@ -168,8 +168,7 @@ def _check_want_to_be_running(stackname):
     if not should_start:
         return False
 
-    from buildercore import lifecycle
-    lifecycle.start(stackname)
+    core_lifecycle.start(stackname)
     # to get the ip addresses that are assigned to the now-running instances
     # and that weren't there before
     return core.find_ec2_instances(stackname)

--- a/src/tasks.py
+++ b/src/tasks.py
@@ -63,7 +63,7 @@ def create_ami(stackname):
     #new_project_file = project.update_project_file(path, amiid)
     #output_file = project.write_project_file(new_project_file)
     print '\n' * 4
-    #print 'wrote', output_file
+    # print 'wrote', output_file
     print 'update project file with new ami %s. these changes must be merged and committed manually' % amiid
     print '\n' * 4
 


### PR DESCRIPTION
We modify these DNS entries when we start and stop an EC2 instance. CloudFormation then abandons them and does not delete them on destroy. Therefore, we destroy them manually