### PR TITLE
Working Cloudfront support

### DIFF
--- a/projects/elife.yaml
+++ b/projects/elife.yaml
@@ -84,7 +84,9 @@ defaults:
         #               suffix: '.xml'
         #       deletion-policy: delete|retain
         s3: {}
-        cloudfront: null
+        cloudfront: 
+            # cloudfront defaults only used if an 'elb' section present in project
+            certificate: arn:aws:iam::512686554592:server-certificate/cloudfront/wildcard.elifesciences.org/wildcard.elifesciences.org
     aws-alt:
         fresh:
             description: uses a plain Ubuntu basebox instead of an ami

--- a/projects/elife.yaml
+++ b/projects/elife.yaml
@@ -88,6 +88,7 @@ defaults:
             # cloudfront defaults only used if a 'cloudfront' section present in project
             certificate_id: ASCAIRXYIRFBOR5QSDP5M
             cookies: []
+            compress: True
     aws-alt:
         fresh:
             description: uses a plain Ubuntu basebox instead of an ami

--- a/projects/elife.yaml
+++ b/projects/elife.yaml
@@ -736,7 +736,12 @@ iiif:
                 size: 30 # GB
         shielded:
             cloudfront:
-                subdomain: "{instance}--cdn-iiif"
+                subdomains: 
+                    - "{instance}--cdn-iiif"
+        shielded2:
+            cloudfront:
+                subdomains: 
+                    - "{instance}--cdn-iiif"
     vagrant:
         ports:
             1241: 80

--- a/projects/elife.yaml
+++ b/projects/elife.yaml
@@ -86,7 +86,7 @@ defaults:
         s3: {}
         cloudfront: 
             # cloudfront defaults only used if an 'elb' section present in project
-            certificate: arn:aws:iam::512686554592:server-certificate/cloudfront/wildcard.elifesciences.org/wildcard.elifesciences.org
+            certificate_id: ASCAIRXYIRFBOR5QSDP5M
     aws-alt:
         fresh:
             description: uses a plain Ubuntu basebox instead of an ami

--- a/projects/elife.yaml
+++ b/projects/elife.yaml
@@ -85,7 +85,7 @@ defaults:
         #       deletion-policy: delete|retain
         s3: {}
         cloudfront: 
-            # cloudfront defaults only used if an 'elb' section present in project
+            # cloudfront defaults only used if a 'cloudfront' section present in project
             certificate_id: ASCAIRXYIRFBOR5QSDP5M
     aws-alt:
         fresh:

--- a/projects/elife.yaml
+++ b/projects/elife.yaml
@@ -89,6 +89,7 @@ defaults:
             certificate_id: ASCAIRXYIRFBOR5QSDP5M
             cookies: []
             compress: True
+            headers: []
     aws-alt:
         fresh:
             description: uses a plain Ubuntu basebox instead of an ami

--- a/projects/elife.yaml
+++ b/projects/elife.yaml
@@ -747,6 +747,10 @@ iiif:
             cloudfront:
                 subdomains: 
                     - "{instance}--cdn-iiif"
+        shielded3:
+            cloudfront:
+                subdomains: 
+                    - "{instance}--cdn-iiif"
     vagrant:
         ports:
             1241: 80

--- a/projects/elife.yaml
+++ b/projects/elife.yaml
@@ -87,6 +87,7 @@ defaults:
         cloudfront: 
             # cloudfront defaults only used if a 'cloudfront' section present in project
             certificate_id: ASCAIRXYIRFBOR5QSDP5M
+            cookies: []
     aws-alt:
         fresh:
             description: uses a plain Ubuntu basebox instead of an ami

--- a/projects/elife.yaml
+++ b/projects/elife.yaml
@@ -736,6 +736,10 @@ iiif:
         end2end:
             ext:
                 size: 30 # GB
+        continuumtest:
+            cloudfront:
+                subdomains: 
+                    - "{instance}--cdn-iiif"
         prod:
             ext:
                 size: 30 # GB

--- a/projects/elife.yaml
+++ b/projects/elife.yaml
@@ -84,7 +84,7 @@ defaults:
         #               suffix: '.xml'
         #       deletion-policy: delete|retain
         s3: {}
-        cloudfront: None
+        cloudfront: null
     aws-alt:
         fresh:
             description: uses a plain Ubuntu basebox instead of an ami
@@ -734,6 +734,9 @@ iiif:
         prod:
             ext:
                 size: 30 # GB
+        shielded:
+            cloudfront:
+                subdomain: "{instance}--cdn-iiif"
     vagrant:
         ports:
             1241: 80

--- a/projects/elife.yaml
+++ b/projects/elife.yaml
@@ -84,6 +84,7 @@ defaults:
         #               suffix: '.xml'
         #       deletion-policy: delete|retain
         s3: {}
+        cloudfront: None
     aws-alt:
         fresh:
             description: uses a plain Ubuntu basebox instead of an ami

--- a/src/buildercore/bootstrap.py
+++ b/src/buildercore/bootstrap.py
@@ -111,7 +111,7 @@ def _wait_until_in_progress(stackname):
     utils.call_while(partial(is_updating, stackname), timeout=3600, update_msg='Waiting for AWS to finish creating stack ...')
     final_stack = core.describe_stack(stackname)
     events = [(e.resource_status, e.resource_status_reason) for e in final_stack.describe_events()]
-    ensure(final_stack.stack_status in ['CREATE_COMPLETE'], "Final stack status is not successful: %s.\nEvents: %s", final_stack.stack_status, pformat(events))
+    ensure(final_stack.stack_status in ['CREATE_COMPLETE'], "Failed to create stack: %s.\nEvents: %s", final_stack.stack_status, pformat(events))
 
 
 def setup_ec2(stackname, context_ec2):

--- a/src/buildercore/bootstrap.py
+++ b/src/buildercore/bootstrap.py
@@ -7,6 +7,7 @@ without the extension."""
 import json
 import os
 from os.path import join
+from pprint import pformat
 from functools import partial
 from StringIO import StringIO
 from . import core, utils, config, keypair, bvars
@@ -104,8 +105,14 @@ def _create_generic_stack(stackname, parameters=None, on_start=_noop, on_error=_
 
 def _wait_until_in_progress(stackname):
     def is_updating(stackname):
-        return core.describe_stack(stackname).stack_status in ['CREATE_IN_PROGRESS']
+        stack_status = core.describe_stack(stackname).stack_status
+        LOG.info("Stack status: %s", stack_status)
+        return stack_status in ['CREATE_IN_PROGRESS']
     utils.call_while(partial(is_updating, stackname), timeout=1200, update_msg='Waiting for AWS to finish creating stack ...')
+    final_stack = core.describe_stack(stackname)
+    events = [(e.resource_status, e.resource_status_reason) for e in final_stack.describe_events()]
+    ensure(final_stack.stack_status in ['CREATE_COMPLETE'], "Final stack status is not successful: %s.\nEvents: %s", final_stack.stack_status, pformat(events))
+
 
 def setup_ec2(stackname, context_ec2):
     if not context_ec2:

--- a/src/buildercore/bootstrap.py
+++ b/src/buildercore/bootstrap.py
@@ -108,7 +108,7 @@ def _wait_until_in_progress(stackname):
         stack_status = core.describe_stack(stackname).stack_status
         LOG.info("Stack status: %s", stack_status)
         return stack_status in ['CREATE_IN_PROGRESS']
-    utils.call_while(partial(is_updating, stackname), timeout=1200, update_msg='Waiting for AWS to finish creating stack ...')
+    utils.call_while(partial(is_updating, stackname), timeout=3600, update_msg='Waiting for AWS to finish creating stack ...')
     final_stack = core.describe_stack(stackname)
     events = [(e.resource_status, e.resource_status_reason) for e in final_stack.describe_events()]
     ensure(final_stack.stack_status in ['CREATE_COMPLETE'], "Final stack status is not successful: %s.\nEvents: %s", final_stack.stack_status, pformat(events))

--- a/src/buildercore/bootstrap.py
+++ b/src/buildercore/bootstrap.py
@@ -485,7 +485,7 @@ def delete_stack(stackname):
                 if err.message.endswith('does not exist'):
                     return False
                 raise # not sure what happened, but we're not handling it here. die.
-        utils.call_while(partial(is_deleting, stackname), update_msg='Waiting for AWS to finish deleting stack ...')
+        utils.call_while(partial(is_deleting, stackname), timeout=3600, update_msg='Waiting for AWS to finish deleting stack ...')
         keypair.delete_keypair(stackname)
         delete_stack_file(stackname)
         delete_dns(stackname)

--- a/src/buildercore/cfngen.py
+++ b/src/buildercore/cfngen.py
@@ -166,6 +166,7 @@ def build_context_cloudfront(context, parameterize):
         context['cloudfront'] = {
             'subdomains': [parameterize(x) for x in context['project']['aws']['cloudfront']['subdomains']],
             'certificate_id': context['project']['aws']['cloudfront']['certificate_id'],
+            'cookies': context['project']['aws']['cloudfront']['cookies'],
         }
     else:
         context['cloudfront'] = False

--- a/src/buildercore/cfngen.py
+++ b/src/buildercore/cfngen.py
@@ -167,6 +167,7 @@ def build_context_cloudfront(context, parameterize):
             'subdomains': [parameterize(x) for x in context['project']['aws']['cloudfront']['subdomains']],
             'certificate_id': context['project']['aws']['cloudfront']['certificate_id'],
             'cookies': context['project']['aws']['cloudfront']['cookies'],
+            'compress': context['project']['aws']['cloudfront']['compress'],
         }
     else:
         context['cloudfront'] = False

--- a/src/buildercore/cfngen.py
+++ b/src/buildercore/cfngen.py
@@ -61,8 +61,8 @@ def build_context(pname, **more_context): # pylint: disable=too-many-locals
         'elb': False,
         'sns': [],
         'sqs': {},
-        'ext': None,
-        'cloudfront': None,
+        'ext': False,
+        'cloudfront': False,
     }
 
     context = copy.deepcopy(defaults)

--- a/src/buildercore/cfngen.py
+++ b/src/buildercore/cfngen.py
@@ -61,7 +61,8 @@ def build_context(pname, **more_context): # pylint: disable=too-many-locals
         'elb': False,
         'sns': [],
         'sqs': {},
-        'ext': None
+        'ext': None,
+        'cloudfront': None,
     }
 
     context = copy.deepcopy(defaults)
@@ -151,6 +152,11 @@ def build_context(pname, **more_context): # pylint: disable=too-many-locals
         configuration = context['project']['aws']['s3'][bucket_template_name]
         context['s3'][bucket_name] = default_bucket_configuration.copy()
         context['s3'][bucket_name].update(configuration if configuration else {})
+
+    if 'cloudfront' in context['project']['aws']:
+        context['cloudfront'] = {
+            'subdomain': _parameterize(context['project']['aws']['cloudfront']['subdomain'])
+        }
 
     return context
 

--- a/src/buildercore/cfngen.py
+++ b/src/buildercore/cfngen.py
@@ -168,6 +168,7 @@ def build_context_cloudfront(context, parameterize):
             'certificate_id': context['project']['aws']['cloudfront']['certificate_id'],
             'cookies': context['project']['aws']['cloudfront']['cookies'],
             'compress': context['project']['aws']['cloudfront']['compress'],
+            'headers': context['project']['aws']['cloudfront']['headers'],
         }
     else:
         context['cloudfront'] = False

--- a/src/buildercore/cfngen.py
+++ b/src/buildercore/cfngen.py
@@ -153,11 +153,14 @@ def build_context(pname, **more_context): # pylint: disable=too-many-locals
         context['s3'][bucket_name] = default_bucket_configuration.copy()
         context['s3'][bucket_name].update(configuration if configuration else {})
 
-    ensure('cloudfront' in context['project']['aws'], "Context for AWS is missing an explicit configuration for cloudfront: %s", context['project']['aws'])
-    if context['project']['aws']['cloudfront']:
+    # first check if it is defined at all in defaults
+    if 'cloudfront' in context['project']['aws']:
         context['cloudfront'] = {
-            'subdomains': [_parameterize(x) for x in context['project']['aws']['cloudfront']['subdomains']]
+            'subdomains': [_parameterize(x) for x in context['project']['aws']['cloudfront']['subdomains']],
+            'certificate': context['project']['aws']['cloudfront']['certificate'],
         }
+    else:
+        context['cloudfront'] = False
 
     return context
 

--- a/src/buildercore/cfngen.py
+++ b/src/buildercore/cfngen.py
@@ -153,7 +153,8 @@ def build_context(pname, **more_context): # pylint: disable=too-many-locals
         context['s3'][bucket_name] = default_bucket_configuration.copy()
         context['s3'][bucket_name].update(configuration if configuration else {})
 
-    if 'cloudfront' in context['project']['aws']:
+    ensure('cloudfront' in context['project']['aws'], "Context for AWS is missing an explicit configuration for cloudfront: %s", context['project']['aws'])
+    if context['project']['aws']['cloudfront']:
         context['cloudfront'] = {
             'subdomain': _parameterize(context['project']['aws']['cloudfront']['subdomain'])
         }

--- a/src/buildercore/cfngen.py
+++ b/src/buildercore/cfngen.py
@@ -156,7 +156,7 @@ def build_context(pname, **more_context): # pylint: disable=too-many-locals
     ensure('cloudfront' in context['project']['aws'], "Context for AWS is missing an explicit configuration for cloudfront: %s", context['project']['aws'])
     if context['project']['aws']['cloudfront']:
         context['cloudfront'] = {
-            'subdomain': _parameterize(context['project']['aws']['cloudfront']['subdomain'])
+            'subdomains': [_parameterize(x) for x in context['project']['aws']['cloudfront']['subdomains']]
         }
 
     return context

--- a/src/buildercore/project/files.py
+++ b/src/buildercore/project/files.py
@@ -75,7 +75,14 @@ def project_data(pname, project_file, snippets=0xDEADBEEF):
 
     # exceptions.
     # these values *shouldn't* be merged if they *don't* exist in the project
-    excluding = ['aws', 'vagrant', 'vagrant-alt', 'aws-alt', {'aws': ['rds', 'ext', 'elb']}]
+    aws_excluding = ['rds', 'ext', 'elb', 'cloudfront']
+    excluding = [
+        'aws',
+        'vagrant',
+        'vagrant-alt',
+        'aws-alt',
+        {'aws': aws_excluding},
+    ]
     project_data = copy.deepcopy(global_defaults)
     utils.deepmerge(project_data, project_list[pname], excluding)
 
@@ -95,7 +102,7 @@ def project_data(pname, project_file, snippets=0xDEADBEEF):
         # merge this over top of original aws defaults
         orig_defaults = copy.deepcopy(global_defaults['aws'])
 
-        utils.deepmerge(orig_defaults, project_aws, ['rds', 'ext', 'elb'])
+        utils.deepmerge(orig_defaults, project_aws, aws_excluding)
         project_data['aws-alt'][altname] = orig_defaults
 
     for altname, altdata in project_data.get('vagrant-alt', {}).items():

--- a/src/buildercore/trop.py
+++ b/src/buildercore/trop.py
@@ -506,6 +506,15 @@ def render_elb(context, template, ec2_instances):
 def render_cloudfront(context, template, origin_hostname):
     origin = CLOUDFRONT_TITLE + 'Origin'
     allowed_cnames = ["%s.%s" % (subdomain, context['domain']) for subdomain in context['cloudfront']['subdomains']]
+    if context['cloudfront']['cookies']:
+        cookies = cloudfront.Cookies(
+            Forward='whitelist',
+            WhitelistedNames=context['cloudfront']['cookies']
+        )
+    else:
+        cookies = cloudfront.Cookies(
+            Forward='none'
+        )
     props = {
         'Aliases': allowed_cnames,
         'DefaultCacheBehavior': cloudfront.DefaultCacheBehavior(
@@ -514,10 +523,7 @@ def render_cloudfront(context, template, origin_hostname):
             Compress=context['cloudfront']['compress'],
             TargetOriginId=origin,
             ForwardedValues=cloudfront.ForwardedValues(
-                Cookies=cloudfront.Cookies(
-                    Forward='whitelist',
-                    WhitelistedNames=context['cloudfront']['cookies']
-                ),
+                Cookies=cookies,
                 Headers=context['cloudfront']['headers'],
                 QueryString=True
             ),

--- a/src/buildercore/trop.py
+++ b/src/buildercore/trop.py
@@ -524,7 +524,11 @@ def render_cloudfront(context, template, origin_hostname):
                     OriginProtocolPolicy='https-only'
                 )
             )
-        ]
+        ],
+        'ViewerCertificate': cloudfront.ViewerCertificate(
+            AcmCertificateArn=context['cloudfront']['certificate'],
+            SslSupportMethod='sni-only'
+        )
     }
     template.add_resource(cloudfront.Distribution(
         CLOUDFRONT_TITLE,

--- a/src/buildercore/trop.py
+++ b/src/buildercore/trop.py
@@ -524,6 +524,7 @@ def render_cloudfront(context, template, origin_hostname):
             ViewerProtocolPolicy='redirect-to-https',
         ),
         'Enabled': True,
+        'HttpVersion': 'http2',
         'Origins': [
             cloudfront.Origin(
                 DomainName=origin_hostname,

--- a/src/buildercore/trop.py
+++ b/src/buildercore/trop.py
@@ -515,6 +515,10 @@ def render_cloudfront(context, template, origin_hostname):
             cloudfront.Origin(
                 DomainName=origin_hostname,
                 Id=origin
+                #CustomOriginConfig=CustomOrigin(
+                #    HTTPSPort=443,
+                #    OriginProtocolPolicy='https-only'
+                #)
             )
         ]
     }
@@ -553,8 +557,7 @@ def render(context):
                "If there is no load balancer, only a single EC2 instance can be assigned a DNS entry: %s" % context)
 
         if context['full_hostname']:
-            dns_record = template.add_resource(external_dns_ec2(context))
-            hostname = context['full_hostname']
+            template.add_resource(external_dns_ec2(context))
 
         # ec2 nodes in a cluster DONT get an internal hostname
         if context['int_full_hostname']:

--- a/src/buildercore/trop.py
+++ b/src/buildercore/trop.py
@@ -482,9 +482,10 @@ def render_elb(context, template, ec2_instances):
 
 def render_cloudfront(context, template, origin_hostname):
     origin = CLOUDFRONT_TITLE+'Origin'
+    allowed_cnames = "*.%s" % context['domain']
     cdn_hostname = "%s.%s" % (context['cloudfront']['subdomain'], context['domain'])
     props = {
-        'Aliases': [cdn_hostname],
+        'Aliases': [allowed_cnames],
         'DefaultCacheBehavior': cloudfront.DefaultCacheBehavior(
             TargetOriginId=origin,
             ForwardedValues=cloudfront.ForwardedValues(
@@ -534,8 +535,6 @@ def render(context):
         ensure(context['ec2']['cluster-size'] == 1,
                "If there is no load balancer, only a single EC2 instance can be assigned a DNS entry: %s" % context)
 
-        #from pprint import pprint
-        #pprint(context)
         if context['full_hostname']:
             dns_record = template.add_resource(external_dns_ec2(context))
             hostname = context['full_hostname']

--- a/src/buildercore/trop.py
+++ b/src/buildercore/trop.py
@@ -511,6 +511,7 @@ def render_cloudfront(context, template, origin_hostname):
         'DefaultCacheBehavior': cloudfront.DefaultCacheBehavior(
             AllowedMethods=['DELETE', 'GET', 'HEAD', 'OPTIONS', 'PATCH', 'POST', 'PUT'],
             CachedMethods=['GET', 'HEAD'],
+            Compress=context['cloudfront']['compress'],
             TargetOriginId=origin,
             ForwardedValues=cloudfront.ForwardedValues(
                 Cookies=cloudfront.Cookies(

--- a/src/buildercore/trop.py
+++ b/src/buildercore/trop.py
@@ -509,8 +509,14 @@ def render_cloudfront(context, template, origin_hostname):
     props = {
         'Aliases': allowed_cnames,
         'DefaultCacheBehavior': cloudfront.DefaultCacheBehavior(
+            AllowedMethods=['DELETE', 'GET', 'HEAD', 'OPTIONS', 'PATCH', 'POST', 'PUT'],
+            CachedMethods=['GET', 'HEAD'],
             TargetOriginId=origin,
             ForwardedValues=cloudfront.ForwardedValues(
+                Cookies=cloudfront.Cookies(
+                    Forward='whitelist',
+                    WhitelistedNames=context['cloudfront']['cookies']
+                ),
                 Headers=[],
                 QueryString=True
             ),

--- a/src/buildercore/trop.py
+++ b/src/buildercore/trop.py
@@ -514,11 +514,11 @@ def render_cloudfront(context, template, origin_hostname):
         'Origins': [
             cloudfront.Origin(
                 DomainName=origin_hostname,
-                Id=origin
-                #CustomOriginConfig=CustomOrigin(
-                #    HTTPSPort=443,
-                #    OriginProtocolPolicy='https-only'
-                #)
+                Id=origin,
+                CustomOriginConfig=cloudfront.CustomOrigin(
+                    HTTPSPort=443,
+                    OriginProtocolPolicy='https-only'
+                )
             )
         ]
     }

--- a/src/buildercore/trop.py
+++ b/src/buildercore/trop.py
@@ -503,7 +503,7 @@ def render_elb(context, template, ec2_instances):
     template.add_resource(dns(context))
 
 def render_cloudfront(context, template, origin_hostname):
-    origin = CLOUDFRONT_TITLE+'Origin'
+    origin = CLOUDFRONT_TITLE + 'Origin'
     allowed_cnames = ["%s.%s" % (subdomain, context['domain']) for subdomain in context['cloudfront']['subdomains']]
     props = {
         'Aliases': allowed_cnames,
@@ -526,7 +526,7 @@ def render_cloudfront(context, template, origin_hostname):
             )
         ],
         'ViewerCertificate': cloudfront.ViewerCertificate(
-            AcmCertificateArn=context['cloudfront']['certificate'],
+            IamCertificateId=context['cloudfront']['certificate_id'],
             SslSupportMethod='sni-only'
         )
     }

--- a/src/buildercore/trop.py
+++ b/src/buildercore/trop.py
@@ -35,6 +35,8 @@ R53_EXT_TITLE = "ExtDNS"
 R53_INT_TITLE = "IntDNS"
 R53_CDN_TITLE = "CloudFrontCDNDNS%s"
 CLOUDFRONT_TITLE = 'CloudFrontCDN'
+# from http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-route53-aliastarget.html
+CLOUDFRONT_HOSTED_ZONE_ID = 'Z2FDTNDATAQYW2'
 
 KEYPAIR = "KeyName"
 
@@ -314,8 +316,7 @@ def external_dns_cloudfront(context):
             Name=cdn_hostname,
             Type="A",
             AliasTarget=route53.AliasTarget(
-                # Magic value, put in a constant
-                "Z2FDTNDATAQYW2",
+                CLOUDFRONT_HOSTED_ZONE_ID,
                 GetAtt(CLOUDFRONT_TITLE, "DomainName")
             )
         ))

--- a/src/buildercore/trop.py
+++ b/src/buildercore/trop.py
@@ -511,6 +511,7 @@ def render_cloudfront(context, template, origin_hostname):
         'DefaultCacheBehavior': cloudfront.DefaultCacheBehavior(
             TargetOriginId=origin,
             ForwardedValues=cloudfront.ForwardedValues(
+                Headers=[],
                 QueryString=True
             ),
             ViewerProtocolPolicy='redirect-to-https',

--- a/src/buildercore/trop.py
+++ b/src/buildercore/trop.py
@@ -518,7 +518,7 @@ def render_cloudfront(context, template, origin_hostname):
                     Forward='whitelist',
                     WhitelistedNames=context['cloudfront']['cookies']
                 ),
-                Headers=[],
+                Headers=context['cloudfront']['headers'],
                 QueryString=True
             ),
             ViewerProtocolPolicy='redirect-to-https',

--- a/src/tests/fixtures/projects/dummy-project.yaml
+++ b/src/tests/fixtures/projects/dummy-project.yaml
@@ -68,7 +68,7 @@ defaults:
         sns: []
         sqs: []
         s3: []
-        cloudfront: None
+        cloudfront: null
     aws-alt:
         fresh:
             description: uses a plain Ubuntu basebox instead of an ami
@@ -195,7 +195,6 @@ project-with-cloudfront:
             - 80
         cloudfront:
             subdomain: "{instance}--cdn-of-www"
-            additional_subdomains: []
 
 
 project-with-cluster:

--- a/src/tests/fixtures/projects/dummy-project.yaml
+++ b/src/tests/fixtures/projects/dummy-project.yaml
@@ -71,6 +71,7 @@ defaults:
         cloudfront:
             # cloudfront defaults only used if a 'cloudfront' section present in project
             certificate_id: 'dummy...'
+            cookies: []
     aws-alt:
         fresh:
             description: uses a plain Ubuntu basebox instead of an ami
@@ -198,6 +199,8 @@ project-with-cloudfront:
         cloudfront:
             subdomains:
                 - "{instance}--cdn-of-www"
+            cookies:
+                - session_id
 
 
 project-with-cluster:

--- a/src/tests/fixtures/projects/dummy-project.yaml
+++ b/src/tests/fixtures/projects/dummy-project.yaml
@@ -70,7 +70,7 @@ defaults:
         s3: []
         cloudfront:
             # cloudfront defaults only used if an 'elb' section present in project
-            certificate: 'dummy...'
+            certificate_id: 'dummy...'
     vagrant:
         box: ubuntu/trusty64 # Ubuntu 14.04
         box-url: null # not needed for boxes hosted on Atlas 

--- a/src/tests/fixtures/projects/dummy-project.yaml
+++ b/src/tests/fixtures/projects/dummy-project.yaml
@@ -68,12 +68,9 @@ defaults:
         sns: []
         sqs: []
         s3: []
-        cloudfront: null
-    aws-alt:
-        fresh:
-            description: uses a plain Ubuntu basebox instead of an ami
-            ec2:
-                ami: ami-9eaa1cf6 # Ubuntu 14.04
+        cloudfront:
+            # cloudfront defaults only used if an 'elb' section present in project
+            certificate: 'dummy...'
     vagrant:
         box: ubuntu/trusty64 # Ubuntu 14.04
         box-url: null # not needed for boxes hosted on Atlas 

--- a/src/tests/fixtures/projects/dummy-project.yaml
+++ b/src/tests/fixtures/projects/dummy-project.yaml
@@ -71,6 +71,11 @@ defaults:
         cloudfront:
             # cloudfront defaults only used if an 'elb' section present in project
             certificate_id: 'dummy...'
+    aws-alt:
+        fresh:
+            description: uses a plain Ubuntu basebox instead of an ami
+            ec2:
+                ami: ami-9eaa1cf6 # Ubuntu 14.04
     vagrant:
         box: ubuntu/trusty64 # Ubuntu 14.04
         box-url: null # not needed for boxes hosted on Atlas 

--- a/src/tests/fixtures/projects/dummy-project.yaml
+++ b/src/tests/fixtures/projects/dummy-project.yaml
@@ -73,6 +73,7 @@ defaults:
             certificate_id: 'dummy...'
             cookies: []
             compress: True
+            headers: []
     aws-alt:
         fresh:
             description: uses a plain Ubuntu basebox instead of an ami
@@ -202,6 +203,8 @@ project-with-cloudfront:
                 - "{instance}--cdn-of-www"
             cookies:
                 - session_id
+            headers:
+                - Accept
 
 
 project-with-cluster:

--- a/src/tests/fixtures/projects/dummy-project.yaml
+++ b/src/tests/fixtures/projects/dummy-project.yaml
@@ -189,11 +189,13 @@ project-with-ext:
 
 project-with-cloudfront:
     repo: ssh://git@github.com/elifesciences/dummy3
+    subdomain: www
     aws:
         ports:
             - 80
         cloudfront:
-            subdomain: "{instance}--cdn"
+            subdomain: "{instance}--cdn-of-www"
+            additional_subdomains: []
 
 
 project-with-cluster:

--- a/src/tests/fixtures/projects/dummy-project.yaml
+++ b/src/tests/fixtures/projects/dummy-project.yaml
@@ -69,7 +69,7 @@ defaults:
         sqs: []
         s3: []
         cloudfront:
-            # cloudfront defaults only used if an 'elb' section present in project
+            # cloudfront defaults only used if a 'cloudfront' section present in project
             certificate_id: 'dummy...'
     aws-alt:
         fresh:

--- a/src/tests/fixtures/projects/dummy-project.yaml
+++ b/src/tests/fixtures/projects/dummy-project.yaml
@@ -194,7 +194,8 @@ project-with-cloudfront:
         ports:
             - 80
         cloudfront:
-            subdomain: "{instance}--cdn-of-www"
+            subdomains:
+                - "{instance}--cdn-of-www"
 
 
 project-with-cluster:

--- a/src/tests/fixtures/projects/dummy-project.yaml
+++ b/src/tests/fixtures/projects/dummy-project.yaml
@@ -68,6 +68,7 @@ defaults:
         sns: []
         sqs: []
         s3: []
+        cloudfront: None
     aws-alt:
         fresh:
             description: uses a plain Ubuntu basebox instead of an ami
@@ -185,6 +186,15 @@ project-with-ext:
             - 80
         ext: 
             size: 200
+
+project-with-cloudfront:
+    repo: ssh://git@github.com/elifesciences/dummy3
+    aws:
+        ports:
+            - 80
+        cloudfront:
+            subdomain: "{instance}--cdn"
+
 
 project-with-cluster:
     repo: ssh://git@github.com/elifesciences/dummy3

--- a/src/tests/fixtures/projects/dummy-project.yaml
+++ b/src/tests/fixtures/projects/dummy-project.yaml
@@ -72,6 +72,7 @@ defaults:
             # cloudfront defaults only used if a 'cloudfront' section present in project
             certificate_id: 'dummy...'
             cookies: []
+            compress: True
     aws-alt:
         fresh:
             description: uses a plain Ubuntu basebox instead of an ami

--- a/src/tests/fixtures/projects/dummy-project.yaml
+++ b/src/tests/fixtures/projects/dummy-project.yaml
@@ -206,6 +206,16 @@ project-with-cloudfront:
             headers:
                 - Accept
 
+project-with-cloudfront-minimal:
+    repo: ssh://git@github.com/elifesciences/dummy3
+    subdomain: www
+    aws:
+        ports:
+            - 80
+        cloudfront:
+            subdomains:
+                - "{instance}--cdn-of-www"
+
 
 project-with-cluster:
     repo: ssh://git@github.com/elifesciences/dummy3

--- a/src/tests/fixtures/projects/dummy-project2.yaml
+++ b/src/tests/fixtures/projects/dummy-project2.yaml
@@ -59,6 +59,7 @@ defaults:
         sns: []
         sqs: []
         s3: []
+        cloudfront: null
     aws-alt:
         fresh:
             description: uses a plain Ubuntu basebox instead of an ami

--- a/src/tests/test_buildercore_project.py
+++ b/src/tests/test_buildercore_project.py
@@ -23,7 +23,7 @@ class TestProject(base.BaseCase):
         "a map of organisations and their projects are returned"
         prj_loc_lst = self.parsed_config['project-locations']
         expected = {'dummy-project': [
-            'dummy1', 'dummy2', 'dummy3', 'just-some-sns', 'project-with-sqs', 'project-with-s3', 'project-with-ext', 'project-with-cloudfront', 'project-with-cluster',
+            'dummy1', 'dummy2', 'dummy3', 'just-some-sns', 'project-with-sqs', 'project-with-s3', 'project-with-ext', 'project-with-cloudfront', 'project-with-cloudfront-minimal', 'project-with-cluster',
         ]}
         #self.assertEqual(project.org_project_map(prj_loc_lst), expected)
         self.assertEqual(project.org_map(prj_loc_lst), expected)
@@ -32,7 +32,7 @@ class TestProject(base.BaseCase):
         "a simple list of projects are returned, ignoring which org they belong to"
         prj_loc_lst = self.parsed_config['project-locations']
         expected = [
-            'dummy1', 'dummy2', 'dummy3', 'just-some-sns', 'project-with-sqs', 'project-with-s3', 'project-with-ext', 'project-with-cloudfront', 'project-with-cluster',
+            'dummy1', 'dummy2', 'dummy3', 'just-some-sns', 'project-with-sqs', 'project-with-s3', 'project-with-ext', 'project-with-cloudfront', 'project-with-cloudfront-minimal', 'project-with-cluster',
         ]
         self.assertEqual(project.project_list(prj_loc_lst), expected)
 
@@ -204,7 +204,7 @@ class TestMultiProjects(base.BaseCase):
 
     def test_project_list_from_multiple_files(self):
         expected = [
-            'dummy1', 'dummy2', 'dummy3', 'just-some-sns', 'project-with-sqs', 'project-with-s3', 'project-with-ext', 'project-with-cloudfront', 'project-with-cluster',
+            'dummy1', 'dummy2', 'dummy3', 'just-some-sns', 'project-with-sqs', 'project-with-s3', 'project-with-ext', 'project-with-cloudfront', 'project-with-cloudfront-minimal', 'project-with-cluster',
 
             'yummy1'
         ]

--- a/src/tests/test_buildercore_project.py
+++ b/src/tests/test_buildercore_project.py
@@ -23,7 +23,7 @@ class TestProject(base.BaseCase):
         "a map of organisations and their projects are returned"
         prj_loc_lst = self.parsed_config['project-locations']
         expected = {'dummy-project': [
-            'dummy1', 'dummy2', 'dummy3', 'just-some-sns', 'project-with-sqs', 'project-with-s3', 'project-with-ext', 'project-with-cluster',
+            'dummy1', 'dummy2', 'dummy3', 'just-some-sns', 'project-with-sqs', 'project-with-s3', 'project-with-ext', 'project-with-cloudfront', 'project-with-cluster',
         ]}
         #self.assertEqual(project.org_project_map(prj_loc_lst), expected)
         self.assertEqual(project.org_map(prj_loc_lst), expected)
@@ -32,7 +32,7 @@ class TestProject(base.BaseCase):
         "a simple list of projects are returned, ignoring which org they belong to"
         prj_loc_lst = self.parsed_config['project-locations']
         expected = [
-            'dummy1', 'dummy2', 'dummy3', 'just-some-sns', 'project-with-sqs', 'project-with-s3', 'project-with-ext', 'project-with-cluster',
+            'dummy1', 'dummy2', 'dummy3', 'just-some-sns', 'project-with-sqs', 'project-with-s3', 'project-with-ext', 'project-with-cloudfront', 'project-with-cluster',
         ]
         self.assertEqual(project.project_list(prj_loc_lst), expected)
 
@@ -204,7 +204,7 @@ class TestMultiProjects(base.BaseCase):
 
     def test_project_list_from_multiple_files(self):
         expected = [
-            'dummy1', 'dummy2', 'dummy3', 'just-some-sns', 'project-with-sqs', 'project-with-s3', 'project-with-ext', 'project-with-cluster',
+            'dummy1', 'dummy2', 'dummy3', 'just-some-sns', 'project-with-sqs', 'project-with-s3', 'project-with-ext', 'project-with-cloudfront', 'project-with-cluster',
 
             'yummy1'
         ]

--- a/src/tests/test_buildercore_project_files.py
+++ b/src/tests/test_buildercore_project_files.py
@@ -18,3 +18,9 @@ class TestFiles(base.BaseCase):
         self.assertIn('repo', projects['dummy1'])
         self.assertIn('aws', projects['dummy1'])
         self.assertIn('vagrant', projects['dummy1'])
+
+    def test_dummy2_aws_alt_should_not_have_incomplete_defaults_for_cloudfront(self):
+        dummy2 = files.project_data('dummy2', self.project_file)
+        self.assertIn('rds', dummy2['aws-alt']['alt-config1'].keys())
+        self.assertNotIn('elb', dummy2['aws-alt']['alt-config1'].keys())
+        self.assertNotIn('cloudfront', dummy2['aws-alt']['alt-config1'].keys())

--- a/src/tests/test_buildercore_trop.py
+++ b/src/tests/test_buildercore_trop.py
@@ -264,6 +264,7 @@ class TestBuildercoreTrop(base.BaseCase):
         self.assertEquals(
             {
                 'certificate_id': 'dummy...',
+                'cookies': ['session_id'],
                 'subdomains': ['prod--cdn-of-www'],
             },
             context['cloudfront']
@@ -278,7 +279,13 @@ class TestBuildercoreTrop(base.BaseCase):
                     'DistributionConfig': {
                         'Aliases': ['prod--cdn-of-www.example.org'],
                         'DefaultCacheBehavior': {
+                            'AllowedMethods': ['DELETE', 'GET', 'HEAD', 'OPTIONS', 'PATCH', 'POST', 'PUT'],
+                            'CachedMethods': ['GET', 'HEAD'],
                             'ForwardedValues': {
+                                'Cookies': {
+                                    'Forward': 'whitelist',
+                                    'WhitelistedNames': ['session_id'],
+                                },
                                 'Headers': [],
                                 # yes this is a string containing the word 'true'...
                                 'QueryString': "true",

--- a/src/tests/test_buildercore_trop.py
+++ b/src/tests/test_buildercore_trop.py
@@ -263,7 +263,7 @@ class TestBuildercoreTrop(base.BaseCase):
         context = cfngen.build_context('project-with-cloudfront', **extra)
         self.assertEquals(
             {
-                'subdomain': 'prod--cdn-of-www'
+                'subdomains': ['prod--cdn-of-www']
             },
             context['cloudfront']
         )
@@ -275,7 +275,7 @@ class TestBuildercoreTrop(base.BaseCase):
                 'Type': 'AWS::CloudFront::Distribution',
                 'Properties': {
                     'DistributionConfig': {
-                        'Aliases': ['*.example.org'],
+                        'Aliases': ['prod--cdn-of-www.example.org'],
                         'DefaultCacheBehavior': {
                             'ForwardedValues': {
                                 # yes this is a string containing the word 'true'...
@@ -301,7 +301,7 @@ class TestBuildercoreTrop(base.BaseCase):
             },
             data['Resources']['CloudFrontCDN']
         )
-        self.assertTrue('CloudFrontCDNDNS' in data['Resources'].keys())
+        self.assertTrue('CloudFrontCDNDNS1' in data['Resources'].keys())
         self.assertEqual(
             {
                 'Type': 'AWS::Route53::RecordSet',
@@ -318,7 +318,7 @@ class TestBuildercoreTrop(base.BaseCase):
                     'Type': 'A',
                 },
             },
-            data['Resources']['CloudFrontCDNDNS']
+            data['Resources']['CloudFrontCDNDNS1']
         )
 
     def _parse_json(self, dump):

--- a/src/tests/test_buildercore_trop.py
+++ b/src/tests/test_buildercore_trop.py
@@ -1,6 +1,5 @@
 import yaml
 from os.path import join
-import json
 from . import base
 from buildercore import cfngen, trop, utils
 

--- a/src/tests/test_buildercore_trop.py
+++ b/src/tests/test_buildercore_trop.py
@@ -264,6 +264,7 @@ class TestBuildercoreTrop(base.BaseCase):
         self.assertEquals(
             {
                 'certificate_id': 'dummy...',
+                'compress': True,
                 'cookies': ['session_id'],
                 'subdomains': ['prod--cdn-of-www'],
             },
@@ -281,6 +282,7 @@ class TestBuildercoreTrop(base.BaseCase):
                         'DefaultCacheBehavior': {
                             'AllowedMethods': ['DELETE', 'GET', 'HEAD', 'OPTIONS', 'PATCH', 'POST', 'PUT'],
                             'CachedMethods': ['GET', 'HEAD'],
+                            'Compress': 'true',
                             'ForwardedValues': {
                                 'Cookies': {
                                     'Forward': 'whitelist',

--- a/src/tests/test_buildercore_trop.py
+++ b/src/tests/test_buildercore_trop.py
@@ -263,7 +263,7 @@ class TestBuildercoreTrop(base.BaseCase):
         context = cfngen.build_context('project-with-cloudfront', **extra)
         self.assertEquals(
             {
-                'subdomain': 'prod--cdn'
+                'subdomain': 'prod--cdn-of-www'
             },
             context['cloudfront']
         )
@@ -275,6 +275,7 @@ class TestBuildercoreTrop(base.BaseCase):
                 'Type': 'AWS::CloudFront::Distribution',
                 'Properties': {
                     'DistributionConfig': {
+                        'Aliases': ['prod--cdn-of-www.example.org'],
                         'DefaultCacheBehavior': {
                             'ForwardedValues': {
                                 # yes this is a string containing the word 'true'...
@@ -287,7 +288,7 @@ class TestBuildercoreTrop(base.BaseCase):
                         'Enabled': 'true',
                         'Origins': [
                             {
-                                'DomainName': '',
+                                'DomainName': 'prod--www.example.org',
                                 'Id': 'CloudFrontCDNOrigin',
                             }
                         ],

--- a/src/tests/test_buildercore_trop.py
+++ b/src/tests/test_buildercore_trop.py
@@ -338,6 +338,21 @@ class TestBuildercoreTrop(base.BaseCase):
             data['Resources']['CloudFrontCDNDNS1']
         )
 
+    def test_cdn_template_minimal(self):
+        extra = {
+            'stackname': 'project-with-cloudfront-minimal--prod',
+        }
+        context = cfngen.build_context('project-with-cloudfront-minimal', **extra)
+        cfn_template = trop.render(context)
+        data = self._parse_json(cfn_template)
+        self.assertTrue('CloudFrontCDN' in data['Resources'].keys())
+        self.assertEquals(
+            {
+                'Forward': 'none',
+            },
+            data['Resources']['CloudFrontCDN']['Properties']['DistributionConfig']['DefaultCacheBehavior']['ForwardedValues']['Cookies']
+        )
+
     def _parse_json(self, dump):
         """Parses dump into a dictionary, using strings rather than unicode strings
 

--- a/src/tests/test_buildercore_trop.py
+++ b/src/tests/test_buildercore_trop.py
@@ -263,7 +263,7 @@ class TestBuildercoreTrop(base.BaseCase):
         context = cfngen.build_context('project-with-cloudfront', **extra)
         self.assertEquals(
             {
-                'certificate': 'dummy...',
+                'certificate_id': 'dummy...',
                 'subdomains': ['prod--cdn-of-www'],
             },
             context['cloudfront']
@@ -298,7 +298,7 @@ class TestBuildercoreTrop(base.BaseCase):
                             }
                         ],
                         'ViewerCertificate': {
-                            'AcmCertificateArn': 'dummy...',
+                            'IamCertificateId': 'dummy...',
                             'SslSupportMethod': 'sni-only',
                         },
                     },

--- a/src/tests/test_buildercore_trop.py
+++ b/src/tests/test_buildercore_trop.py
@@ -279,6 +279,7 @@ class TestBuildercoreTrop(base.BaseCase):
                         'Aliases': ['prod--cdn-of-www.example.org'],
                         'DefaultCacheBehavior': {
                             'ForwardedValues': {
+                                'Headers': [],
                                 # yes this is a string containing the word 'true'...
                                 'QueryString': "true",
                             },

--- a/src/tests/test_buildercore_trop.py
+++ b/src/tests/test_buildercore_trop.py
@@ -266,6 +266,7 @@ class TestBuildercoreTrop(base.BaseCase):
                 'certificate_id': 'dummy...',
                 'compress': True,
                 'cookies': ['session_id'],
+                'headers': ['Accept'],
                 'subdomains': ['prod--cdn-of-www'],
             },
             context['cloudfront']
@@ -288,7 +289,7 @@ class TestBuildercoreTrop(base.BaseCase):
                                     'Forward': 'whitelist',
                                     'WhitelistedNames': ['session_id'],
                                 },
-                                'Headers': [],
+                                'Headers': ['Accept'],
                                 # yes this is a string containing the word 'true'...
                                 'QueryString': "true",
                             },

--- a/src/tests/test_buildercore_trop.py
+++ b/src/tests/test_buildercore_trop.py
@@ -275,7 +275,7 @@ class TestBuildercoreTrop(base.BaseCase):
                 'Type': 'AWS::CloudFront::Distribution',
                 'Properties': {
                     'DistributionConfig': {
-                        'Aliases': ['prod--cdn-of-www.example.org'],
+                        'Aliases': ['*.example.org'],
                         'DefaultCacheBehavior': {
                             'ForwardedValues': {
                                 # yes this is a string containing the word 'true'...
@@ -284,7 +284,7 @@ class TestBuildercoreTrop(base.BaseCase):
                             'TargetOriginId': 'CloudFrontCDNOrigin',
                             'ViewerProtocolPolicy': 'redirect-to-https',
                         },
-                                # yes this is a string containing the word 'true'...
+                        # yes this is a string containing the word 'true'...
                         'Enabled': 'true',
                         'Origins': [
                             {

--- a/src/tests/test_buildercore_trop.py
+++ b/src/tests/test_buildercore_trop.py
@@ -290,6 +290,10 @@ class TestBuildercoreTrop(base.BaseCase):
                             {
                                 'DomainName': 'prod--www.example.org',
                                 'Id': 'CloudFrontCDNOrigin',
+                                'CustomOriginConfig': {
+                                    'HTTPSPort': 443,
+                                    'OriginProtocolPolicy': 'https-only',
+                                },
                             }
                         ],
                     },

--- a/src/tests/test_buildercore_trop.py
+++ b/src/tests/test_buildercore_trop.py
@@ -297,6 +297,7 @@ class TestBuildercoreTrop(base.BaseCase):
                         },
                         # yes this is a string containing the word 'true'...
                         'Enabled': 'true',
+                        'HttpVersion': 'http2',
                         'Origins': [
                             {
                                 'DomainName': 'prod--www.example.org',

--- a/src/tests/test_buildercore_trop.py
+++ b/src/tests/test_buildercore_trop.py
@@ -263,7 +263,8 @@ class TestBuildercoreTrop(base.BaseCase):
         context = cfngen.build_context('project-with-cloudfront', **extra)
         self.assertEquals(
             {
-                'subdomains': ['prod--cdn-of-www']
+                'certificate': 'dummy...',
+                'subdomains': ['prod--cdn-of-www'],
             },
             context['cloudfront']
         )
@@ -296,6 +297,10 @@ class TestBuildercoreTrop(base.BaseCase):
                                 },
                             }
                         ],
+                        'ViewerCertificate': {
+                            'AcmCertificateArn': 'dummy...',
+                            'SslSupportMethod': 'sni-only',
+                        },
                     },
                 },
             },


### PR DESCRIPTION
Testing this successfully on a sample IIIF server:
https://shielded2--cdn-iiif.elifesciences.org/lax:00013/elife-00013-fig3-figsupp14-v1.tif/full/560,/0/default.jpg

Out of scope for this PR:
- `error-pages` support
- update of existing CDNs (they can only be added to existing stacks that don't have them, or created from scratch)