### PR TITLE
Journal ELBs supporting both HTTP and HTTPS

### DIFF
--- a/projects/elife.yaml
+++ b/projects/elife.yaml
@@ -182,14 +182,27 @@ journal:
                 cluster-size: 2
             elb:
                 stickiness: True
-                protocol: https
+                protocol: 
+                    - https
+                    - http
+        end2end-test:
+            description: end2end environment for journal. ELB on top of multiple EC2 instances
+            ec2:
+                cluster-size: 2
+            elb:
+                stickiness: True
+                protocol: 
+                    - https
+                    - http
         prod:
             description: prod environment for journal. ELB on top of multiple EC2 instances
             ec2:
                 cluster-size: 2
             elb:
                 stickiness: True
-                protocol: https
+                protocol:
+                    - https
+                    - http
     vagrant:
         ram: 4096
         ports:


### PR DESCRIPTION
Both will forward to Journal EC2 instances on port 80.

Incidentally, they need their own security group opening the ports that
the protocols need.