### PR TITLE
Running bootstrap.sh before highstate.sh on deploy

### DIFF
--- a/scripts/bootstrap.sh
+++ b/scripts/bootstrap.sh
@@ -38,7 +38,8 @@ fi
 
 upgrade_python=false
 install_git=false
-# Python is such a hard dependency of Salt that we have to upgrade it outside of it to avoid changing it while it is running
+# Python is such a hard dependency of Salt that we have to upgrade it outside of 
+# Salt to avoid changing it while it is running
 python_version=$(dpkg-query -W --showformat='${Version}' python2.7) # e.g. 2.7.5-5ubuntu3
 if dpkg --compare-versions "$python_version" lt 2.7.12; then
     sudo add-apt-repository -y ppa:fkrull/deadsnakes-python2.7
@@ -155,4 +156,7 @@ echo "github.com,192.30.252.128 ssh-rsa AAAAB3NzaC1yc2EAAAABIwAAAQEAq2A7hRGmdnm9
 # run the daily cron job
 # this ensures security patches are run for machines that are only brought 
 # online temporarily to run tests
-run-parts /etc/cron.daily &
+if [ ! -e "/root/updated-$(date -I)" ]; then
+    touch "/root/updated-$(date -I)" && run-parts /etc/cron.daily &
+fi
+

--- a/src/deploy.py
+++ b/src/deploy.py
@@ -49,4 +49,5 @@ def deploy(pname, instance_id=None, branch='master', part_filter=None):
 @requires_aws_stack
 def switch_revision_update_instance(stackname, revision=None):
     buildvars.switch_revision(stackname, revision)
+    core.stack_all_ec2_nodes(stackname, lambda: bootstrap.run_script('bootstrap.sh'))
     core.stack_all_ec2_nodes(stackname, lambda: bootstrap.run_script('highstate.sh'))


### PR DESCRIPTION
Open for discussion. It possibly upgraded Python and Salt bringing them at the version we want; question is whether to run it on every deploy or only in specialized commands like in update