### PR TITLE
Trying to insert New Relic

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -28,6 +28,7 @@ scripts/customize.sh
 scripts/salt/*.minion
 /custom-vagrant/salt/
 /custom-vagrant/pillar/
+/newrelic.ini
 
 .no-install-basebox.flag
 .no-vagrant-s3auth.flag

--- a/bldr
+++ b/bldr
@@ -17,4 +17,8 @@ fi
 # a wrapper around fabric that activates the elife-builder virtualenv
 
 fabric=$(which fab)
-$fabric "$*" -f src/fabfile.py
+if [ -e newrelic.ini ]; then
+    NEW_RELIC_CONFIG_FILE=./newrelic.ini newrelic-admin run-program $fabric "$*" -f src/fabfile.py
+else
+    $fabric "$*" -f src/fabfile.py
+fi

--- a/requirements.txt
+++ b/requirements.txt
@@ -18,3 +18,4 @@ troposphere==1.5.0
 mock==2.0.0
 python-dateutil<3.0.0,>=2.1
 pytz==2016.6.1
+newrelic==2.74.0.54

--- a/src/fabfile.py
+++ b/src/fabfile.py
@@ -7,6 +7,10 @@ SRC_DIR = os.path.dirname(os.path.abspath(__file__)) # elife-builder/src/
 # once called 'THIS_DIR', now deprecated as confusing.
 PROJECT_DIR = os.path.dirname(SRC_DIR)    # elife-builder/
 
+import monitoring
+import fabric.api
+fabric.api.task = monitoring.task
+
 from cfn import *
 
 # aws tasks are not working for some reason.. possibly circular dependency

--- a/src/monitoring.py
+++ b/src/monitoring.py
@@ -1,0 +1,21 @@
+import functools
+from fabric.api import task as original_task
+import newrelic.agent
+
+def task(*args, **kwargs):
+    invoked = bool(not args or kwargs)
+    if not invoked:
+        func, args = args[0], ()
+
+    def wrapper(func):
+        @functools.wraps(func)
+        def monitored(*args, **kwargs):
+            application = newrelic.agent.register_application(timeout=1.0)
+            #print func.func_name
+            with newrelic.agent.BackgroundTask(application, name='example_short_startup_timeout'):
+                return func(*args, **kwargs)
+
+        return original_task(monitored, *args, **kwargs)
+
+    return wrapper if invoked else wrapper(func)
+

--- a/src/tasks.py
+++ b/src/tasks.py
@@ -13,6 +13,8 @@ from buildercore.core import stack_conn
 import utils
 from buildercore.decorators import osissue
 from buildercore.context_handler import load_context
+import time
+import newrelic.agent
 
 @debugtask
 @requires_project
@@ -204,3 +206,12 @@ def repair_context(stackname):
 @requires_aws_stack
 def remove_minion_key(stackname):
     bootstrap.remove_minion_key(stackname)
+
+@task
+def sleep(seconds):
+    total = 0
+    for i in range(0, 10000000*int(seconds)):
+        total = total + i
+    print total
+    time.sleep(int(seconds))
+


### PR DESCRIPTION
Will probably close this soon with no results. The bottom line is the New Relic agent takes a variable time to start up that goes from 1-2 seconds to 20. The builder tasks would have to wait for that to be performed before they can run, which is a latency killer (even if they do not consume CPU while doing so). New Relic seems to be ill-fitted for many short-lived processes.