### PR TITLE
Allowing update of template of existing EC2 instances

### DIFF
--- a/src/buildercore/trop.py
+++ b/src/buildercore/trop.py
@@ -162,7 +162,7 @@ def ec2instance(context, node):
 
     project_ec2 = {
         "ImageId": lu('project.aws.ec2.ami'),
-        "InstanceType": lu('project.aws.type'), # t2.small, m1.medium, etc
+        "InstanceType": context['ec2']['type'], # t2.small, m1.medium, etc
         "KeyName": Ref(KEYPAIR),
         "SecurityGroupIds": [Ref(SECURITY_GROUP_TITLE)],
         "SubnetId": subnet_id, # ll: "subnet-1d4eb46a"

--- a/src/tests/test_buildercore_cfngen.py
+++ b/src/tests/test_buildercore_cfngen.py
@@ -66,12 +66,20 @@ class TestBuildercoreCfngen(base.BaseCase):
         self.assertEqual(delta['Resources'].keys(), [])
         self.assertEqual(delta['Outputs'].keys(), [])
 
-    def test_template_delta_never_includes_ec2(self):
+    def test_template_delta_does_not_normally_include_ec2(self):
         "we do not want to mess with running VMs"
         context = self._base_context()
         context['ec2']['cluster_size'] = 2
         delta = cfngen.template_delta('dummy1', context)
         self.assertEqual(delta['Resources'].keys(), [])
+        self.assertEqual(delta['Outputs'].keys(), [])
+
+    def test_template_delta_includes_ec2_instance_type(self):
+        "we accept to reboot VMs if an instance type change is requested"
+        context = self._base_context()
+        context['ec2']['type'] = 't2.xlarge'
+        delta = cfngen.template_delta('dummy1', context)
+        self.assertEqual(delta['Resources'].keys(), ['EC2Instance1'])
         self.assertEqual(delta['Outputs'].keys(), [])
 
     def test_template_delta_includes_parts_of_cloudfront(self):


### PR DESCRIPTION
But not messing with adding new EC2 instances. This will give us the possibility, in case we need, to change the type of an EC2 instance. It's used in the specialized task `update_template` and it requires confirmation like all CloudFormation template updates. Requires downtime as the reboot is performed.