### PR TITLE
Waiting until all nodes are running, even according to secondary indexes of the EC2 API

### DIFF
--- a/src/buildercore/core.py
+++ b/src/buildercore/core.py
@@ -354,6 +354,9 @@ def describe_stack(stackname):
     "returns the full details of a stack given it's name or ID"
     return first(connect_aws_with_stack(stackname, 'cfn').describe_stacks(stackname))
 
+class NoRunningInstances(Exception):
+    pass
+
 # TODO: rename or something
 def stack_data(stackname, ensure_single_instance=False):
     """like `describe_stack`, but returns a list of dictionaries"""
@@ -362,7 +365,7 @@ def stack_data(stackname, ensure_single_instance=False):
         ec2_instances = find_ec2_instances(stackname)
 
         if len(ec2_instances) < 1:
-            raise RuntimeError("found no running ec2 instances for %r. The stack nodes may have been stopped" % stackname)
+            raise NoRunningInstances("found no running ec2 instances for %r. The stack nodes may have been stopped" % stackname)
         elif len(ec2_instances) > 1 and ensure_single_instance:
             raise RuntimeError("talking to multiple EC2 instances is not supported for this task yet: %r" % stackname)
 


### PR DESCRIPTION
See comment, my guess is that some internal indexes of the EC2 API are not updated atomically with the node data:
```
13:41:13 [medium--end2end] 2016-11-25 13:41:13,047 - INFO - MainProcess
- buildercore.core - find_ec2_instances with filters
{'tag:aws:cloudformation:stack-name': ['medium--end2end']} returned
instances [u'i-6f727961']
13:41:13 [medium--end2end] 2016-11-25 13:41:13,047 - INFO - MainProcess
- buildercore.lifecycle - states of medium--end2end nodes
([u'i-6f727961']): {u'i-6f727961': u'running'}
13:41:13 [medium--end2end] 2016-11-25 13:41:13,047 - INFO - MainProcess
- buildercore.utils - all nodes in state running
13:41:13 [medium--end2end] 2016-11-25 13:41:13,177 - INFO - MainProcess
- buildercore.core - find_ec2_instances with filters
{'tag:aws:cloudformation:stack-name': ['medium--end2end'],
'instance-state-name': ['running']} returned instances []
13:41:13 [medium--end2end] 2016-11-25 13:41:13,177 - ERROR - MainProcess
- buildercore.core - caught an exception attempting to discover more
information about this instance. The instance may not exist yet ...
13:41:13 [medium--end2end] Traceback (most recent call last):
13:41:13 [medium--end2end]   File
"/ext/srv/builder/src/buildercore/core.py", line 365, in stack_data
13:41:13 [medium--end2end]     raise RuntimeError("found no running ec2
instances for %r. The stack nodes may have been stopped" % stackname)
13:41:13 [medium--end2end] RuntimeError: found no running ec2 instances
for 'medium--end2end'. The stack nodes may have been stopped
```