### PR TITLE
Precisely specifying the Salt version

### DIFF
--- a/projects/elife.yaml
+++ b/projects/elife.yaml
@@ -1,6 +1,6 @@
 defaults:
     description: defaults for all projects in this file
-    salt: '2016.3' # the version of salt these project use
+    salt: '2016.3.4' # the version of salt these project use
     # use False with a subdomain to assign internal addresses only
     domain: elifesciences.org
     # addressing within VPC


### PR DESCRIPTION
Newly created minions are at 2016.3.4, while older machines are at 2016.3.1 which has a bug that doesn't show `Total run time: ... s` when running highstate.

Since the grep in `scripts/bootstrap.sh` is on this value, the version did not get upgraded. With this change, everyone will get `2016.3.4`.