### PR TITLE
Storing context when updating a template

### DIFF
--- a/projects/elife.yaml
+++ b/projects/elife.yaml
@@ -214,7 +214,8 @@ journal:
                     domain: end2end-elife-error-pages.s3-website-us-east-1.amazonaws.com
                     pattern: "???.html"
                     codes:
-                        502: "/5xx.html"
+                        # ELB with no active instances
+                        503: "/5xx.html"
                     protocol: http
         continuumtest:
             cloudfront:
@@ -224,7 +225,7 @@ journal:
                     domain: continuumtest-elife-error-pages.s3-website-us-east-1.amazonaws.com
                     pattern: "???.html"
                     codes:
-                        502: "/5xx.html"
+                        503: "/5xx.html"
                     protocol: http
         prod:
             description: prod environment for journal. ELB on top of multiple EC2 instances
@@ -246,7 +247,8 @@ journal:
                     domain: prod-elife-error-pages.s3-website-us-east-1.amazonaws.com
                     pattern: "???.html"
                     codes:
-                        502: "/5xx.html"
+                        # ELB with no active instances
+                        503: "/5xx.html"
                     protocol: http
     vagrant:
         ram: 4096

--- a/src/buildercore/cfngen.py
+++ b/src/buildercore/cfngen.py
@@ -288,12 +288,11 @@ def generate_stack(pname, **more_context):
     context_handler.write_context(stackname, context)
     return context, out_fname
 
-def template_delta(pname, **more_context):
+def template_delta(pname, context):
     """given an already existing template, regenerates it and produces a delta containing only the new resources.
 
     Existing resources are treated as immutable and not put in the delta"""
-    old_template = read_template(more_context['stackname'])
-    context = build_context(pname, **more_context)
+    old_template = read_template(context['stackname'])
     template = json.loads(render_template(context))
     updatable_title_prefixes = ['CloudFront']
 

--- a/src/buildercore/cfngen.py
+++ b/src/buildercore/cfngen.py
@@ -18,7 +18,7 @@ A developer wants a temporary instance deployed for testing or debugging.
 import os, json, copy
 import netaddr
 from slugify import slugify
-from . import utils, trop, core, project, context_handler
+from . import utils, trop, core, project, bootstrap, context_handler
 from .utils import ensure
 from .config import STACK_DIR
 
@@ -287,6 +287,13 @@ def generate_stack(pname, **more_context):
     out_fname = write_template(stackname, template)
     context_handler.write_context(stackname, context)
     return context, out_fname
+
+def regenerate_stack(pname, **more_context):
+    current_template = bootstrap.current_template(more_context['stackname'])
+    write_template(more_context['stackname'], json.dumps(current_template))
+    context = build_context(pname, **more_context)
+    delta = template_delta(pname, context)
+    return context, delta
 
 def template_delta(pname, context):
     """given an already existing template, regenerates it and produces a delta containing only the new resources.

--- a/src/cfn.py
+++ b/src/cfn.py
@@ -9,8 +9,6 @@ from buildercore import core, cfngen, utils as core_utils, bootstrap, project, c
 from buildercore.core import stack_conn, stack_pem, stack_all_ec2_nodes
 from buildercore.decorators import PredicateException
 from buildercore.config import DEPLOY_USER, BOOTSTRAP_USER, FabricException
-# TODO: avoid when cfngen has new signature
-import json
 
 import logging
 LOG = logging.getLogger(__name__)

--- a/src/cfn.py
+++ b/src/cfn.py
@@ -71,11 +71,9 @@ def update_template(stackname):
     core_lifecycle.start(stackname)
 
     (pname, _) = core.parse_stackname(stackname)
-    current_template = bootstrap.current_template(stackname)
-    cfngen.write_template(stackname, json.dumps(current_template))
     more_context = cfngen.choose_config(stackname)
-    context = cfngen.build_context(pname, **more_context)
-    delta = cfngen.template_delta(pname, context)
+
+    context, delta = cfngen.regenerate_stack(pname, **more_context)
     LOG.info("%s", pformat(delta))
     utils.confirm('Confirming changes to the stack template?')
 

--- a/src/cfn.py
+++ b/src/cfn.py
@@ -5,7 +5,7 @@ import fabric.state
 from fabric.contrib import files
 import aws, utils
 from decorators import requires_project, requires_aws_stack, requires_steady_stack, echo_output, setdefault, debugtask, timeit
-from buildercore import core, cfngen, utils as core_utils, bootstrap, project, checks, lifecycle as core_lifecycle
+from buildercore import core, cfngen, utils as core_utils, bootstrap, project, checks, lifecycle as core_lifecycle, context_handler
 from buildercore.core import stack_conn, stack_pem, stack_all_ec2_nodes
 from buildercore.decorators import PredicateException
 from buildercore.config import DEPLOY_USER, BOOTSTRAP_USER, FabricException
@@ -73,12 +73,13 @@ def update_template(stackname):
     (pname, _) = core.parse_stackname(stackname)
     current_template = bootstrap.current_template(stackname)
     cfngen.write_template(stackname, json.dumps(current_template))
-
     more_context = cfngen.choose_config(stackname)
-    delta = cfngen.template_delta(pname, **more_context)
+    context = cfngen.build_context(pname, **more_context)
+    delta = cfngen.template_delta(pname, context)
     LOG.info("%s", pformat(delta))
     utils.confirm('Confirming changes to the stack template?')
 
+    context_handler.write_context(stackname, context)
     new_template = cfngen.merge_delta(stackname, delta)
     bootstrap.update_template(stackname, new_template)
 

--- a/src/tests/test_buildercore_cfngen.py
+++ b/src/tests/test_buildercore_cfngen.py
@@ -1,7 +1,6 @@
 from time import sleep
 from . import base
 from buildercore import cfngen, project, context_handler
-from mock import patch
 
 import logging
 LOG = logging.getLogger(__name__)
@@ -38,62 +37,53 @@ class TestBuildercoreCfngen(base.BaseCase):
         self.switch_in_test_settings()
 
     def test_empty_template_delta(self):
-        template = cfngen.quick_render('dummy1')
-        cfngen.write_template('dummy1--test', template)
-        delta = cfngen.template_delta('dummy1', stackname='dummy1--test')
+        context = self._base_context()
+        delta = cfngen.template_delta('dummy1', context)
         self.assertEqual(delta, {'Outputs': {}, 'Resources': {}})
 
     def test_template_delta_includes_cloudfront(self):
         "we can add CDNs (that takes an hour or more) without downtime"
         context = self._base_context()
-        with patch('buildercore.cfngen.build_context') as mock_build_context:
-            context['full_hostname'] = "test--dummy1.example.org"
-            context['cloudfront'] = {
-                "subdomains": [
-                    "test--cdn-dummy1"
-                ],
-                "compress": True,
-                "cookies": [],
-                "certificate_id": "AAAA...",
-                "headers": [],
-                "errors": None,
-                "default-ttl": 300,
-            }
-            mock_build_context.return_value = context
-            delta = cfngen.template_delta('dummy1', stackname='dummy1--test')
-            self.assertEqual(delta['Resources'].keys(), ['CloudFrontCDN', 'CloudFrontCDNDNS1', 'ExtDNS'])
-            self.assertEqual(delta['Outputs'].keys(), ['DomainName'])
+        context['full_hostname'] = "test--dummy1.example.org"
+        context['cloudfront'] = {
+            "subdomains": [
+                "test--cdn-dummy1"
+            ],
+            "compress": True,
+            "cookies": [],
+            "certificate_id": "AAAA...",
+            "headers": [],
+            "errors": None,
+            "default-ttl": 300,
+        }
+        delta = cfngen.template_delta('dummy1', context)
+        self.assertEqual(delta['Resources'].keys(), ['CloudFrontCDN', 'CloudFrontCDNDNS1', 'ExtDNS'])
+        self.assertEqual(delta['Outputs'].keys(), ['DomainName'])
 
     def test_template_delta_does_not_include_cloudfront_if_there_are_no_modifications(self):
         context = self._base_context('project-with-cloudfront-minimal')
-        with patch('buildercore.cfngen.build_context') as mock_build_context:
-            mock_build_context.return_value = context
-            delta = cfngen.template_delta('project-with-cloudfront-minimal', stackname='project-with-cloudfront-minimal--test')
-            self.assertEqual(delta['Resources'].keys(), [])
-            self.assertEqual(delta['Outputs'].keys(), [])
+        delta = cfngen.template_delta('project-with-cloudfront-minimal', context)
+        self.assertEqual(delta['Resources'].keys(), [])
+        self.assertEqual(delta['Outputs'].keys(), [])
 
     def test_template_delta_never_includes_ec2(self):
         "we do not want to mess with running VMs"
         context = self._base_context()
-        with patch('buildercore.cfngen.build_context') as mock_build_context:
-            context['ec2']['cluster_size'] = 2
-            mock_build_context.return_value = context
-            delta = cfngen.template_delta('dummy1', stackname='dummy1--test')
-            self.assertEqual(delta['Resources'].keys(), [])
-            self.assertEqual(delta['Outputs'].keys(), [])
+        context['ec2']['cluster_size'] = 2
+        delta = cfngen.template_delta('dummy1', context)
+        self.assertEqual(delta['Resources'].keys(), [])
+        self.assertEqual(delta['Outputs'].keys(), [])
 
     def test_template_delta_includes_parts_of_cloudfront(self):
         "we want to update CDNs in place given how long it takes to recreate them"
         context = self._base_context('project-with-cloudfront-minimal')
-        with patch('buildercore.cfngen.build_context') as mock_build_context:
-            context['cloudfront']['subdomains'] = [
-                "custom-subdomain"
-            ]
-            mock_build_context.return_value = context
-            delta = cfngen.template_delta('project-with-cloudfront-minimal', stackname='project-with-cloudfront-minimal--test')
-            self.assertEqual(delta['Resources'].keys(), ['CloudFrontCDN', 'CloudFrontCDNDNS1'])
-            self.assertEqual(delta['Resources']['CloudFrontCDNDNS1']['Properties']['Name'], 'custom-subdomain.example.org.')
-            self.assertEqual(delta['Outputs'].keys(), [])
+        context['cloudfront']['subdomains'] = [
+            "custom-subdomain"
+        ]
+        delta = cfngen.template_delta('project-with-cloudfront-minimal', context)
+        self.assertEqual(delta['Resources'].keys(), ['CloudFrontCDN', 'CloudFrontCDNDNS1'])
+        self.assertEqual(delta['Resources']['CloudFrontCDNDNS1']['Properties']['Name'], 'custom-subdomain.example.org.')
+        self.assertEqual(delta['Outputs'].keys(), [])
 
     def _base_context(self, project_name='dummy1'):
         stackname = '%s--test' % project_name


### PR DESCRIPTION
What we do is to generate a new context, and then (partially and safely) updating the CloudFormation template as a result of this. Therefore, we should store the new context in S3 and locally, not just the updated template.

Testing this tomorrow on journal--* instances.