### PR TITLE
Caching loading of YAML projects data

### DIFF
--- a/src/buildercore/project/files.py
+++ b/src/buildercore/project/files.py
@@ -5,6 +5,7 @@ from collections import OrderedDict
 # from . import core # DONT import core. this module should be relatively independent
 from buildercore import utils
 from buildercore.decorators import testme
+from kids.cache import cache as cached
 
 import logging
 LOG = logging.getLogger(__name__)
@@ -37,6 +38,7 @@ def write_project_file(new_project_data, project_file):
 #
 #
 
+@cached
 def all_projects(project_file):  # , project_file=config.PROJECT_FILE):
     allp = utils.ordered_load(open(project_file))
     if allp is None:

--- a/src/tests/test_buildercore_project.py
+++ b/src/tests/test_buildercore_project.py
@@ -39,13 +39,11 @@ class TestProject(base.BaseCase):
 
 class TestProjectData(base.BaseCase):
     def setUp(self):
+        project.files.all_projects.cache_clear()
         self.dummy_yaml = join(self.fixtures_dir, 'projects', 'dummy-project.yaml')
         self.dummy1_config = join(self.fixtures_dir, 'dummy1-project.json')
         self.dummy2_config = join(self.fixtures_dir, 'dummy2-project.json')
         self.dummy3_config = join(self.fixtures_dir, 'dummy3-project.json')
-
-    def tearDown(self):
-        pass
 
     def test_configurations(self):
         expected = [


### PR DESCRIPTION
According to cProfile, this function is rather expensive and is called 34 times for every builder commands that is executed.

The builder bootstrap time goes from 7 to 1-2 seconds.