### PR TITLE
Diagnosing recurrent os.mkdir error

### DIFF
--- a/src/buildercore/project/files.py
+++ b/src/buildercore/project/files.py
@@ -115,7 +115,15 @@ def project_dir_path(project_file):
     # /path/to/elife-builder/project/elife/
     path = join(os.path.dirname(project_file), project_file_name(project_file))
     if not os.path.exists(path):
-        os.mkdir(path)
+        # this call fails non-deterministically in build, debugging it
+
+        try:
+            os.mkdir(path)
+        except:
+            import subprocess
+            print "Debugging os.mkdir(path) failure"
+            print subprocess.check_output(["ls", "-l", os.path.dirname(path)], stderr=subprocess.STDOUT)
+            raise
     return path
 
 def find_snippets(project_file):


### PR DESCRIPTION
We continue to get this exception in integration tests:
```
12:11:01 Error in integration_tests.test_provisioning.TestProvisioning.test_create
12:11:01   File "/usr/lib/python2.7/unittest/case.py", line 329, in run
12:11:01     testMethod()
12:11:01   File "/ext/jenkins/workspace/test-builder/src/integration_tests/test_provisioning.py", line 26, in test_create
12:11:01     cfn.ensure_destroyed(stackname)
12:11:01   File "/ext/jenkins/workspace/test-builder/venv/local/lib/python2.7/site-packages/fabric/tasks.py", line 170, in __call__
12:11:01     return self.run(*args, **kwargs)
12:11:01   File "/ext/jenkins/workspace/test-builder/venv/local/lib/python2.7/site-packages/fabric/tasks.py", line 173, in run
12:11:01     return self.wrapped(*args, **kwargs)
12:11:01   File "/ext/jenkins/workspace/test-builder/src/cfn.py", line 36, in ensure_destroyed
12:11:01     return bootstrap.delete_stack(stackname)
12:11:01   File "/ext/jenkins/workspace/test-builder/src/buildercore/bootstrap.py", line 474, in delete_stack
12:11:01     connect_aws_with_stack(stackname, 'cfn').delete_stack(stackname)
12:11:01   File "/ext/jenkins/workspace/test-builder/src/buildercore/core.py", line 132, in connect_aws_with_stack
12:11:01     return connect_aws_with_pname(pname, service)
12:11:01   File "/ext/jenkins/workspace/test-builder/venv/local/lib/python2.7/site-packages/kids/cache/__init__.py", line 112, in _cache_wrapper
12:11:01     result = wrapped(*args, **kwargs)
12:11:01   File "/ext/jenkins/workspace/test-builder/src/buildercore/core.py", line 124, in connect_aws_with_pname
12:11:01     pdata = project.project_data(pname)
12:11:01   File "/ext/jenkins/workspace/test-builder/src/buildercore/project/__init__.py", line 108, in project_data
12:11:01     data = project_map(project_locations_list)
12:11:01   File "/ext/jenkins/workspace/test-builder/venv/local/lib/python2.7/site-packages/kids/cache/__init__.py", line 112, in _cache_wrapper
12:11:01     result = wrapped(*args, **kwargs)
12:11:01   File "/ext/jenkins/workspace/test-builder/src/buildercore/project/__init__.py", line 92, in project_map
12:11:01     opm = org_project_map(project_locations_list)
12:11:01   File "/ext/jenkins/workspace/test-builder/src/buildercore/project/__init__.py", line 78, in org_project_map
12:11:01     data = map(find_project, project_locations_list)
12:11:01   File "/ext/jenkins/workspace/test-builder/src/buildercore/project/__init__.py", line 67, in find_project
12:11:01     return fnmap[protocol](path, hostname)
12:11:01   File "/ext/jenkins/workspace/test-builder/src/buildercore/project/files.py", line 140, in projects_from_file
12:11:01     pdata = map(lambda pname: project_data(pname, path_to_file), project_list)
12:11:01   File "/ext/jenkins/workspace/test-builder/src/buildercore/project/files.py", line 140, in <lambda>
12:11:01     pdata = map(lambda pname: project_data(pname, path_to_file), project_list)
12:11:01   File "/ext/jenkins/workspace/test-builder/src/buildercore/project/files.py", line 68, in project_data
12:11:01     snippets = find_snippets(project_file)
12:11:01   File "/ext/jenkins/workspace/test-builder/src/buildercore/project/files.py", line 122, in find_snippets
12:11:01     path = project_dir_path(project_file)
12:11:01   File "/ext/jenkins/workspace/test-builder/src/buildercore/project/files.py", line 118, in project_dir_path
12:11:01     os.mkdir(path)
12:11:01 OSError: [Errno 17] File exists: '/ext/jenkins/workspace/test-builder/src/tests/fixtures/projects/dummy-project'
```

`os.mkdir` is guarded by `os.path.exists` so it should not be executed if the directory already exists.