### PR TITLE
Adding public configuration fields for buckets

### DIFF
--- a/projects/elife.yaml
+++ b/projects/elife.yaml
@@ -322,6 +322,7 @@ elife-bot:
             "{instance}-elife-silent-corrections":
             "{instance}-elife-published":
                 deletion-policy: retain
+                public: true
     aws-alt:
         #prod:
         #    eip: 54.164.145.166

--- a/src/buildercore/cfngen.py
+++ b/src/buildercore/cfngen.py
@@ -136,6 +136,7 @@ def build_context(pname, **more_context): # pylint: disable=too-many-locals
         'deletion-policy': 'delete',
         'website-configuration': None,
         'cors': None,
+        'public': False,
     }
     for bucket_template_name in context['project']['aws']['s3']:
         bucket_name = _parameterize(bucket_template_name)

--- a/src/buildercore/trop.py
+++ b/src/buildercore/trop.py
@@ -401,27 +401,34 @@ def render_s3(context, template):
             props['WebsiteConfiguration'] = s3.WebsiteConfiguration(
                 IndexDocument=index_document
             )
-            template.add_resource(s3.BucketPolicy(
-                "%sPolicy" % bucket_title,
-                Bucket=bucket_name,
-                PolicyDocument={
-                    "Version": "2012-10-17",
-                    "Statement": [{
-                        "Sid": "AddPerm",
-                        "Effect": "Allow",
-                        "Principal": "*",
-                        "Action": ["s3:GetObject"],
-                        "Resource":[
-                            "arn:aws:s3:::%s/*" % bucket_name
-                        ]
-                    }]
-                }
-            ))
+            _add_bucket_policy(template, bucket_title, bucket_name)
+
+        if context['s3'][bucket_name]['public']:
+            _add_bucket_policy(template, bucket_title, bucket_name)
+
         template.add_resource(s3.Bucket(
             bucket_title,
             BucketName=bucket_name,
             **props
         ))
+
+def _add_bucket_policy(template, bucket_title, bucket_name):
+    template.add_resource(s3.BucketPolicy(
+        "%sPolicy" % bucket_title,
+        Bucket=bucket_name,
+        PolicyDocument={
+            "Version": "2012-10-17",
+            "Statement": [{
+                "Sid": "AddPerm",
+                "Effect": "Allow",
+                "Principal": "*",
+                "Action": ["s3:GetObject"],
+                "Resource":[
+                    "arn:aws:s3:::%s/*" % bucket_name
+                ]
+            }]
+        }
+    ))
 
 def render_elb(context, template, ec2_instances):
     ensure(any([context['full_hostname'], context['int_full_hostname']]),

--- a/src/tests/fixtures/projects/dummy-project.yaml
+++ b/src/tests/fixtures/projects/dummy-project.yaml
@@ -185,6 +185,8 @@ project-with-s3:
                 website-configuration:
                     index-document: index.html
                 cors: True
+            widgets-just-access-{instance}:
+                public: True
 
 project-with-ext:
     repo: ssh://git@github.com/elifesciences/dummy3

--- a/src/tests/test_buildercore_trop.py
+++ b/src/tests/test_buildercore_trop.py
@@ -183,6 +183,7 @@ class TestBuildercoreTrop(base.BaseCase):
                 'deletion-policy': 'delete',
                 'website-configuration': None,
                 'cors': None,
+                'public': False,
             },
             context['s3']['widgets-prod']
         )
@@ -254,6 +255,28 @@ class TestBuildercoreTrop(base.BaseCase):
                 },
             },
             data['Resources']['WidgetsStaticHostingProdBucketPolicy']
+        )
+
+        self.assertEqual(
+            {
+                'Type': 'AWS::S3::BucketPolicy',
+                'Properties': {
+                    'Bucket': 'widgets-just-access-prod',
+                    'PolicyDocument': {
+                        "Version": "2012-10-17",
+                        "Statement": [{
+                            "Sid": "AddPerm",
+                            "Effect": "Allow",
+                            "Principal": "*",
+                            "Action": ["s3:GetObject"],
+                            "Resource":[
+                                "arn:aws:s3:::widgets-just-access-prod/*",
+                            ]
+                        }]
+                    }
+                },
+            },
+            data['Resources']['WidgetsJustAccessProdBucketPolicy']
         )
 
     def test_cdn_template(self):


### PR DESCRIPTION
This makes their content publicly accessible, but does not set up the website configuration