### PR TITLE
Support for adding Aliases to CloudFront without the relevant DNS

### DIFF
--- a/projects/elife.yaml
+++ b/projects/elife.yaml
@@ -88,6 +88,7 @@ defaults:
         s3: {}
         cloudfront: 
             # cloudfront defaults only used if a 'cloudfront' section present in project
+            subdomains-without-dns: []
             certificate_id: ASCAIRXYIRFBOR5QSDP5M
             cookies: []
             compress: True
@@ -263,6 +264,8 @@ journal:
                     #- elife
                     #- prod
                     #- ""
+                subdomains-without-dns:
+                    - gamma
                 headers:
                     - X-Requested-With
                 cookies:

--- a/src/buildercore/cfngen.py
+++ b/src/buildercore/cfngen.py
@@ -177,6 +177,7 @@ def build_context_cloudfront(context, parameterize):
             errors = None
         context['cloudfront'] = {
             'subdomains': [parameterize(x) for x in context['project']['aws']['cloudfront']['subdomains']],
+            'subdomains-without-dns': [parameterize(x) for x in context['project']['aws']['cloudfront']['subdomains-without-dns']],
             'certificate_id': context['project']['aws']['cloudfront']['certificate_id'],
             'cookies': context['project']['aws']['cloudfront']['cookies'],
             'compress': context['project']['aws']['cloudfront']['compress'],

--- a/src/buildercore/trop.py
+++ b/src/buildercore/trop.py
@@ -520,7 +520,7 @@ def render_cloudfront(context, template, origin_hostname):
     origin = CLOUDFRONT_TITLE + 'Origin'
     allowed_cnames = [
         "%s.%s" % (subdomain, context['domain']) if subdomain != '' else context['domain']
-        for subdomain in context['cloudfront']['subdomains']
+        for subdomain in context['cloudfront']['subdomains'] + context['cloudfront']['subdomains-without-dns']
     ]
     if context['cloudfront']['cookies']:
         cookies = cloudfront.Cookies(

--- a/src/tests/fixtures/projects/dummy-project.yaml
+++ b/src/tests/fixtures/projects/dummy-project.yaml
@@ -72,6 +72,7 @@ defaults:
         s3: []
         cloudfront:
             # cloudfront defaults only used if a 'cloudfront' section present in project
+            subdomains-without-dns: []
             certificate_id: 'dummy...'
             cookies: []
             compress: True
@@ -208,6 +209,8 @@ project-with-cloudfront:
             subdomains:
                 - "{instance}--cdn-of-www"
                 - ""
+            subdomains-without-dns:
+                - future
             cookies:
                 - session_id
             headers:

--- a/src/tests/test_buildercore_cfngen.py
+++ b/src/tests/test_buildercore_cfngen.py
@@ -49,6 +49,7 @@ class TestBuildercoreCfngen(base.BaseCase):
             "subdomains": [
                 "test--cdn-dummy1"
             ],
+            "subdomains-without-dns": [],
             "compress": True,
             "cookies": [],
             "certificate_id": "AAAA...",

--- a/src/tests/test_buildercore_trop.py
+++ b/src/tests/test_buildercore_trop.py
@@ -291,6 +291,7 @@ class TestBuildercoreTrop(base.BaseCase):
                 'cookies': ['session_id'],
                 'headers': ['Accept'],
                 'subdomains': ['prod--cdn-of-www', ''],
+                'subdomains-without-dns': ['future'],
                 'errors': None,
                 'default-ttl': 5,
             },
@@ -304,7 +305,7 @@ class TestBuildercoreTrop(base.BaseCase):
                 'Type': 'AWS::CloudFront::Distribution',
                 'Properties': {
                     'DistributionConfig': {
-                        'Aliases': ['prod--cdn-of-www.example.org', 'example.org'],
+                        'Aliases': ['prod--cdn-of-www.example.org', 'example.org', 'future.example.org'],
                         'DefaultCacheBehavior': {
                             'AllowedMethods': ['DELETE', 'GET', 'HEAD', 'OPTIONS', 'PATCH', 'POST', 'PUT'],
                             'CachedMethods': ['GET', 'HEAD'],


### PR DESCRIPTION
This allows to prepare a CDN for the DNS to be easily switched (atomically is
too strong a word) later.