### PR TITLE
Generic CDN

### DIFF
--- a/projects/elife.yaml
+++ b/projects/elife.yaml
@@ -89,6 +89,7 @@ defaults:
         cloudfront: 
             # cloudfront defaults only used if a 'cloudfront' section present in project
             subdomains-without-dns: []
+            origins: {}
             certificate_id: ASCAIRXYIRFBOR5QSDP5M
             cookies: []
             compress: true
@@ -378,6 +379,23 @@ elife-bot:
             # digilib
             1232: 8080
 
+generic-cdn:
+    description: generic CDN for content like PDF, images
+    default-branch: null
+    domain: null
+    intdomain: null
+    aws:
+        ec2: false
+        cloudfront:
+            subdomains:
+                - "{instance}-cdn.elifesciences.org"
+            origins:
+                # first is default
+                default:
+                    hostname: elife-cdn.s3.amazonaws.com
+                articles:
+                    hostname: "{instance}-elife-published.s3.amazonaws.com"
+                    pattern: articles/*
 
 journal-cms:
     subdomain: journal-cms # journal-cms.elifesciences.org

--- a/projects/elife.yaml
+++ b/projects/elife.yaml
@@ -382,13 +382,12 @@ elife-bot:
 generic-cdn:
     description: generic CDN for content like PDF, images
     default-branch: null
-    domain: null
     intdomain: null
     aws:
         ec2: false
         cloudfront:
             subdomains:
-                - "{instance}-cdn.elifesciences.org"
+                - "{instance}-cdn"
             origins:
                 # first is default
                 default:

--- a/src/buildercore/cfngen.py
+++ b/src/buildercore/cfngen.py
@@ -17,6 +17,7 @@ A developer wants a temporary instance deployed for testing or debugging.
 """
 import os, json, copy
 import re
+from collections import OrderedDict
 import netaddr
 from slugify import slugify
 from . import utils, trop, core, project, bootstrap, context_handler
@@ -185,7 +186,10 @@ def build_context_cloudfront(context, parameterize):
             'headers': context['project']['aws']['cloudfront']['headers'],
             'default-ttl': context['project']['aws']['cloudfront']['default-ttl'],
             'errors': errors,
-            'origins': { o_id: { 'hostname': parameterize(o['hostname']) } for o_id, o in context['project']['aws']['cloudfront']['origins'].iteritems()},
+            'origins': OrderedDict([
+                (o_id, { 'hostname': parameterize(o['hostname']), 'pattern': o.get('pattern') }) \
+                for o_id, o in context['project']['aws']['cloudfront']['origins'].iteritems()
+            ]),
         }
     else:
         context['cloudfront'] = False

--- a/src/buildercore/cfngen.py
+++ b/src/buildercore/cfngen.py
@@ -187,7 +187,7 @@ def build_context_cloudfront(context, parameterize):
             'default-ttl': context['project']['aws']['cloudfront']['default-ttl'],
             'errors': errors,
             'origins': OrderedDict([
-                (o_id, { 'hostname': parameterize(o['hostname']), 'pattern': o.get('pattern') }) \
+                (o_id, {'hostname': parameterize(o['hostname']), 'pattern': o.get('pattern')})
                 for o_id, o in context['project']['aws']['cloudfront']['origins'].iteritems()
             ]),
         }

--- a/src/buildercore/cfngen.py
+++ b/src/buildercore/cfngen.py
@@ -185,7 +185,7 @@ def build_context_cloudfront(context, parameterize):
             'headers': context['project']['aws']['cloudfront']['headers'],
             'default-ttl': context['project']['aws']['cloudfront']['default-ttl'],
             'errors': errors,
-            'origins': context['project']['aws']['cloudfront']['origins'],
+            'origins': { o_id: { 'hostname': parameterize(o['hostname']) } for o_id, o in context['project']['aws']['cloudfront']['origins'].iteritems()},
         }
     else:
         context['cloudfront'] = False

--- a/src/buildercore/cfngen.py
+++ b/src/buildercore/cfngen.py
@@ -189,7 +189,7 @@ def build_context_cloudfront(context, parameterize):
             'errors': errors,
             'origins': OrderedDict([
                 (o_id, {'hostname': parameterize(o['hostname']), 'pattern': o.get('pattern')})
-                for o_id, o in context['project']['aws']['cloudfront']['origins'].iteritems()
+                for o_id, o in context['project']['aws']['cloudfront']['origins'].items()
             ]),
         }
     else:
@@ -351,12 +351,12 @@ def template_delta(pname, context):
         return title_in_old != title_in_new
 
     resources = {
-        title: r for (title, r) in template['Resources'].iteritems()
+        title: r for (title, r) in template['Resources'].items()
         if (title not in old_template['Resources'] and 'EC2Instance' not in title)
         or (_title_is_updatable(title) and _title_has_been_updated(title, 'Resources'))
     }
     outputs = {
-        title: o for (title, o) in template['Outputs'].iteritems()
+        title: o for (title, o) in template['Outputs'].items()
         if (title not in old_template['Outputs'] and not _related_to_ec2(o))
         or (_title_is_updatable(title) and _title_has_been_updated(title, 'Outputs'))
     }

--- a/src/buildercore/cfngen.py
+++ b/src/buildercore/cfngen.py
@@ -185,6 +185,7 @@ def build_context_cloudfront(context, parameterize):
             'headers': context['project']['aws']['cloudfront']['headers'],
             'default-ttl': context['project']['aws']['cloudfront']['default-ttl'],
             'errors': errors,
+            'origins': context['project']['aws']['cloudfront']['origins'],
         }
     else:
         context['cloudfront'] = False

--- a/src/buildercore/core.py
+++ b/src/buildercore/core.py
@@ -274,7 +274,7 @@ def current_ec2_node_id():
     current_public_ip = env.host
 
     assert 'public_ips' in env, "This is supposed to be called by stack_all_ec2_nodes, which provides the correct configuration"
-    matching_instance_ids = [instance_id for (instance_id, public_ip) in env.public_ips.iteritems() if current_public_ip == public_ip]
+    matching_instance_ids = [instance_id for (instance_id, public_ip) in env.public_ips.items() if current_public_ip == public_ip]
 
     assert len(matching_instance_ids) == 1, ("Too many instance ids (%s) pointing to this ip (%s)" % (matching_instance_ids, current_public_ip))
     return matching_instance_ids[0]

--- a/src/buildercore/lifecycle.py
+++ b/src/buildercore/lifecycle.py
@@ -80,14 +80,14 @@ def last_start_time(stackname):
 def stop_if_next_hour_is_imminent(stackname, minimum_minutes=55):
     maximum_minutes = 60
     starting_times = last_start_time(stackname)
-    running_times = {node_id: int((datetime.utcnow() - launch_time).total_seconds()) % (maximum_minutes * 60) for (node_id, launch_time) in starting_times.iteritems()}
+    running_times = {node_id: int((datetime.utcnow() - launch_time).total_seconds()) % (maximum_minutes * 60) for (node_id, launch_time) in starting_times.items()}
     LOG.info("Hourly fraction running times: %s", running_times)
 
     minimum_running_time = minimum_minutes * 60
     maximum_running_time = maximum_minutes * 60
     LOG.info("Interval to select nodes to stop: %s-%s", minimum_running_time, maximum_running_time)
 
-    to_be_stopped = [node_id for (node_id, running_time) in running_times.iteritems() if running_time >= minimum_running_time]
+    to_be_stopped = [node_id for (node_id, running_time) in running_times.items() if running_time >= minimum_running_time]
     LOG.info("Selected for stopping: %s", to_be_stopped)
     if to_be_stopped:
         _connection(stackname).stop_instances(to_be_stopped)
@@ -178,7 +178,7 @@ def _delete_dns_a_record(stackname, zone_name, name):
         LOG.info("No DNS record to delete")
 
 def _select_nodes_with_state(interesting_state, states):
-    return [instance_id for (instance_id, state) in states.iteritems() if state == interesting_state]
+    return [instance_id for (instance_id, state) in states.items() if state == interesting_state]
 
 def _nodes_states(stackname, node_ids=None):
     """dictionary from instance id to a string state.
@@ -201,8 +201,8 @@ def _nodes_states(stackname, node_ids=None):
 
     ec2_data = find_ec2_instances(stackname, state=None, node_ids=node_ids)
     by_node_name = _by_node_name(ec2_data)
-    unified_nodes = {name: _unify_node_information(nodes) for name, nodes in by_node_name.iteritems()}
-    return {node.id: node.state for name, node in unified_nodes.iteritems()}
+    unified_nodes = {name: _unify_node_information(nodes) for name, nodes in by_node_name.items()}
+    return {node.id: node.state for name, node in unified_nodes.items()}
 
 def _connection(stackname):
     return connect_aws_with_stack(stackname, 'ec2')

--- a/src/buildercore/trop.py
+++ b/src/buildercore/trop.py
@@ -564,7 +564,7 @@ def render_cloudfront(context, template, origin_hostname):
                     OriginProtocolPolicy='https-only'
                 )
             )
-            for o_id, o in context['cloudfront']['origins'].iteritems()
+            for o_id, o in context['cloudfront']['origins'].items()
         ]
         origin = origins[0].Id
     else:
@@ -634,13 +634,13 @@ def render_cloudfront(context, template, origin_hostname):
                 ErrorCode=code,
                 ResponseCode=code,
                 ResponsePagePath=page
-            ) for code, page in context['cloudfront']['errors']['codes'].iteritems()
+            ) for code, page in context['cloudfront']['errors']['codes'].items()
         ]
 
     if context['cloudfront']['origins']:
         props['CacheBehaviors'] = [
             _cache_behavior(o_id, o['pattern'])
-            for o_id, o in context['cloudfront']['origins'].iteritems()
+            for o_id, o in context['cloudfront']['origins'].items()
             if o['pattern']
         ]
 

--- a/src/buildercore/trop.py
+++ b/src/buildercore/trop.py
@@ -616,9 +616,9 @@ def render_cloudfront(context, template, origin_hostname):
 
     if context['cloudfront']['origins']:
         props['CacheBehaviors'] = [
-            _cache_behavior(o_id, o['pattern']) \
-                    for o_id, o in context['cloudfront']['origins'].iteritems() \
-                    if o['pattern']
+            _cache_behavior(o_id, o['pattern'])
+            for o_id, o in context['cloudfront']['origins'].iteritems()
+            if o['pattern']
         ]
 
     template.add_resource(cloudfront.Distribution(

--- a/src/buildercore/trop.py
+++ b/src/buildercore/trop.py
@@ -531,7 +531,6 @@ def render_cloudfront(context, template, origin_hostname):
             Forward='none'
         )
 
-    origins = []
     if context['cloudfront']['origins']:
         origins = [
             cloudfront.Origin(
@@ -556,7 +555,7 @@ def render_cloudfront(context, template, origin_hostname):
                     OriginProtocolPolicy='https-only'
                 )
             )
-        ],
+        ]
     props = {
         'Aliases': allowed_cnames,
         'DefaultCacheBehavior': cloudfront.DefaultCacheBehavior(

--- a/src/tests/fixtures/projects/dummy-project.yaml
+++ b/src/tests/fixtures/projects/dummy-project.yaml
@@ -253,8 +253,11 @@ project-with-cloudfront-origins:
             subdomains:
                 - "{instance}--cdn"
             origins:
+                default-bucket:
+                    hostname: "{instance}--default-bucket.s3.amazonaws.com"
                 some-bucket:
                     hostname: "{instance}--some-bucket.s3.amazonaws.com"
+                    pattern: articles/*
 
 project-with-cluster:
     repo: ssh://git@github.com/elifesciences/dummy3

--- a/src/tests/fixtures/projects/dummy-project.yaml
+++ b/src/tests/fixtures/projects/dummy-project.yaml
@@ -73,6 +73,7 @@ defaults:
         cloudfront:
             # cloudfront defaults only used if a 'cloudfront' section present in project
             subdomains-without-dns: []
+            origins: {}
             certificate_id: 'dummy...'
             cookies: []
             compress: true
@@ -242,6 +243,18 @@ project-with-cloudfront-error-pages:
                 codes:
                     502: "/5xx.html"
                 protocol: http
+
+project-with-cloudfront-origins:
+    repo: ssh://git@github.com/elifesciences/dummy3
+    aws:
+        ports:
+            - 80
+        cloudfront:
+            subdomains:
+                - "{instance}--cdn"
+            origins:
+                some-bucket:
+                    hostname: some-bucket.s3.amazonaws.com
 
 project-with-cluster:
     repo: ssh://git@github.com/elifesciences/dummy3

--- a/src/tests/fixtures/projects/dummy-project.yaml
+++ b/src/tests/fixtures/projects/dummy-project.yaml
@@ -254,7 +254,7 @@ project-with-cloudfront-origins:
                 - "{instance}--cdn"
             origins:
                 some-bucket:
-                    hostname: some-bucket.s3.amazonaws.com
+                    hostname: "{instance}--some-bucket.s3.amazonaws.com"
 
 project-with-cluster:
     repo: ssh://git@github.com/elifesciences/dummy3

--- a/src/tests/test_buildercore_cfngen.py
+++ b/src/tests/test_buildercore_cfngen.py
@@ -50,6 +50,7 @@ class TestBuildercoreCfngen(base.BaseCase):
                 "test--cdn-dummy1"
             ],
             "subdomains-without-dns": [],
+            "origins": {},
             "compress": True,
             "cookies": [],
             "certificate_id": "AAAA...",

--- a/src/tests/test_buildercore_project.py
+++ b/src/tests/test_buildercore_project.py
@@ -23,7 +23,7 @@ class TestProject(base.BaseCase):
         "a map of organisations and their projects are returned"
         prj_loc_lst = self.parsed_config['project-locations']
         expected = {'dummy-project': [
-            'dummy1', 'dummy2', 'dummy3', 'just-some-sns', 'project-with-sqs', 'project-with-s3', 'project-with-ext', 'project-with-cloudfront', 'project-with-cloudfront-minimal', 'project-with-cloudfront-error-pages', 'project-with-cluster',
+            'dummy1', 'dummy2', 'dummy3', 'just-some-sns', 'project-with-sqs', 'project-with-s3', 'project-with-ext', 'project-with-cloudfront', 'project-with-cloudfront-minimal', 'project-with-cloudfront-error-pages', 'project-with-cloudfront-origins', 'project-with-cluster',
         ]}
         #self.assertEqual(project.org_project_map(prj_loc_lst), expected)
         self.assertEqual(project.org_map(prj_loc_lst), expected)
@@ -32,7 +32,7 @@ class TestProject(base.BaseCase):
         "a simple list of projects are returned, ignoring which org they belong to"
         prj_loc_lst = self.parsed_config['project-locations']
         expected = [
-            'dummy1', 'dummy2', 'dummy3', 'just-some-sns', 'project-with-sqs', 'project-with-s3', 'project-with-ext', 'project-with-cloudfront', 'project-with-cloudfront-minimal', 'project-with-cloudfront-error-pages', 'project-with-cluster',
+            'dummy1', 'dummy2', 'dummy3', 'just-some-sns', 'project-with-sqs', 'project-with-s3', 'project-with-ext', 'project-with-cloudfront', 'project-with-cloudfront-minimal', 'project-with-cloudfront-error-pages', 'project-with-cloudfront-origins', 'project-with-cluster',
         ]
         self.assertEqual(project.project_list(prj_loc_lst), expected)
 
@@ -204,7 +204,7 @@ class TestMultiProjects(base.BaseCase):
 
     def test_project_list_from_multiple_files(self):
         expected = [
-            'dummy1', 'dummy2', 'dummy3', 'just-some-sns', 'project-with-sqs', 'project-with-s3', 'project-with-ext', 'project-with-cloudfront', 'project-with-cloudfront-minimal', 'project-with-cloudfront-error-pages', 'project-with-cluster',
+            'dummy1', 'dummy2', 'dummy3', 'just-some-sns', 'project-with-sqs', 'project-with-s3', 'project-with-ext', 'project-with-cloudfront', 'project-with-cloudfront-minimal', 'project-with-cloudfront-error-pages', 'project-with-cloudfront-origins', 'project-with-cluster',
 
             'yummy1'
         ]

--- a/src/tests/test_buildercore_project.py
+++ b/src/tests/test_buildercore_project.py
@@ -5,6 +5,14 @@ from buildercore import config, project, utils
 from buildercore.project import files as project_files
 from collections import OrderedDict
 
+ALL_PROJECTS = [
+    'dummy1', 'dummy2', 'dummy3',
+    'just-some-sns', 'project-with-sqs', 'project-with-s3',
+    'project-with-ext', 'project-with-cloudfront', 'project-with-cloudfront-minimal',
+    'project-with-cloudfront-error-pages', 'project-with-cloudfront-origins', 'project-with-cluster',
+    'project-with-db-params',
+]
+
 class TestProject(base.BaseCase):
     def setUp(self):
         self.project_file = join(self.fixtures_dir, 'projects', 'dummy-project.yaml')
@@ -22,26 +30,14 @@ class TestProject(base.BaseCase):
     def test_org_map(self):
         "a map of organisations and their projects are returned"
         prj_loc_lst = self.parsed_config['project-locations']
-        expected = {'dummy-project': [
-            'dummy1', 'dummy2', 'dummy3',
-            'just-some-sns', 'project-with-sqs', 'project-with-s3',
-            'project-with-ext', 'project-with-cloudfront', 'project-with-cloudfront-minimal',
-            'project-with-cloudfront-error-pages', 'project-with-cloudfront-origins', 'project-with-cluster',
-            'project-with-db-params',
-        ]}
+        expected = {'dummy-project': ALL_PROJECTS}
         #self.assertEqual(project.org_project_map(prj_loc_lst), expected)
         self.assertEqual(project.org_map(prj_loc_lst), expected)
 
     def test_project_list(self):
         "a simple list of projects are returned, ignoring which org they belong to"
         prj_loc_lst = self.parsed_config['project-locations']
-        expected = [
-            'dummy1', 'dummy2', 'dummy3',
-            'just-some-sns', 'project-with-sqs', 'project-with-s3',
-            'project-with-ext', 'project-with-cloudfront', 'project-with-cloudfront-minimal',
-            'project-with-cloudfront-error-pages', 'project-with-cloudfront-origins', 'project-with-cluster',
-            'project-with-db-params'
-        ]
+        expected = ALL_PROJECTS
         self.assertEqual(project.project_list(prj_loc_lst), expected)
 
 
@@ -211,12 +207,5 @@ class TestMultiProjects(base.BaseCase):
         pass
 
     def test_project_list_from_multiple_files(self):
-        expected = [
-            'dummy1', 'dummy2', 'dummy3',
-            'just-some-sns', 'project-with-sqs', 'project-with-s3',
-            'project-with-ext', 'project-with-cloudfront', 'project-with-cloudfront-minimal',
-            'project-with-cloudfront-error-pages', 'project-with-cloudfront-origins', 'project-with-cluster',
-            'project-with-db-params',
-            'yummy1'
-        ]
+        expected = ALL_PROJECTS + ['yummy1']
         self.assertEqual(project.project_list(self.parsed_config), expected)

--- a/src/tests/test_buildercore_trop.py
+++ b/src/tests/test_buildercore_trop.py
@@ -423,11 +423,32 @@ class TestBuildercoreTrop(base.BaseCase):
                         'HTTPSPort': 443,
                         'OriginProtocolPolicy': 'https-only',
                     },
+                    'DomainName': 'prod--default-bucket.s3.amazonaws.com',
+                    'Id': 'default-bucket',
+                },
+                {
+                    'CustomOriginConfig': {
+                        'HTTPSPort': 443,
+                        'OriginProtocolPolicy': 'https-only',
+                    },
                     'DomainName': 'prod--some-bucket.s3.amazonaws.com',
                     'Id': 'some-bucket',
                 }
             ],
             distribution_config['Origins']
+        )
+        self.assertEquals(
+            'default-bucket',
+            distribution_config['DefaultCacheBehavior']['TargetOriginId'],
+        )
+        self.assertEquals(1, len(distribution_config['CacheBehaviors']))
+        self.assertEquals(
+            'some-bucket',
+            distribution_config['CacheBehaviors'][0]['TargetOriginId'],
+        )
+        self.assertEquals(
+            'articles/*',
+            distribution_config['CacheBehaviors'][0]['PathPattern'],
         )
 
     def test_cdn_template_error_pages(self):

--- a/src/tests/test_buildercore_trop.py
+++ b/src/tests/test_buildercore_trop.py
@@ -407,6 +407,29 @@ class TestBuildercoreTrop(base.BaseCase):
             data['Resources']['CloudFrontCDN']['Properties']['DistributionConfig']['DefaultCacheBehavior']['ForwardedValues']['Cookies']
         )
 
+    def test_cdn_template_multiple_origins(self):
+        extra = {
+            'stackname': 'project-with-cloudfront-origins--prod',
+        }
+        context = cfngen.build_context('project-with-cloudfront-origins', **extra)
+        cfn_template = trop.render(context)
+        data = self._parse_json(cfn_template)
+        self.assertTrue('CloudFrontCDN' in data['Resources'].keys())
+        distribution_config = data['Resources']['CloudFrontCDN']['Properties']['DistributionConfig']
+        self.assertEquals(
+            [
+                {
+                    'CustomOriginConfig': {
+                        'HTTPSPort': 443,
+                        'OriginProtocolPolicy': 'https-only',
+                    },
+                    'DomainName': 'some-bucket.s3.amazonaws.com',
+                    'Id': 'some-bucket',
+                }
+            ],
+            distribution_config['Origins']
+        )
+
     def test_cdn_template_error_pages(self):
         extra = {
             'stackname': 'project-with-cloudfront-error-pages--prod',

--- a/src/tests/test_buildercore_trop.py
+++ b/src/tests/test_buildercore_trop.py
@@ -417,7 +417,7 @@ class TestBuildercoreTrop(base.BaseCase):
         self.assertTrue('CloudFrontCDN' in data['Resources'].keys())
         distribution_config = data['Resources']['CloudFrontCDN']['Properties']['DistributionConfig']
         self.assertEquals(
-            [ 'prod--cdn.example.org' ],
+            ['prod--cdn.example.org'],
             distribution_config['Aliases']
         )
         self.assertEquals(

--- a/src/tests/test_buildercore_trop.py
+++ b/src/tests/test_buildercore_trop.py
@@ -417,6 +417,10 @@ class TestBuildercoreTrop(base.BaseCase):
         self.assertTrue('CloudFrontCDN' in data['Resources'].keys())
         distribution_config = data['Resources']['CloudFrontCDN']['Properties']['DistributionConfig']
         self.assertEquals(
+            [ 'prod--cdn.example.org' ],
+            distribution_config['Aliases']
+        )
+        self.assertEquals(
             [
                 {
                     'CustomOriginConfig': {

--- a/src/tests/test_buildercore_trop.py
+++ b/src/tests/test_buildercore_trop.py
@@ -423,7 +423,7 @@ class TestBuildercoreTrop(base.BaseCase):
                         'HTTPSPort': 443,
                         'OriginProtocolPolicy': 'https-only',
                     },
-                    'DomainName': 'some-bucket.s3.amazonaws.com',
+                    'DomainName': 'prod--some-bucket.s3.amazonaws.com',
                     'Id': 'some-bucket',
                 }
             ],

--- a/src/tests/test_buildercore_trop.py
+++ b/src/tests/test_buildercore_trop.py
@@ -298,6 +298,7 @@ class TestBuildercoreTrop(base.BaseCase):
                 'compress': True,
                 'cookies': ['session_id'],
                 'headers': ['Accept'],
+                'origins': {},
                 'subdomains': ['prod--cdn-of-www', ''],
                 'subdomains-without-dns': ['future'],
                 'errors': None,


### PR DESCRIPTION
It is a CloudFront CDN with multiple, custom origins. 

- Supporting a default origin (the first one specified)
- Supporting parameterization of hostnames
- Supporting path pattern for custom origins (typically from the second cache behavior onwards)

The goal is to model with builder the cdn.elifesciences.org snowflake, at least for testing environments.