### PR TITLE
Avoid unnecessary call to Cloudformation

### DIFF
--- a/src/buildercore/core.py
+++ b/src/buildercore/core.py
@@ -27,6 +27,7 @@ class DeprecationException(Exception):
 class NoMasterException(Exception):
     pass
 
+
 ALL_CFN_STATUS = [
     'CREATE_IN_PROGRESS',
     'CREATE_FAILED',
@@ -79,6 +80,7 @@ def _set_raw_subscription_attribute(sns_connection, subscription_arn):
     }
     return sns_connection._make_request('SetSubscriptionAttributes', params)
 
+
 sns.connection.SNSConnection.set_raw_subscription_attribute = _set_raw_subscription_attribute
 
 
@@ -129,13 +131,15 @@ def connect_aws_with_stack(stackname, service):
     pname = project_name_from_stackname(stackname)
     return connect_aws_with_pname(pname, service)
 
-def find_ec2_instances(stackname, state='running', node_ids=None):
+def find_ec2_instances(stackname, state='running', node_ids=None, allow_empty=False):
     "returns list of ec2 instances data for a *specific* stackname"
     # http://docs.aws.amazon.com/AWSEC2/latest/APIReference/API_DescribeInstances.html
     conn = connect_aws_with_stack(stackname, 'ec2')
     filters = _all_nodes_filter(stackname, state=state, node_ids=node_ids)
     ec2_instances = conn.get_only_instances(filters=filters)
     LOG.info("find_ec2_instances with filters %s returned instances %s", filters, [e.id for e in ec2_instances])
+    if not allow_empty and not ec2_instances:
+        raise RuntimeError("ec2_instances is empty and this it not allowed in this situation")
     return ec2_instances
 
 

--- a/src/buildercore/lifecycle.py
+++ b/src/buildercore/lifecycle.py
@@ -113,7 +113,7 @@ def _wait_daemons():
     call_while(is_starting_daemons, interval=3, update_msg='Waiting for %s to be detected on %s...' % (path, node_id))
 
 def update_dns(stackname):
-    nodes = find_ec2_instances(stackname)
+    nodes = find_ec2_instances(stackname, allow_empty=True)
     LOG.info("Nodes found for DNS update: %s", [node.id for node in nodes])
     if len(nodes) == 0:
         raise RuntimeError("No nodes found for %s, they may be in a stopped state: (%s). They need to be `running` to have a (public, at least) ip address that can be mapped onto a DNS" % (stackname, _nodes_states(stackname)))

--- a/src/cfn.py
+++ b/src/cfn.py
@@ -169,7 +169,7 @@ def _pick_node(instance_list, node):
     return instance
 
 def _check_want_to_be_running(stackname):
-    instance_list = core.find_ec2_instances(stackname)
+    instance_list = core.find_ec2_instances(stackname, allow_empty=True)
     num_instances = len(instance_list)
     if num_instances >= 1:
         return instance_list

--- a/src/decorators.py
+++ b/src/decorators.py
@@ -92,6 +92,9 @@ def requires_aws_stack(func):
     def call(*args, **kwargs):
         stackname = first(args) or os.environ.get('INSTANCE')
         region = aws.find_region(stackname)
+        if stackname:
+            args = args[1:]
+            return func(stackname, *args, **kwargs)
         asl = core.active_stack_names(region)
         if not asl:
             raise RuntimeError('\nno AWS stacks *in an active state* exist, cannot continue.')

--- a/src/tests/test_buildercore_cfngen.py
+++ b/src/tests/test_buildercore_cfngen.py
@@ -32,7 +32,7 @@ class TestBuildercoreCfngen(base.BaseCase):
 
         for pname in project.aws_projects().keys():
             self.assertTrue(cfngen.validate_project(pname))
-            sleep(0.25)
+            sleep(0.5)
 
         self.switch_in_test_settings()
 

--- a/src/tests/test_buildercore_core.py
+++ b/src/tests/test_buildercore_core.py
@@ -124,7 +124,10 @@ class SimpleCases(base.BaseCase):
             self.assertEqual(["us-east-1", "eu-central-1"], e.regions())
 
     def test_find_ec2_instances(self):
-        self.assertEquals([], core.find_ec2_instances('dummy1--prod'))
+        self.assertEquals([], core.find_ec2_instances('dummy1--prod', allow_empty=True))
+
+    def test_find_ec2_instances_requiring_a_non_empty_list(self):
+        self.assertRaises(RuntimeError, core.find_ec2_instances, 'dummy1--prod', allow_empty=False)
 
 
 class TestCoreNewProjectData(base.BaseCase):


### PR DESCRIPTION
When a stackname is explicitly passed in, don't ask for the list to propose to the user, just trust it.

We are getting rate limited on this call, that is performed for every builder command