### PR TITLE
Start nodes caught when stopping

### DIFF
--- a/src/buildercore/lifecycle.py
+++ b/src/buildercore/lifecycle.py
@@ -21,7 +21,15 @@ def start(stackname):
 
     states = _nodes_states(stackname)
     LOG.info("Current states: %s", states)
-    _ensure_valid_states(states, {'stopped', 'pending', 'running'})
+    _ensure_valid_states(states, {'stopped', 'pending', 'running', 'stopping'})
+
+    stopping = _select_nodes_with_state('stopping', states)
+    if stopping:
+        LOG.info("Nodes are stopping: %s", stopping)
+        _wait_all_in_state(stackname, 'stopped', stopping)
+        states = _nodes_states(stackname)
+    LOG.info("Current states: %s", states)
+
     to_be_started = _select_nodes_with_state('stopped', states)
     if not to_be_started:
         LOG.info("Nodes are all running")


### PR DESCRIPTION
Rarely, a node takes a long time to stop and the Jenkins builds that does so times out, unlocking it. If a start task is then executed it fails. We support also the stopping state now, so that if a node is caught stopping it will be waited upon and then restarted as requested.

This happened both to me and @thewilkybarkid