### PR TITLE
Log message cannot use single host information

### DIFF
--- a/src/buildercore/core.py
+++ b/src/buildercore/core.py
@@ -238,7 +238,7 @@ def stack_all_ec2_nodes(stackname, workfn, username=config.DEPLOY_USER, **kwargs
             execute(single_node_work, hosts=public_ips.values())
         except config.FabricException as err:
             if str(err.message).startswith('Timed out trying to connect'):
-                LOG.info("Timeout while executing task on %s (node %s), retrying once on all nodes", current_ip(), current_ec2_node_id())
+                LOG.info("Timeout while executing task on a %s node (%s), retrying once on all nodes", stackname, err.message)
                 execute(single_node_work, hosts=public_ips.values())
             else:
                 raise err


### PR DESCRIPTION
Since there are in general multiple hosts on which the command is executed, and these current_*() functions can only be called in the context of a single host