### PR TITLE
Trying to avoid a situation where nodes are running but we can't connect yet

### DIFF
--- a/src/buildercore/core.py
+++ b/src/buildercore/core.py
@@ -200,6 +200,9 @@ def stack_conn(stackname, username=config.DEPLOY_USER, **kwargs):
     with settings(**params):
         yield
 
+class NoPublicIps(Exception):
+    pass
+
 def stack_all_ec2_nodes(stackname, workfn, username=config.DEPLOY_USER, **kwargs):
     """Executes work on all the EC2 nodes of stackname.
     Optionally connects with the specified username"""
@@ -221,7 +224,7 @@ def stack_all_ec2_nodes(stackname, workfn, username=config.DEPLOY_USER, **kwargs
 
     LOG.info("Executing %s on all ec2 nodes (%s)", workfn, public_ips)
 
-    ensure(None not in public_ips.values(), "Public ips are not valid: %s", public_ips)
+    ensure(None not in public_ips.values(), "Public ips are not valid: %s", public_ips, exception_class=NoPublicIps)
     with settings(**params):
         # TODO: decorate work to print what it is connecting only
         execute(workfn, hosts=public_ips.values(), **work_kwargs)

--- a/src/buildercore/utils.py
+++ b/src/buildercore/utils.py
@@ -233,11 +233,20 @@ def ymd(dt=None, fmt="%Y-%m-%d"):
         dt = datetime.now() # TODO: replace this with a utcnow()
     return dt.strftime(fmt)
 
-def ensure(assertion, msg, *args):
+def ensure(assertion, msg, *args, **kwargs):
     """intended as a convenient replacement for `assert` statements that
     get compiled away with -O flags"""
+
+    exception_class = AssertionError
+    if 'exception_class' in kwargs:
+        exception_class = kwargs['exception_class']
+        del kwargs['exception_class']
+
+    if len(kwargs):
+        raise ValueError("No other keyword arguments than exception_class are accepted: %s", kwargs)
+
     if not assertion:
-        raise AssertionError(msg % args)
+        raise exception_class(msg % args)
 
 def mkdir_p(path):
     os.system("mkdir -p %s" % path)

--- a/src/tests/test_buildercore_utils.py
+++ b/src/tests/test_buildercore_utils.py
@@ -96,3 +96,14 @@ class TestBuildercoreUtils(base.BaseCase):
             self.fail("Should not return normally")
         except:
             self.assertEqual(3, len(sleep.mock_calls))
+
+    def test_ensure(self):
+        utils.ensure(True, "True should allow ensure() to continue")
+        self.assertRaises(AssertionError, lambda: utils.ensure(False, "Error message"))
+        self.assertRaises(AssertionError, lambda: utils.ensure(False, "Error message: %s", "argument"))
+
+        class CustomException(Exception):
+            pass
+        self.assertRaises(CustomException, lambda: utils.ensure(False, "Error message", exception_class=CustomException))
+        self.assertRaises(CustomException, lambda: utils.ensure(False, "Error message: %s", "argument", exception_class=CustomException))
+        self.assertRaises(ValueError, lambda: utils.ensure(False, "Error message", random_argument=CustomException))


### PR DESCRIPTION
Happened in https://ci--alfred.elifesciences.org/job/pull-requests-projects/job/elife-bot/job/PR-351/1/console

Also, add `exception_class` as an optional keyword argument to `ensure()`.