### PR TITLE
Show error when build vars cannot be accessed

### DIFF
--- a/src/buildercore/bvars.py
+++ b/src/buildercore/bvars.py
@@ -2,7 +2,6 @@ from os.path import join
 from StringIO import StringIO
 import json, base64
 from fabric.api import get
-from .config import FabricException
 
 def decode_bvars(contents):
     return json.loads(base64.b64decode(contents))
@@ -14,11 +13,7 @@ def read_from_current_host():
     "returns the buildvars from the CURRENTLY CONNECTED host"
     # due to a typo we now have two types of file naming in existence
     # prefer hyphenated over underscores
-    for fname in ['build-vars.json.b64', 'build_vars.json.b64']:
-        try:
-            strbuffer = StringIO()
-            get(join('/etc/', fname), strbuffer)
-            return decode_bvars(strbuffer.getvalue())
-        except FabricException:
-            # file not found
-            continue
+    fname = 'build-vars.json.b64'
+    strbuffer = StringIO()
+    get(join('/etc/', fname), strbuffer)
+    return decode_bvars(strbuffer.getvalue())


### PR DESCRIPTION
This was saying that the file cannot be found while the real problem was a missing SSH key in authorized_files