### PR TITLE
Remove minions key task when destroying a stack

### DIFF
--- a/src/buildercore/bootstrap.py
+++ b/src/buildercore/bootstrap.py
@@ -457,13 +457,16 @@ def delete_stack_file(stackname):
 def remove_minion_key(stackname):
     pdata = project_data_for_stackname(stackname)
     region = pdata['aws']['region']
-    with stack_conn(core.find_master(region)):
-        sudo("rm -f /etc/salt/pki/master/minions/%s--*" % stackname)
+    master_stack = core.find_master(region)
+    try:
+        with stack_conn(master_stack):
+            sudo("rm -f /etc/salt/pki/master/minions/%s--*" % stackname)
+    except ValueError:
+        LOG.info("No master detected as %s, skipping removal of key", master_stack)
 
 
 def delete_stack(stackname):
     try:
-        remove_minion_key(stackname)
         connect_aws_with_stack(stackname, 'cfn').delete_stack(stackname)
 
         def is_deleting(stackname):

--- a/src/buildercore/bootstrap.py
+++ b/src/buildercore/bootstrap.py
@@ -458,12 +458,8 @@ def remove_minion_key(stackname):
     pdata = project_data_for_stackname(stackname)
     region = pdata['aws']['region']
     master_stack = core.find_master(region)
-    try:
-        with stack_conn(master_stack):
-            sudo("rm -f /etc/salt/pki/master/minions/%s--*" % stackname)
-    except ValueError:
-        LOG.info("No master detected as %s, skipping removal of key", master_stack)
-
+    with stack_conn(master_stack):
+        sudo("rm -f /etc/salt/pki/master/minions/%s--*" % stackname)
 
 def delete_stack(stackname):
     try:

--- a/src/buildercore/bootstrap.py
+++ b/src/buildercore/bootstrap.py
@@ -12,7 +12,7 @@ from StringIO import StringIO
 from . import core, utils, config, keypair, bvars
 from collections import OrderedDict
 from datetime import datetime
-from .core import connect_aws_with_stack, stack_pem, stack_all_ec2_nodes, project_data_for_stackname
+from .core import connect_aws_with_stack, stack_pem, stack_all_ec2_nodes, project_data_for_stackname, stack_conn
 from .utils import first, call_while, ensure, subdict
 from .lifecycle import delete_dns
 from .config import BOOTSTRAP_USER
@@ -454,8 +454,16 @@ def delete_stack_file(stackname):
         return not os.path.exists(path)
     return dict(zip(paths, map(_unlink, paths)))
 
+def remove_minion_key(stackname):
+    pdata = project_data_for_stackname(stackname)
+    region = pdata['aws']['region']
+    with stack_conn(core.find_master(region)):
+        sudo("rm -f /etc/salt/pki/master/minions/%s--*" % stackname)
+
+
 def delete_stack(stackname):
     try:
+        remove_minion_key(stackname)
         connect_aws_with_stack(stackname, 'cfn').delete_stack(stackname)
 
         def is_deleting(stackname):

--- a/src/tasks.py
+++ b/src/tasks.py
@@ -199,3 +199,8 @@ def repair_cfn_info(stackname):
 def repair_context(stackname):
     # triggers the workaround of downloading it from EC2 and persisting it
     load_context(stackname)
+
+@task
+@requires_aws_stack
+def remove_minion_key(stackname):
+    bootstrap.remove_minion_key(stackname)


### PR DESCRIPTION
Especially when destroying and recreating a stack, now the keys have to be manually removed for the master to accept the new EC2 instance from the new instance of the stack.

The feature provides as a task for manual repairs. Cannot really automate it fully for now as it is too difficult to fit in our integration tests, which do not use a master server.