### PR TITLE
Actually do things in parallel

### DIFF
--- a/src/cfn.py
+++ b/src/cfn.py
@@ -1,6 +1,6 @@
 from distutils.util import strtobool  # pylint: disable=import-error,no-name-in-module
 from pprint import pformat
-from fabric.api import task, local, run, sudo, put, get, abort, parallel, settings
+from fabric.api import task, local, run, sudo, put, get, abort, settings
 import fabric.state
 from fabric.contrib import files
 import aws, utils
@@ -260,7 +260,7 @@ def _user(use_bootstrap_user):
 
 @task
 @requires_aws_stack
-def cmd(stackname, command=None, username=DEPLOY_USER, clean_output=False):
+def cmd(stackname, command=None, username=DEPLOY_USER, clean_output=False, concurrency=None):
     if command is None:
         abort("Please specify a command e.g. ./bldr cmd:%s,ls" % stackname)
     LOG.info("Connecting to: %s", stackname)
@@ -274,11 +274,12 @@ def cmd(stackname, command=None, username=DEPLOY_USER, clean_output=False):
         custom_settings['output_prefix'] = False
 
     with settings(**custom_settings):
-        stack_all_ec2_nodes(
+        return stack_all_ec2_nodes(
             stackname,
-            (parallel(run), {'command': command}),
+            (run, {'command': command}),
             username=username,
-            abort_on_prompts=True)
+            abort_on_prompts=True,
+            concurrency=concurrency)
 
 @task
 def project_list():

--- a/src/deploy.py
+++ b/src/deploy.py
@@ -47,6 +47,7 @@ def deploy(pname, instance_id=None, branch='master', part_filter=None):
 
 @task
 @requires_aws_stack
-def switch_revision_update_instance(stackname, revision=None):
+def switch_revision_update_instance(stackname, revision=None, concurrency=None):
+    """concurrency default is to perform updates in parallel to multiple machines"""
     buildvars.switch_revision(stackname, revision)
-    bootstrap.update_stack(stackname)
+    bootstrap.update_stack(stackname, concurrency=concurrency)

--- a/src/deploy.py
+++ b/src/deploy.py
@@ -47,7 +47,7 @@ def deploy(pname, instance_id=None, branch='master', part_filter=None):
 
 @task
 @requires_aws_stack
-def switch_revision_update_instance(stackname, revision=None, concurrency=None):
+def switch_revision_update_instance(stackname, revision=None, concurrency='serial'):
     """concurrency default is to perform updates in parallel to multiple machines"""
     buildvars.switch_revision(stackname, revision)
     bootstrap.update_stack(stackname, concurrency=concurrency)

--- a/src/integration_tests/test_provisioning.py
+++ b/src/integration_tests/test_provisioning.py
@@ -3,6 +3,7 @@ from subprocess import check_output
 from fabric.api import settings
 from tests import base
 from buildercore import bootstrap, cfngen, lifecycle
+from buildercore.config import BOOTSTRAP_USER
 import buildvars
 import cfn
 
@@ -33,3 +34,5 @@ class TestProvisioning(base.BaseCase):
 
             lifecycle.stop(stackname)
             lifecycle.start(stackname)
+
+            cfn.cmd(stackname, "ls -l", username=BOOTSTRAP_USER, concurrency='parallel')


### PR DESCRIPTION
There was a regression some time ago in which the @parallel tagged function started to get wrapped into other lambdas. Then fabric executed it serially rather that in parallel for multiple hosts. This fixes parallel behavior but provides a switch for executings tasks serially when necessary