### PR TITLE
Updating the ELB HealthCheck in place

### DIFF
--- a/projects/elife.yaml
+++ b/projects/elife.yaml
@@ -68,7 +68,9 @@ defaults:
             idle_timeout: 60
             certificate: arn:aws:iam::512686554592:server-certificate/cloudfront/wildcard.elifesciences.org/wildcard.elifesciences.org
             healthcheck:
+                protocol: http
                 port: 80
+                path: /ping
                 timeout: 4 
                 interval: 5
                 unhealthy_threshold: 2

--- a/src/buildercore/cfngen.py
+++ b/src/buildercore/cfngen.py
@@ -301,7 +301,7 @@ def template_delta(pname, context):
     Existing resources are treated as immutable and not put in the delta"""
     old_template = read_template(context['stackname'])
     template = json.loads(render_template(context))
-    updatable_title_prefixes = ['CloudFront']
+    updatable_title_prefixes = ['CloudFront', 'ElasticLoadBalancer']
 
     def _related_to_ec2(output):
         if 'Value' in output:

--- a/src/buildercore/trop.py
+++ b/src/buildercore/trop.py
@@ -468,6 +468,11 @@ def render_elb(context, template, ec2_instances):
         else:
             raise RuntimeError("Unknown procotol `%s`" % context['elb']['protocol'])
 
+    if context['elb']['healthcheck']['protocol'] == 'tcp':
+        healthcheck_target = 'TCP:%d' % context['elb']['healthcheck'].get('port', 80)
+    elif context['elb']['healthcheck']['protocol'] == 'http':
+        healthcheck_target = 'HTTP:%s%s' % (context['elb']['healthcheck']['port'], context['elb']['healthcheck']['path'])
+
     template.add_resource(elb.LoadBalancer(
         ELB_TITLE,
         ConnectionDrainingPolicy=elb.ConnectionDrainingPolicy(
@@ -483,7 +488,7 @@ def render_elb(context, template, ec2_instances):
         Listeners=listeners,
         LBCookieStickinessPolicy=cookie_stickiness,
         HealthCheck=elb.HealthCheck(
-            Target='TCP:%d' % context['elb']['healthcheck'].get('port', 80),
+            Target=healthcheck_target,
             HealthyThreshold=str(context['elb']['healthcheck'].get('healthy_threshold', 10)),
             UnhealthyThreshold=str(context['elb']['healthcheck'].get('unhealthy_threshold', 2)),
             Interval=str(context['elb']['healthcheck'].get('interval', 30)),

--- a/src/tests/fixtures/projects/dummy-project.yaml
+++ b/src/tests/fixtures/projects/dummy-project.yaml
@@ -60,7 +60,9 @@ defaults:
             protocol: http
             idle_timeout: 60
             healthcheck:
+                protocol: http
                 port: 80
+                path: /ping
                 timeout: 4 
                 interval: 5
                 unhealthy_threshold: 2

--- a/src/tests/test_buildercore_cfngen.py
+++ b/src/tests/test_buildercore_cfngen.py
@@ -85,6 +85,15 @@ class TestBuildercoreCfngen(base.BaseCase):
         self.assertEqual(delta['Resources']['CloudFrontCDNDNS1']['Properties']['Name'], 'custom-subdomain.example.org.')
         self.assertEqual(delta['Outputs'].keys(), [])
 
+    def test_template_delta_includes_parts_of_elb(self):
+        "we want to update ELBs in place given how long it takes to recreate them"
+        context = self._base_context('project-with-cluster')
+        context['elb']['healthcheck']['protocol'] = 'tcp'
+        delta = cfngen.template_delta('project-with-cluster', context)
+        self.assertEqual(delta['Resources'].keys(), ['ElasticLoadBalancer'])
+        self.assertEqual(delta['Resources']['ElasticLoadBalancer']['Properties']['HealthCheck']['Target'], 'TCP:80')
+        self.assertEqual(delta['Outputs'].keys(), [])
+
     def _base_context(self, project_name='dummy1'):
         stackname = '%s--test' % project_name
         context = cfngen.build_context(project_name, stackname=stackname)

--- a/src/tests/test_buildercore_trop.py
+++ b/src/tests/test_buildercore_trop.py
@@ -145,7 +145,7 @@ class TestBuildercoreTrop(base.BaseCase):
         self.assertEqual(
             elb['HealthCheck'],
             {
-                'Target': 'TCP:80',
+                'Target': 'HTTP:80/ping',
                 'Timeout': '4',
                 'Interval': '5',
                 'HealthyThreshold': '2',


### PR DESCRIPTION
We go from opening a TCP connection to port 80 to the EC2 instances (which fails if the DNS is down) to do a HTTP request for /ping (which fails if the PHP bootstrap fails).

The result of this HealthCheck failing is for the instance to be taken out of the ELB. If all machines are taken out, the ELB starts returning 503.

In theory we can update this in the CloudFormation template with `No Interruption` so the downstream DNS for the ELB should not change. Let's see.