### PR TITLE
When we use bldr update, servers should be taken down one at a time

### DIFF
--- a/src/cfn.py
+++ b/src/cfn.py
@@ -48,7 +48,7 @@ def update(stackname, *service_list):
     instances = _check_want_to_be_running(stackname)
     if not instances:
         return
-    return bootstrap.update_stack(stackname, service_list)
+    return bootstrap.update_stack(stackname, service_list, concurrency='serial')
 
 @task
 @timeit


### PR DESCRIPTION
For example, this ensures journal's availability. Deploys already do this through bldr switch_revision_update_instance