### PR TITLE
Configuring error codes in CloudFront

### DIFF
--- a/projects/elife.yaml
+++ b/projects/elife.yaml
@@ -214,8 +214,6 @@ journal:
                     pattern: "???.html"
                     codes:
                         - 404
-                        # not supported
-                        # - 410 
                         - 503
         continuumtest:
             cloudfront:
@@ -226,8 +224,6 @@ journal:
                     pattern: "???.html"
                     codes:
                         - 404
-                        # not supported
-                        # - 410 
                         - 503
         prod:
             description: prod environment for journal. ELB on top of multiple EC2 instances
@@ -247,8 +243,6 @@ journal:
                     pattern: "???.html"
                     codes:
                         - 404
-                        # not supported
-                        # - 410 
                         - 503
     vagrant:
         ram: 4096

--- a/projects/elife.yaml
+++ b/projects/elife.yaml
@@ -220,7 +220,7 @@ journal:
                 subdomains:
                     - "{instance}--cdn-journal"
                 errors: 
-                    domain: prod-elife-error-pages.s3-website-us-east-1.amazonaws.com
+                    domain: continuumtest-elife-error-pages.s3-website-us-east-1.amazonaws.com
                     pattern: "???.html"
                     codes:
                         - 404

--- a/projects/elife.yaml
+++ b/projects/elife.yaml
@@ -213,8 +213,7 @@ journal:
                     domain: end2end-elife-error-pages.s3-website-us-east-1.amazonaws.com
                     pattern: "???.html"
                     codes:
-                        - 404
-                        - 503
+                        502: "/5xx.html"
         continuumtest:
             cloudfront:
                 subdomains:
@@ -223,8 +222,7 @@ journal:
                     domain: continuumtest-elife-error-pages.s3-website-us-east-1.amazonaws.com
                     pattern: "???.html"
                     codes:
-                        - 404
-                        - 503
+                        502: "/5xx.html"
         prod:
             description: prod environment for journal. ELB on top of multiple EC2 instances
             ec2:
@@ -242,8 +240,7 @@ journal:
                     domain: prod-elife-error-pages.s3-website-us-east-1.amazonaws.com
                     pattern: "???.html"
                     codes:
-                        - 404
-                        - 503
+                        502: "/5xx.html"
     vagrant:
         ram: 4096
         ports:

--- a/projects/elife.yaml
+++ b/projects/elife.yaml
@@ -214,6 +214,7 @@ journal:
                     pattern: "???.html"
                     codes:
                         502: "/5xx.html"
+                    protocol: http
         continuumtest:
             cloudfront:
                 subdomains:
@@ -223,6 +224,7 @@ journal:
                     pattern: "???.html"
                     codes:
                         502: "/5xx.html"
+                    protocol: http
         prod:
             description: prod environment for journal. ELB on top of multiple EC2 instances
             ec2:
@@ -241,6 +243,7 @@ journal:
                     pattern: "???.html"
                     codes:
                         502: "/5xx.html"
+                    protocol: http
     vagrant:
         ram: 4096
         ports:

--- a/projects/elife.yaml
+++ b/projects/elife.yaml
@@ -237,7 +237,10 @@ journal:
             cloudfront:
                 subdomains:
                     - "{instance}--cdn-journal"
-                    - journal # in the future 'beta' or... ''?
+                    - beta
+                    #- elife
+                    #- prod
+                    #- ""
                 errors: 
                     domain: prod-elife-error-pages.s3-website-us-east-1.amazonaws.com
                     pattern: "???.html"

--- a/projects/elife.yaml
+++ b/projects/elife.yaml
@@ -90,6 +90,7 @@ defaults:
             cookies: []
             compress: True
             headers: []
+            errors: null
     aws-alt:
         fresh:
             description: uses a plain Ubuntu basebox instead of an ami

--- a/projects/elife.yaml
+++ b/projects/elife.yaml
@@ -91,6 +91,7 @@ defaults:
             compress: True
             headers: []
             errors: null
+            default-ttl: 300 # seconds
     aws-alt:
         fresh:
             description: uses a plain Ubuntu basebox instead of an ami

--- a/projects/elife.yaml
+++ b/projects/elife.yaml
@@ -205,15 +205,29 @@ journal:
                 protocol: 
                     - https
                     - http
-        end2end-test:
-            description: end2end environment for journal. ELB on top of multiple EC2 instances
-            ec2:
-                cluster-size: 2
-            elb:
-                stickiness: True
-                protocol: 
-                    - https
-                    - http
+            cloudfront:
+                subdomains:
+                    - "{instance}--cdn-journal"
+                errors: 
+                    domain: end2end-elife-error-pages.s3-website-us-east-1.amazonaws.com
+                    pattern: "???.html"
+                    codes:
+                        - 404
+                        # not supported
+                        # - 410 
+                        - 503
+        continuumtest:
+            cloudfront:
+                subdomains:
+                    - "{instance}--cdn-journal"
+                errors: 
+                    domain: prod-elife-error-pages.s3-website-us-east-1.amazonaws.com
+                    pattern: "???.html"
+                    codes:
+                        - 404
+                        # not supported
+                        # - 410 
+                        - 503
         prod:
             description: prod environment for journal. ELB on top of multiple EC2 instances
             ec2:
@@ -223,6 +237,18 @@ journal:
                 protocol:
                     - https
                     - http
+            cloudfront:
+                subdomains:
+                    - "{instance}--cdn-journal"
+                    - journal # in the future 'beta' or... ''?
+                errors: 
+                    domain: prod-elife-error-pages.s3-website-us-east-1.amazonaws.com
+                    pattern: "???.html"
+                    codes:
+                        - 404
+                        # not supported
+                        # - 410 
+                        - 503
     vagrant:
         ram: 4096
         ports:

--- a/src/buildercore/bootstrap.py
+++ b/src/buildercore/bootstrap.py
@@ -346,7 +346,12 @@ def update_template(stackname, template):
     pdata = project_data_for_stackname(stackname)
     if pdata['aws']['ec2']:
         parameters.append(('KeyName', stackname))
-    conn.update_stack(stackname, json.dumps(template), parameters=parameters)
+    try:
+        conn.update_stack(stackname, json.dumps(template), parameters=parameters)
+    except BotoServerError as ex:
+        if ex.message == 'No updates are to be performed.':
+            return
+        raise
 
     def stack_is_updating():
         return not core.stack_is(stackname, ['UPDATE_COMPLETE'], terminal_states=['UPDATE_ROLLBACK_COMPLETE'])

--- a/src/buildercore/bootstrap.py
+++ b/src/buildercore/bootstrap.py
@@ -116,7 +116,7 @@ def _wait_until_in_progress(stackname):
         return stack_status in ['CREATE_IN_PROGRESS']
     utils.call_while(
         partial(is_updating, stackname),
-        timeout=3600,
+        timeout=7200,
         update_msg='Waiting for AWS to finish creating stack ...',
         exception_class=StackTakingALongTimeToComplete
     )
@@ -350,7 +350,7 @@ def update_template(stackname, template):
 
     def stack_is_updating():
         return not core.stack_is(stackname, ['UPDATE_COMPLETE'], terminal_states=['UPDATE_ROLLBACK_COMPLETE'])
-    call_while(stack_is_updating, interval=2, update_msg="waiting for template of %s to be updated" % stackname, done_msg="template of %s is in state UPDATE_COMPLETE" % stackname)
+    call_while(stack_is_updating, interval=2, timeout=7200, update_msg="waiting for template of %s to be updated" % stackname, done_msg="template of %s is in state UPDATE_COMPLETE" % stackname)
 
 @core.requires_active_stack
 def template_info(stackname):

--- a/src/buildercore/cfngen.py
+++ b/src/buildercore/cfngen.py
@@ -169,6 +169,8 @@ def build_context_cloudfront(context, parameterize):
             'cookies': context['project']['aws']['cloudfront']['cookies'],
             'compress': context['project']['aws']['cloudfront']['compress'],
             'headers': context['project']['aws']['cloudfront']['headers'],
+            # TODO: parameterize 'template_url'
+            'errors': context['project']['aws']['cloudfront']['errors'],
         }
     else:
         context['cloudfront'] = False

--- a/src/buildercore/cfngen.py
+++ b/src/buildercore/cfngen.py
@@ -168,6 +168,7 @@ def build_context_cloudfront(context, parameterize):
                 'domain': parameterize(context['project']['aws']['cloudfront']['errors']['domain']),
                 'pattern': context['project']['aws']['cloudfront']['errors']['pattern'],
                 'codes': context['project']['aws']['cloudfront']['errors']['codes'],
+                'protocol': context['project']['aws']['cloudfront']['errors']['protocol'],
             }
         else:
             errors = None

--- a/src/buildercore/cfngen.py
+++ b/src/buildercore/cfngen.py
@@ -163,18 +163,22 @@ def build_context_elb(context):
 
 def build_context_cloudfront(context, parameterize):
     if 'cloudfront' in context['project']['aws']:
+        if context['project']['aws']['cloudfront']['errors']:
+            errors = {
+                # TODO: parameterize 'domain'
+                'domain': context['project']['aws']['cloudfront']['errors']['domain'],
+                'pattern': context['project']['aws']['cloudfront']['errors']['pattern'],
+                'codes': context['project']['aws']['cloudfront']['errors']['codes'],
+            }
+        else:
+            errors = None
         context['cloudfront'] = {
             'subdomains': [parameterize(x) for x in context['project']['aws']['cloudfront']['subdomains']],
             'certificate_id': context['project']['aws']['cloudfront']['certificate_id'],
             'cookies': context['project']['aws']['cloudfront']['cookies'],
             'compress': context['project']['aws']['cloudfront']['compress'],
             'headers': context['project']['aws']['cloudfront']['headers'],
-            'errors': {
-                # TODO: parameterize 'domain'
-                'domain': context['project']['aws']['cloudfront']['errors']['domain'],
-                'pattern': context['project']['aws']['cloudfront']['errors']['pattern'],
-                'codes': context['project']['aws']['cloudfront']['errors']['codes'],
-            }
+            'errors': errors,
         }
     else:
         context['cloudfront'] = False

--- a/src/buildercore/cfngen.py
+++ b/src/buildercore/cfngen.py
@@ -178,6 +178,7 @@ def build_context_cloudfront(context, parameterize):
             'cookies': context['project']['aws']['cloudfront']['cookies'],
             'compress': context['project']['aws']['cloudfront']['compress'],
             'headers': context['project']['aws']['cloudfront']['headers'],
+            'default-ttl': context['project']['aws']['cloudfront']['default-ttl'],
             'errors': errors,
         }
     else:

--- a/src/buildercore/cfngen.py
+++ b/src/buildercore/cfngen.py
@@ -169,7 +169,7 @@ def build_context_cloudfront(context, parameterize):
             'cookies': context['project']['aws']['cloudfront']['cookies'],
             'compress': context['project']['aws']['cloudfront']['compress'],
             'headers': context['project']['aws']['cloudfront']['headers'],
-            # TODO: parameterize 'template_url'
+            # TODO: parameterize 'domain'
             'errors': context['project']['aws']['cloudfront']['errors'],
         }
     else:

--- a/src/buildercore/cfngen.py
+++ b/src/buildercore/cfngen.py
@@ -165,8 +165,7 @@ def build_context_cloudfront(context, parameterize):
     if 'cloudfront' in context['project']['aws']:
         if context['project']['aws']['cloudfront']['errors']:
             errors = {
-                # TODO: parameterize 'domain'
-                'domain': context['project']['aws']['cloudfront']['errors']['domain'],
+                'domain': parameterize(context['project']['aws']['cloudfront']['errors']['domain']),
                 'pattern': context['project']['aws']['cloudfront']['errors']['pattern'],
                 'codes': context['project']['aws']['cloudfront']['errors']['codes'],
             }

--- a/src/buildercore/cfngen.py
+++ b/src/buildercore/cfngen.py
@@ -169,8 +169,12 @@ def build_context_cloudfront(context, parameterize):
             'cookies': context['project']['aws']['cloudfront']['cookies'],
             'compress': context['project']['aws']['cloudfront']['compress'],
             'headers': context['project']['aws']['cloudfront']['headers'],
-            # TODO: parameterize 'domain'
-            'errors': context['project']['aws']['cloudfront']['errors'],
+            'errors': {
+                # TODO: parameterize 'domain'
+                'domain': context['project']['aws']['cloudfront']['errors']['domain'],
+                'pattern': context['project']['aws']['cloudfront']['errors']['pattern'],
+                'codes': context['project']['aws']['cloudfront']['errors']['codes'],
+            }
         }
     else:
         context['cloudfront'] = False

--- a/src/buildercore/cfngen.py
+++ b/src/buildercore/cfngen.py
@@ -306,15 +306,19 @@ def template_delta(pname, **more_context):
 
     def _title_is_updatable(title):
         return len([p for p in updatable_title_prefixes if title.startswith(p)]) > 0
+
+    def _title_has_been_updated(title, section):
+        return template[section][title] != old_template[section][title]
+
     resources = {
         title: r for (title, r) in template['Resources'].iteritems()
         if (title not in old_template['Resources'] and 'EC2Instance' not in title)
-        or _title_is_updatable(title)
+        or (_title_is_updatable(title) and _title_has_been_updated(title, 'Resources'))
     }
     outputs = {
         title: o for (title, o) in template['Outputs'].iteritems()
         if (title not in old_template['Outputs'] and not _related_to_ec2(o))
-        or _title_is_updatable(title)
+        or (_title_is_updatable(title) and _title_has_been_updated(title, 'Outputs'))
     }
 
     return {

--- a/src/buildercore/trop.py
+++ b/src/buildercore/trop.py
@@ -572,7 +572,9 @@ def render_cloudfront(context, template, origin_hostname):
             cloudfront.CustomErrorResponse(
                 ErrorCode=c,
                 ResponseCode=c,
-                ResponsePagePath='%s.html' % c if c in context['cloudfront']['errors']['codes'] else "%sxx.html" % (c / 100)
+                ResponsePagePath='/%s.html' % c \
+                        if c in context['cloudfront']['errors']['codes'] 
+                        else "/%sxx.html" % (c / 100)
             ) for c in all_codes
         ]
     template.add_resource(cloudfront.Distribution(

--- a/src/buildercore/trop.py
+++ b/src/buildercore/trop.py
@@ -572,9 +572,8 @@ def render_cloudfront(context, template, origin_hostname):
             cloudfront.CustomErrorResponse(
                 ErrorCode=c,
                 ResponseCode=c,
-                ResponsePagePath='/%s.html' % c \
-                        if c in context['cloudfront']['errors']['codes'] 
-                        else "/%sxx.html" % (c / 100)
+                ResponsePagePath='/%s.html' % c
+                if c in context['cloudfront']['errors']['codes'] else "/%sxx.html" % (c / 100)
             ) for c in all_codes
         ]
     template.add_resource(cloudfront.Distribution(

--- a/src/buildercore/trop.py
+++ b/src/buildercore/trop.py
@@ -37,6 +37,7 @@ R53_CDN_TITLE = "CloudFrontCDNDNS%s"
 CLOUDFRONT_TITLE = 'CloudFrontCDN'
 # from http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-route53-aliastarget.html
 CLOUDFRONT_HOSTED_ZONE_ID = 'Z2FDTNDATAQYW2'
+CLOUDFRONT_ERROR_ORIGIN_ID = 'ErrorsOrigin'
 
 KEYPAIR = "KeyName"
 
@@ -550,7 +551,7 @@ def render_cloudfront(context, template, origin_hostname):
         props['Origins'].append(cloudfront.Origin(
             DomainName=context['cloudfront']['errors']['domain'],
             # TODO: constant
-            Id='errors',
+            Id=CLOUDFRONT_ERROR_ORIGIN_ID,
             # no advantage in using cloudfront.S3Origin for public buckets
             CustomOriginConfig=cloudfront.CustomOrigin(
                 HTTPSPort=443,
@@ -559,7 +560,7 @@ def render_cloudfront(context, template, origin_hostname):
         ))
         props['CacheBehaviors'] = [
             cloudfront.CacheBehavior(
-                TargetOriginId='errors',
+                TargetOriginId=CLOUDFRONT_ERROR_ORIGIN_ID,
                 ForwardedValues=cloudfront.ForwardedValues(
                     QueryString=False
                 ),

--- a/src/buildercore/trop.py
+++ b/src/buildercore/trop.py
@@ -567,6 +567,14 @@ def render_cloudfront(context, template, origin_hostname):
                 ViewerProtocolPolicy='allow-all',
             ),
         ]
+        all_codes = [400, 403, 404, 405, 414, 416, 500, 501, 502, 503, 504]
+        props['CustomErrorResponses'] = [
+            cloudfront.CustomErrorResponse(
+                ErrorCode=c,
+                ResponseCode=c,
+                ResponsePagePath='%s.html' % c if c in context['cloudfront']['errors']['codes'] else "%sxx.html" % (c / 100)
+            ) for c in all_codes
+        ]
     template.add_resource(cloudfront.Distribution(
         CLOUDFRONT_TITLE,
         DistributionConfig=cloudfront.DistributionConfig(**props)

--- a/src/buildercore/trop.py
+++ b/src/buildercore/trop.py
@@ -555,7 +555,7 @@ def render_cloudfront(context, template, origin_hostname):
             # no advantage in using cloudfront.S3Origin for public buckets
             CustomOriginConfig=cloudfront.CustomOrigin(
                 HTTPSPort=443,
-                OriginProtocolPolicy='https-only'
+                OriginProtocolPolicy='https-only' if context['cloudfront']['errors']['protocol'] == 'https' else 'http-only'
             )
         ))
         props['CacheBehaviors'] = [

--- a/src/buildercore/trop.py
+++ b/src/buildercore/trop.py
@@ -563,7 +563,7 @@ def render_cloudfront(context, template, origin_hostname):
                 ForwardedValues=cloudfront.ForwardedValues(
                     QueryString=False
                 ),
-                PathPattern='/errors/*',
+                PathPattern=context['cloudfront']['errors']['pattern'],
                 ViewerProtocolPolicy='allow-all',
             ),
         ]

--- a/src/buildercore/trop.py
+++ b/src/buildercore/trop.py
@@ -546,6 +546,27 @@ def render_cloudfront(context, template, origin_hostname):
             SslSupportMethod='sni-only'
         )
     }
+    if context['cloudfront']['errors']:
+        props['Origins'].append(cloudfront.Origin(
+            DomainName=context['cloudfront']['errors']['domain'],
+            # TODO: constant
+            Id='errors',
+            # no advantage in using cloudfront.S3Origin for public buckets
+            CustomOriginConfig=cloudfront.CustomOrigin(
+                HTTPSPort=443,
+                OriginProtocolPolicy='https-only'
+            )
+        ))
+        props['CacheBehaviors'] = [
+            cloudfront.CacheBehavior(
+                TargetOriginId='errors',
+                ForwardedValues=cloudfront.ForwardedValues(
+                    QueryString=False
+                ),
+                PathPattern='/errors/*',
+                ViewerProtocolPolicy='allow-all',
+            ),
+        ]
     template.add_resource(cloudfront.Distribution(
         CLOUDFRONT_TITLE,
         DistributionConfig=cloudfront.DistributionConfig(**props)

--- a/src/buildercore/trop.py
+++ b/src/buildercore/trop.py
@@ -568,7 +568,6 @@ def render_cloudfront(context, template, origin_hostname):
                 ViewerProtocolPolicy='allow-all',
             ),
         ]
-        all_codes = [400, 403, 404, 405, 414, 416, 500, 501, 502, 503, 504]
         props['CustomErrorResponses'] = [
             cloudfront.CustomErrorResponse(
                 ErrorCode=code,

--- a/src/buildercore/trop.py
+++ b/src/buildercore/trop.py
@@ -571,11 +571,10 @@ def render_cloudfront(context, template, origin_hostname):
         all_codes = [400, 403, 404, 405, 414, 416, 500, 501, 502, 503, 504]
         props['CustomErrorResponses'] = [
             cloudfront.CustomErrorResponse(
-                ErrorCode=c,
-                ResponseCode=c,
-                ResponsePagePath='/%s.html' % c
-                if c in context['cloudfront']['errors']['codes'] else "/%sxx.html" % (c / 100)
-            ) for c in all_codes
+                ErrorCode=code,
+                ResponseCode=code,
+                ResponsePagePath=page
+            ) for code, page in context['cloudfront']['errors']['codes'].iteritems()
         ]
     template.add_resource(cloudfront.Distribution(
         CLOUDFRONT_TITLE,

--- a/src/buildercore/trop.py
+++ b/src/buildercore/trop.py
@@ -522,6 +522,7 @@ def render_cloudfront(context, template, origin_hostname):
             AllowedMethods=['DELETE', 'GET', 'HEAD', 'OPTIONS', 'PATCH', 'POST', 'PUT'],
             CachedMethods=['GET', 'HEAD'],
             Compress=context['cloudfront']['compress'],
+            DefaultTTL=context['cloudfront']['default-ttl'],
             TargetOriginId=origin,
             ForwardedValues=cloudfront.ForwardedValues(
                 Cookies=cookies,
@@ -561,6 +562,7 @@ def render_cloudfront(context, template, origin_hostname):
         props['CacheBehaviors'] = [
             cloudfront.CacheBehavior(
                 TargetOriginId=CLOUDFRONT_ERROR_ORIGIN_ID,
+                DefaultTTL=context['cloudfront']['default-ttl'],
                 ForwardedValues=cloudfront.ForwardedValues(
                     QueryString=False
                 ),

--- a/src/cfn.py
+++ b/src/cfn.py
@@ -53,6 +53,7 @@ def update(stackname, *service_list):
     return bootstrap.update_stack(stackname, service_list)
 
 @task
+@timeit
 def update_template(stackname):
     """Limited update of the Cloudformation template.
 

--- a/src/tests/fixtures/projects/dummy-project.yaml
+++ b/src/tests/fixtures/projects/dummy-project.yaml
@@ -231,6 +231,7 @@ project-with-cloudfront-error-pages:
                 pattern: "???.html"
                 codes:
                     502: "/5xx.html"
+                protocol: http
 
 project-with-cluster:
     repo: ssh://git@github.com/elifesciences/dummy3

--- a/src/tests/fixtures/projects/dummy-project.yaml
+++ b/src/tests/fixtures/projects/dummy-project.yaml
@@ -230,7 +230,7 @@ project-with-cloudfront-error-pages:
                 domain: example-errors.com
                 pattern: "???.html"
                 codes:
-                    - 404
+                    502: "/5xx.html"
 
 project-with-cluster:
     repo: ssh://git@github.com/elifesciences/dummy3

--- a/src/tests/fixtures/projects/dummy-project.yaml
+++ b/src/tests/fixtures/projects/dummy-project.yaml
@@ -74,6 +74,7 @@ defaults:
             cookies: []
             compress: True
             headers: []
+            errors: null
     aws-alt:
         fresh:
             description: uses a plain Ubuntu basebox instead of an ami
@@ -216,6 +217,17 @@ project-with-cloudfront-minimal:
             subdomains:
                 - "{instance}--cdn-of-www"
 
+project-with-cloudfront-error-pages:
+    repo: ssh://git@github.com/elifesciences/dummy3
+    subdomain: www
+    aws:
+        ports:
+            - 80
+        cloudfront:
+            subdomains:
+                - "{instance}--cdn-of-www"
+            errors: 
+                domain: example-errors.com
 
 project-with-cluster:
     repo: ssh://git@github.com/elifesciences/dummy3

--- a/src/tests/fixtures/projects/dummy-project.yaml
+++ b/src/tests/fixtures/projects/dummy-project.yaml
@@ -229,6 +229,8 @@ project-with-cloudfront-error-pages:
             errors: 
                 domain: example-errors.com
                 pattern: "???.html"
+                codes:
+                    - 404
 
 project-with-cluster:
     repo: ssh://git@github.com/elifesciences/dummy3

--- a/src/tests/fixtures/projects/dummy-project.yaml
+++ b/src/tests/fixtures/projects/dummy-project.yaml
@@ -75,6 +75,7 @@ defaults:
             compress: True
             headers: []
             errors: null
+            default-ttl: 300 # seconds
     aws-alt:
         fresh:
             description: uses a plain Ubuntu basebox instead of an ami
@@ -202,10 +203,12 @@ project-with-cloudfront:
         cloudfront:
             subdomains:
                 - "{instance}--cdn-of-www"
+                #- ""
             cookies:
                 - session_id
             headers:
                 - Accept
+            default-ttl: 5
 
 project-with-cloudfront-minimal:
     repo: ssh://git@github.com/elifesciences/dummy3

--- a/src/tests/fixtures/projects/dummy-project.yaml
+++ b/src/tests/fixtures/projects/dummy-project.yaml
@@ -227,7 +227,7 @@ project-with-cloudfront-error-pages:
             subdomains:
                 - "{instance}--cdn-of-www"
             errors: 
-                domain: example-errors.com
+                domain: "{instance}--example-errors.com"
                 pattern: "???.html"
                 codes:
                     502: "/5xx.html"

--- a/src/tests/fixtures/projects/dummy-project.yaml
+++ b/src/tests/fixtures/projects/dummy-project.yaml
@@ -203,7 +203,7 @@ project-with-cloudfront:
         cloudfront:
             subdomains:
                 - "{instance}--cdn-of-www"
-                #- ""
+                - ""
             cookies:
                 - session_id
             headers:

--- a/src/tests/fixtures/projects/dummy-project.yaml
+++ b/src/tests/fixtures/projects/dummy-project.yaml
@@ -228,6 +228,7 @@ project-with-cloudfront-error-pages:
                 - "{instance}--cdn-of-www"
             errors: 
                 domain: example-errors.com
+                pattern: "???.html"
 
 project-with-cluster:
     repo: ssh://git@github.com/elifesciences/dummy3

--- a/src/tests/test_buildercore_cfngen.py
+++ b/src/tests/test_buildercore_cfngen.py
@@ -57,6 +57,7 @@ class TestBuildercoreCfngen(base.BaseCase):
                 "certificate_id": "AAAA...",
                 "headers": [],
                 "errors": None,
+                "default-ttl": 300,
             }
             mock_build_context.return_value = context
             delta = cfngen.template_delta('dummy1', stackname='dummy1--test')
@@ -91,7 +92,7 @@ class TestBuildercoreCfngen(base.BaseCase):
             mock_build_context.return_value = context
             delta = cfngen.template_delta('project-with-cloudfront-minimal', stackname='project-with-cloudfront-minimal--test')
             self.assertEqual(delta['Resources'].keys(), ['CloudFrontCDN', 'CloudFrontCDNDNS1'])
-            self.assertEqual(delta['Resources']['CloudFrontCDNDNS1']['Properties']['Name'], 'custom-subdomain.example.org')
+            self.assertEqual(delta['Resources']['CloudFrontCDNDNS1']['Properties']['Name'], 'custom-subdomain.example.org.')
             self.assertEqual(delta['Outputs'].keys(), [])
 
     def _base_context(self, project_name='dummy1'):

--- a/src/tests/test_buildercore_cfngen.py
+++ b/src/tests/test_buildercore_cfngen.py
@@ -63,6 +63,14 @@ class TestBuildercoreCfngen(base.BaseCase):
             self.assertEqual(delta['Resources'].keys(), ['CloudFrontCDN', 'CloudFrontCDNDNS1', 'ExtDNS'])
             self.assertEqual(delta['Outputs'].keys(), ['DomainName'])
 
+    def test_template_delta_does_not_include_cloudfront_if_there_are_no_modifications(self):
+        context = self._base_context('project-with-cloudfront-minimal')
+        with patch('buildercore.cfngen.build_context') as mock_build_context:
+            mock_build_context.return_value = context
+            delta = cfngen.template_delta('project-with-cloudfront-minimal', stackname='project-with-cloudfront-minimal--test')
+            self.assertEqual(delta['Resources'].keys(), [])
+            self.assertEqual(delta['Outputs'].keys(), [])
+
     def test_template_delta_never_includes_ec2(self):
         "we do not want to mess with running VMs"
         context = self._base_context()

--- a/src/tests/test_buildercore_cfngen.py
+++ b/src/tests/test_buildercore_cfngen.py
@@ -55,7 +55,8 @@ class TestBuildercoreCfngen(base.BaseCase):
                 "compress": True,
                 "cookies": [],
                 "certificate_id": "AAAA...",
-                "headers": []
+                "headers": [],
+                "errors": None,
             }
             mock_build_context.return_value = context
             delta = cfngen.template_delta('dummy1', stackname='dummy1--test')

--- a/src/tests/test_buildercore_project.py
+++ b/src/tests/test_buildercore_project.py
@@ -23,7 +23,7 @@ class TestProject(base.BaseCase):
         "a map of organisations and their projects are returned"
         prj_loc_lst = self.parsed_config['project-locations']
         expected = {'dummy-project': [
-            'dummy1', 'dummy2', 'dummy3', 'just-some-sns', 'project-with-sqs', 'project-with-s3', 'project-with-ext', 'project-with-cloudfront', 'project-with-cloudfront-minimal', 'project-with-cluster',
+            'dummy1', 'dummy2', 'dummy3', 'just-some-sns', 'project-with-sqs', 'project-with-s3', 'project-with-ext', 'project-with-cloudfront', 'project-with-cloudfront-minimal', 'project-with-cloudfront-error-pages', 'project-with-cluster',
         ]}
         #self.assertEqual(project.org_project_map(prj_loc_lst), expected)
         self.assertEqual(project.org_map(prj_loc_lst), expected)
@@ -32,7 +32,7 @@ class TestProject(base.BaseCase):
         "a simple list of projects are returned, ignoring which org they belong to"
         prj_loc_lst = self.parsed_config['project-locations']
         expected = [
-            'dummy1', 'dummy2', 'dummy3', 'just-some-sns', 'project-with-sqs', 'project-with-s3', 'project-with-ext', 'project-with-cloudfront', 'project-with-cloudfront-minimal', 'project-with-cluster',
+            'dummy1', 'dummy2', 'dummy3', 'just-some-sns', 'project-with-sqs', 'project-with-s3', 'project-with-ext', 'project-with-cloudfront', 'project-with-cloudfront-minimal', 'project-with-cloudfront-error-pages', 'project-with-cluster',
         ]
         self.assertEqual(project.project_list(prj_loc_lst), expected)
 
@@ -204,7 +204,7 @@ class TestMultiProjects(base.BaseCase):
 
     def test_project_list_from_multiple_files(self):
         expected = [
-            'dummy1', 'dummy2', 'dummy3', 'just-some-sns', 'project-with-sqs', 'project-with-s3', 'project-with-ext', 'project-with-cloudfront', 'project-with-cloudfront-minimal', 'project-with-cluster',
+            'dummy1', 'dummy2', 'dummy3', 'just-some-sns', 'project-with-sqs', 'project-with-s3', 'project-with-ext', 'project-with-cloudfront', 'project-with-cloudfront-minimal', 'project-with-cloudfront-error-pages', 'project-with-cluster',
 
             'yummy1'
         ]

--- a/src/tests/test_buildercore_trop.py
+++ b/src/tests/test_buildercore_trop.py
@@ -391,7 +391,7 @@ class TestBuildercoreTrop(base.BaseCase):
             {
                 'ErrorCode': 400,
                 'ResponseCode': 400,
-                'ResponsePagePath': '4xx.html'
+                'ResponsePagePath': '/4xx.html'
             },
             actual_custom_error_responses
         )
@@ -399,7 +399,7 @@ class TestBuildercoreTrop(base.BaseCase):
             {
                 'ErrorCode': 404,
                 'ResponseCode': 404,
-                'ResponsePagePath': '404.html'
+                'ResponsePagePath': '/404.html'
             },
             actual_custom_error_responses
         )

--- a/src/tests/test_buildercore_trop.py
+++ b/src/tests/test_buildercore_trop.py
@@ -369,7 +369,7 @@ class TestBuildercoreTrop(base.BaseCase):
                     'OriginProtocolPolicy': 'https-only',
                 },
                 'DomainName': 'example-errors.com',
-                'Id': 'errors',
+                'Id': 'ErrorsOrigin',
             },
             data['Resources']['CloudFrontCDN']['Properties']['DistributionConfig']['Origins'][1]
         )
@@ -380,7 +380,7 @@ class TestBuildercoreTrop(base.BaseCase):
                     'QueryString': 'false',
                 },
                 'PathPattern': '???.html',
-                'TargetOriginId': 'errors',
+                'TargetOriginId': 'ErrorsOrigin',
                 'ViewerProtocolPolicy': 'allow-all',
             }],
             data['Resources']['CloudFrontCDN']['Properties']['DistributionConfig']['CacheBehaviors']

--- a/src/tests/test_buildercore_trop.py
+++ b/src/tests/test_buildercore_trop.py
@@ -378,7 +378,7 @@ class TestBuildercoreTrop(base.BaseCase):
                     # yes this is a string containing the word 'false'...
                     'QueryString': 'false',
                 },
-                'PathPattern': '/errors/*',
+                'PathPattern': '???.html',
                 'TargetOriginId': 'errors',
                 'ViewerProtocolPolicy': 'allow-all',
             }],

--- a/src/tests/test_buildercore_trop.py
+++ b/src/tests/test_buildercore_trop.py
@@ -366,7 +366,7 @@ class TestBuildercoreTrop(base.BaseCase):
             {
                 'CustomOriginConfig': {
                     'HTTPSPort': 443,
-                    'OriginProtocolPolicy': 'https-only',
+                    'OriginProtocolPolicy': 'http-only',
                 },
                 'DomainName': 'prod--example-errors.com',
                 'Id': 'ErrorsOrigin',

--- a/src/tests/test_buildercore_trop.py
+++ b/src/tests/test_buildercore_trop.py
@@ -384,6 +384,24 @@ class TestBuildercoreTrop(base.BaseCase):
             }],
             data['Resources']['CloudFrontCDN']['Properties']['DistributionConfig']['CacheBehaviors']
         )
+        actual_custom_error_responses = data['Resources']['CloudFrontCDN']['Properties']['DistributionConfig']['CustomErrorResponses']
+        self.assertEquals(11, len(actual_custom_error_responses))
+        self.assertIn(
+            {
+                'ErrorCode': 400,
+                'ResponseCode': 400,
+                'ResponsePagePath': '4xx.html'
+            },
+            actual_custom_error_responses
+        )
+        self.assertIn(
+            {
+                'ErrorCode': 404,
+                'ResponseCode': 404,
+                'ResponsePagePath': '404.html'
+            },
+            actual_custom_error_responses
+        )
 
     def _parse_json(self, dump):
         """Parses dump into a dictionary, using strings rather than unicode strings

--- a/src/tests/test_buildercore_trop.py
+++ b/src/tests/test_buildercore_trop.py
@@ -268,6 +268,7 @@ class TestBuildercoreTrop(base.BaseCase):
                 'cookies': ['session_id'],
                 'headers': ['Accept'],
                 'subdomains': ['prod--cdn-of-www'],
+                'errors': None,
             },
             context['cloudfront']
         )

--- a/src/tests/test_buildercore_trop.py
+++ b/src/tests/test_buildercore_trop.py
@@ -368,7 +368,7 @@ class TestBuildercoreTrop(base.BaseCase):
                     'HTTPSPort': 443,
                     'OriginProtocolPolicy': 'https-only',
                 },
-                'DomainName': 'example-errors.com',
+                'DomainName': 'prod--example-errors.com',
                 'Id': 'ErrorsOrigin',
             },
             data['Resources']['CloudFrontCDN']['Properties']['DistributionConfig']['Origins'][1]

--- a/src/tests/test_buildercore_trop.py
+++ b/src/tests/test_buildercore_trop.py
@@ -267,7 +267,7 @@ class TestBuildercoreTrop(base.BaseCase):
                 'compress': True,
                 'cookies': ['session_id'],
                 'headers': ['Accept'],
-                'subdomains': ['prod--cdn-of-www'],
+                'subdomains': ['prod--cdn-of-www', ''],
                 'errors': None,
                 'default-ttl': 5,
             },
@@ -281,7 +281,7 @@ class TestBuildercoreTrop(base.BaseCase):
                 'Type': 'AWS::CloudFront::Distribution',
                 'Properties': {
                     'DistributionConfig': {
-                        'Aliases': ['prod--cdn-of-www.example.org'],
+                        'Aliases': ['prod--cdn-of-www.example.org', 'example.org'],
                         'DefaultCacheBehavior': {
                             'AllowedMethods': ['DELETE', 'GET', 'HEAD', 'OPTIONS', 'PATCH', 'POST', 'PUT'],
                             'CachedMethods': ['GET', 'HEAD'],
@@ -334,11 +334,30 @@ class TestBuildercoreTrop(base.BaseCase):
                     },
                     'Comment': 'External DNS record for Cloudfront distribution',
                     'HostedZoneName': 'example.org.',
-                    'Name': 'prod--cdn-of-www.example.org',
+                    'Name': 'prod--cdn-of-www.example.org.',
                     'Type': 'A',
                 },
             },
             data['Resources']['CloudFrontCDNDNS1']
+        )
+        self.assertTrue('CloudFrontCDNDNS2' in data['Resources'].keys())
+        self.assertEqual(
+            {
+                'Type': 'AWS::Route53::RecordSet',
+                'Properties': {
+                    'AliasTarget': {
+                        'DNSName': {
+                            'Fn::GetAtt': ['CloudFrontCDN', 'DomainName']
+                        },
+                        'HostedZoneId': 'Z2FDTNDATAQYW2',
+                    },
+                    'Comment': 'External DNS record for Cloudfront distribution',
+                    'HostedZoneName': 'example.org.',
+                    'Name': 'example.org.',
+                    'Type': 'A',
+                },
+            },
+            data['Resources']['CloudFrontCDNDNS2']
         )
 
     def test_cdn_template_minimal(self):

--- a/src/tests/test_buildercore_trop.py
+++ b/src/tests/test_buildercore_trop.py
@@ -269,6 +269,7 @@ class TestBuildercoreTrop(base.BaseCase):
                 'headers': ['Accept'],
                 'subdomains': ['prod--cdn-of-www'],
                 'errors': None,
+                'default-ttl': 5,
             },
             context['cloudfront']
         )
@@ -285,6 +286,7 @@ class TestBuildercoreTrop(base.BaseCase):
                             'AllowedMethods': ['DELETE', 'GET', 'HEAD', 'OPTIONS', 'PATCH', 'POST', 'PUT'],
                             'CachedMethods': ['GET', 'HEAD'],
                             'Compress': 'true',
+                            'DefaultTTL': 5,
                             'ForwardedValues': {
                                 'Cookies': {
                                     'Forward': 'whitelist',
@@ -375,6 +377,7 @@ class TestBuildercoreTrop(base.BaseCase):
         )
         self.assertEquals(
             [{
+                'DefaultTTL': 300,
                 'ForwardedValues': {
                     # yes this is a string containing the word 'false'...
                     'QueryString': 'false',

--- a/src/tests/test_buildercore_trop.py
+++ b/src/tests/test_buildercore_trop.py
@@ -385,23 +385,15 @@ class TestBuildercoreTrop(base.BaseCase):
             }],
             data['Resources']['CloudFrontCDN']['Properties']['DistributionConfig']['CacheBehaviors']
         )
-        actual_custom_error_responses = data['Resources']['CloudFrontCDN']['Properties']['DistributionConfig']['CustomErrorResponses']
-        self.assertEquals(11, len(actual_custom_error_responses))
-        self.assertIn(
-            {
-                'ErrorCode': 400,
-                'ResponseCode': 400,
-                'ResponsePagePath': '/4xx.html'
-            },
-            actual_custom_error_responses
-        )
-        self.assertIn(
-            {
-                'ErrorCode': 404,
-                'ResponseCode': 404,
-                'ResponsePagePath': '/404.html'
-            },
-            actual_custom_error_responses
+        self.assertEquals(
+            [
+                {
+                    'ErrorCode': 502,
+                    'ResponseCode': 502,
+                    'ResponsePagePath': '/5xx.html'
+                },
+            ],
+            data['Resources']['CloudFrontCDN']['Properties']['DistributionConfig']['CustomErrorResponses']
         )
 
     def _parse_json(self, dump):


### PR DESCRIPTION
Pages are hosted into a publicly readable bucket, CloudFront allows to:
- point all requests that match `???.html` to this bucket
- specify a fixed set of error codes to be mapped to these paths.