### PR TITLE
Correctly running bootstrap.sh

### DIFF
--- a/scripts/bootstrap.sh
+++ b/scripts/bootstrap.sh
@@ -11,6 +11,12 @@ set -xv  # output the scripts and interpolated steps
 
 echo "-----------------------------"
 
+if [ "$#" -ne 4 ]; then
+    echo "Usage: ./bootstrap.sh version minion_id install_master master_ipaddr"
+    echo "Example: ./bootstrap.sh 2016.3.4 journal--end2end--1 false 10.0.0.1"
+    exit 1
+fi
+
 version=$1
 minion_id=$2
 install_master=$3

--- a/src/deploy.py
+++ b/src/deploy.py
@@ -49,5 +49,4 @@ def deploy(pname, instance_id=None, branch='master', part_filter=None):
 @requires_aws_stack
 def switch_revision_update_instance(stackname, revision=None):
     buildvars.switch_revision(stackname, revision)
-    #core.stack_all_ec2_nodes(stackname, lambda: bootstrap.run_script('bootstrap.sh'))
-    core.stack_all_ec2_nodes(stackname, lambda: bootstrap.run_script('highstate.sh'))
+    bootstrap.update_stack(stackname)


### PR DESCRIPTION
Actually, we could not run bootstrap.sh in this way because it needs 4 arguments. The best way seems to delegate to `buildercore.bootstrap.update_stack()`, which contains the both `bootstrap.sh` and `highstate.sh`.