### PR TITLE
Blue-green deployment

### DIFF
--- a/projects/elife.yaml
+++ b/projects/elife.yaml
@@ -216,6 +216,15 @@ journal:
     aws-alt:
         ci:
             type: t2.medium
+        end2endtest:
+            description: temporary environment for blue-green deployment testing
+            ec2:
+                cluster-size: 2
+            elb:
+                stickiness: true
+                protocol: 
+                    - https
+                    - http
         end2end:
             description: end2end environment for journal. ELB on top of multiple EC2 instances
             ec2:

--- a/src/buildercore/bluegreen.py
+++ b/src/buildercore/bluegreen.py
@@ -36,3 +36,13 @@ def find_load_balancer(stackname):
     balancers = [lb['LoadBalancerName'] for lb in tags if {'Key':'Cluster', 'Value': stackname} in lb['Tags']]
     ensure(len(balancers) == 1, "Expected to find exactly 1 load balancer, but found %s", balancers)
     return balancers[0]
+
+def divide_by_color(params):
+    is_blue = lambda node: node % 2 == 1
+    is_green = lambda node: node % 2 == 0
+    def subset(is_subset):
+        subset = params.copy()
+        subset['nodes'] = {id: node for (id, node) in params['nodes'].items() if is_subset(node)}
+        subset['public_ips'] = {id: ip for (id, ip) in params['public_ips'].items() if id in subset['nodes'].keys() }
+        return subset
+    return subset(is_blue), subset(is_green)

--- a/src/buildercore/bluegreen.py
+++ b/src/buildercore/bluegreen.py
@@ -3,16 +3,12 @@ from .core import boto_elb_conn
 from .utils import ensure
 from pprint import pprint
 
-def concurrency_work(single_node_work, params):
-    pprint(params)
-    #context = load_context(params['stackname'])
-    #pprint(context)
-    #assert context['elb'], "Only ELB stacks can perform blue-green deployment"
+def concurrency_work(single_node_work, nodes_params):
+    pprint(nodes_params)
+    #context = load_context(nodes_params['stackname'])
+    elb_name = find_load_balancer(nodes_params['stackname'])
     
     #waiter = conn.get_waiter('any_instance_in_service')
-    #instances = [
-    #    {'InstanceId': instance_id} for instance_id in params['nodes'].keys()
-    #]
     #waiter.wait(LoadBalancerName=lb, Instances=instances)
     #health = conn.describe_instance_health(LoadBalancerName=lb, Instances=instances)['InstanceStates']
     #pprint(health)
@@ -37,12 +33,22 @@ def find_load_balancer(stackname):
     ensure(len(balancers) == 1, "Expected to find exactly 1 load balancer, but found %s", balancers)
     return balancers[0]
 
-def divide_by_color(params):
+def divide_by_color(nodes_params):
     is_blue = lambda node: node % 2 == 1
     is_green = lambda node: node % 2 == 0
     def subset(is_subset):
-        subset = params.copy()
-        subset['nodes'] = {id: node for (id, node) in params['nodes'].items() if is_subset(node)}
-        subset['public_ips'] = {id: ip for (id, ip) in params['public_ips'].items() if id in subset['nodes'].keys() }
+        subset = nodes_params.copy()
+        subset['nodes'] = {id: node for (id, node) in nodes_params['nodes'].items() if is_subset(node)}
+        subset['public_ips'] = {id: ip for (id, ip) in nodes_params['public_ips'].items() if id in subset['nodes'].keys() }
         return subset
     return subset(is_blue), subset(is_green)
+
+def deregister(elb_name, nodes_params):
+    conn = boto_elb_conn('us-east-1')
+    instances = [
+        {'InstanceId': instance_id} for instance_id in nodes_params['nodes'].keys()
+    ]
+    conn.deregister_instances_from_load_balancer(
+        LoadBalancerName=elb_name,
+        Instances=instances,
+    )

--- a/src/buildercore/bluegreen.py
+++ b/src/buildercore/bluegreen.py
@@ -10,6 +10,10 @@ from .utils import ensure, call_while
 
 LOG = logging.getLogger(__name__)
 
+class BlueGreenConcurrency():
+    def __call__(self, single_node_work, nodes_params):
+        return concurrency_work(single_node_work, nodes_params)
+
 def concurrency_work(single_node_work, nodes_params):
     # TODO: region should come from context of nodes_params['stackname']
     # TODO: transform functions into methods of a class to pass region and/or connection in the constructor

--- a/src/buildercore/bluegreen.py
+++ b/src/buildercore/bluegreen.py
@@ -11,102 +11,94 @@ from .utils import ensure, call_while
 LOG = logging.getLogger(__name__)
 
 class BlueGreenConcurrency():
+    def __init__(self, region='us-east-1'):
+        self.conn = boto_elb_conn(region)
+
     def __call__(self, single_node_work, nodes_params):
-        return concurrency_work(single_node_work, nodes_params)
+        elb_name = self.find_load_balancer(nodes_params['stackname'])
+        blue, green = self.divide_by_color(nodes_params)
 
-def concurrency_work(single_node_work, nodes_params):
-    # TODO: region should come from context of nodes_params['stackname']
-    # TODO: transform functions into methods of a class to pass region and/or connection in the constructor
-    elb_name = find_load_balancer(nodes_params['stackname'])
-    blue, green = divide_by_color(nodes_params)
+        LOG.info("Blue phase on %s: %s", elb_name, self._instance_ids(blue))
+        self.deregister(elb_name, blue)
+        self.wait_deregistered_all(elb_name, blue)
+        parallel_work(single_node_work, blue)
 
-    LOG.info("Blue phase on %s: %s", elb_name, _instance_ids(blue))
-    deregister(elb_name, blue)
-    wait_deregistered_all(elb_name, blue)
-    parallel_work(single_node_work, blue)
+        # this is the window of time in which old and new servers overlap
+        self.register(elb_name, blue)
+        self.wait_registered_any(elb_name, blue)
 
-    # this is the window of time in which old and new servers overlap
-    register(elb_name, blue)
-    wait_registered_any(elb_name, blue)
+        LOG.info("Green phase on %s: %s", elb_name, self._instance_ids(blue))
+        self.deregister(elb_name, green)
+        self.wait_deregistered_all(elb_name, green)
+        parallel_work(single_node_work, green)
+        self.register(elb_name, green)
 
-    LOG.info("Green phase on %s: %s", elb_name, _instance_ids(blue))
-    deregister(elb_name, green)
-    wait_deregistered_all(elb_name, green)
-    parallel_work(single_node_work, green)
-    register(elb_name, green)
+        self.wait_registered_all(elb_name, nodes_params)
 
-    wait_registered_all(elb_name, nodes_params)
+    def find_load_balancer(self, stackname):
+        names = [lb['LoadBalancerName'] for lb in self.conn.describe_load_balancers()['LoadBalancerDescriptions']]
+        ensure(len(names) >= 1, "No load balancers found")
+        tags = self.conn.describe_tags(LoadBalancerNames=names)['TagDescriptions']
+        balancers = [lb['LoadBalancerName'] for lb in tags if {'Key': 'Cluster', 'Value': stackname} in lb['Tags']]
+        ensure(len(balancers) == 1, "Expected to find exactly 1 load balancer, but found %s", balancers)
+        return balancers[0]
 
-def find_load_balancer(stackname):
-    conn = boto_elb_conn('us-east-1')
-    names = [lb['LoadBalancerName'] for lb in conn.describe_load_balancers()['LoadBalancerDescriptions']]
-    ensure(len(names) >= 1, "No load balancers found")
-    tags = conn.describe_tags(LoadBalancerNames=names)['TagDescriptions']
-    balancers = [lb['LoadBalancerName'] for lb in tags if {'Key': 'Cluster', 'Value': stackname} in lb['Tags']]
-    ensure(len(balancers) == 1, "Expected to find exactly 1 load balancer, but found %s", balancers)
-    return balancers[0]
+    def divide_by_color(self, nodes_params):
+        is_blue = lambda node: node % 2 == 1
+        is_green = lambda node: node % 2 == 0
 
-def divide_by_color(nodes_params):
-    is_blue = lambda node: node % 2 == 1
-    is_green = lambda node: node % 2 == 0
+        def subset(is_subset):
+            subset = nodes_params.copy()
+            subset['nodes'] = {id: node for (id, node) in nodes_params['nodes'].items() if is_subset(node)}
+            subset['public_ips'] = {id: ip for (id, ip) in nodes_params['public_ips'].items() if id in subset['nodes'].keys()}
+            return subset
+        return subset(is_blue), subset(is_green)
 
-    def subset(is_subset):
-        subset = nodes_params.copy()
-        subset['nodes'] = {id: node for (id, node) in nodes_params['nodes'].items() if is_subset(node)}
-        subset['public_ips'] = {id: ip for (id, ip) in nodes_params['public_ips'].items() if id in subset['nodes'].keys()}
-        return subset
-    return subset(is_blue), subset(is_green)
-
-def register(elb_name, nodes_params):
-    LOG.info("Registering on %s: %s", elb_name, _instance_ids(nodes_params))
-    conn = boto_elb_conn('us-east-1')
-    conn.register_instances_with_load_balancer(
-        LoadBalancerName=elb_name,
-        Instances=_instances(nodes_params),
-    )
-
-def deregister(elb_name, nodes_params):
-    LOG.info("Deregistering on %s: %s", elb_name, _instance_ids(nodes_params))
-    conn = boto_elb_conn('us-east-1')
-    conn.deregister_instances_from_load_balancer(
-        LoadBalancerName=elb_name,
-        Instances=_instances(nodes_params),
-    )
-
-def wait_registered_any(elb_name, nodes_params):
-    LOG.info("Waiting for registration of any on %s: %s", elb_name, _instance_ids(nodes_params))
-    conn = boto_elb_conn('us-east-1')
-    # TODO: reimplement with call_while because polling interval cannot be customized
-    waiter = conn.get_waiter('any_instance_in_service')
-    waiter.wait(LoadBalancerName=elb_name, Instances=_instances(nodes_params))
-
-def wait_registered_all(elb_name, nodes_params):
-    LOG.info("Waiting for registration of all on %s: %s", elb_name, _instance_ids(nodes_params))
-    conn = boto_elb_conn('us-east-1')
-    # TODO: reimplement with call_while because polling interval cannot be customized
-    waiter = conn.get_waiter('instance_in_service')
-    waiter.wait(LoadBalancerName=elb_name, Instances=_instances(nodes_params))
-
-def wait_deregistered_all(elb_name, nodes_params):
-    LOG.info("Waiting for deregistration of all on %s: %s", elb_name, _instance_ids(nodes_params))
-
-    def condition():
-        conn = boto_elb_conn('us-east-1')
-        health = conn.describe_instance_health(
+    def register(self, elb_name, nodes_params):
+        LOG.info("Registering on %s: %s", elb_name, self._instance_ids(nodes_params))
+        self.conn.register_instances_with_load_balancer(
             LoadBalancerName=elb_name,
-            Instances=_instances(nodes_params)
-        )['InstanceStates']
-        registered = _registered(health)
-        LOG.info("InService: %s", registered)
-        return True in registered.values()
+            Instances=self._instances(nodes_params),
+        )
 
-    call_while(condition)
+    def deregister(self, elb_name, nodes_params):
+        LOG.info("Deregistering on %s: %s", elb_name, self._instance_ids(nodes_params))
+        self.conn.deregister_instances_from_load_balancer(
+            LoadBalancerName=elb_name,
+            Instances=self._instances(nodes_params),
+        )
 
-def _registered(health):
-    return {result['InstanceId']: result['State'] == 'InService' for result in health}
+    def wait_registered_any(self, elb_name, nodes_params):
+        LOG.info("Waiting for registration of any on %s: %s", elb_name, self._instance_ids(nodes_params))
+        # TODO: reimplement with call_while because polling interval cannot be customized
+        waiter = self.conn.get_waiter('any_instance_in_service')
+        waiter.wait(LoadBalancerName=elb_name, Instances=self._instances(nodes_params))
 
-def _instances(nodes_params):
-    return [{'InstanceId': instance_id} for instance_id in _instance_ids(nodes_params)]
+    def wait_registered_all(self, elb_name, nodes_params):
+        LOG.info("Waiting for registration of all on %s: %s", elb_name, self._instance_ids(nodes_params))
+        # TODO: reimplement with call_while because polling interval cannot be customized
+        waiter = self.conn.get_waiter('instance_in_service')
+        waiter.wait(LoadBalancerName=elb_name, Instances=self._instances(nodes_params))
 
-def _instance_ids(nodes_params):
-    return nodes_params['nodes'].keys()
+    def wait_deregistered_all(self, elb_name, nodes_params):
+        LOG.info("Waiting for deregistration of all on %s: %s", elb_name, self._instance_ids(nodes_params))
+
+        def condition():
+            health = self.conn.describe_instance_health(
+                LoadBalancerName=elb_name,
+                Instances=self._instances(nodes_params)
+            )['InstanceStates']
+            registered = self._registered(health)
+            LOG.info("InService: %s", registered)
+            return True in registered.values()
+
+        call_while(condition)
+
+    def _registered(self, health):
+        return {result['InstanceId']: result['State'] == 'InService' for result in health}
+
+    def _instances(self, nodes_params):
+        return [{'InstanceId': instance_id} for instance_id in self._instance_ids(nodes_params)]
+
+    def _instance_ids(self, nodes_params):
+        return nodes_params['nodes'].keys()

--- a/src/buildercore/bluegreen.py
+++ b/src/buildercore/bluegreen.py
@@ -1,3 +1,9 @@
+"""Performs blue-green actions over a load-balanced stack.
+
+The nodes inside a stack are divided into two groups: blue and green. Actions are performed separately on the two groups while they are detached from the load balancer. Obviously, requires a load balancer.
+
+nodes_params is a data structure (dictionary) .
+TODO: make nodes_params a named tuple"""
 import logging
 from .core import boto_elb_conn, parallel_work
 from .utils import ensure, call_while
@@ -6,9 +12,12 @@ from pprint import pprint
 LOG = logging.getLogger(__name__)
 
 def concurrency_work(single_node_work, nodes_params):
+    # TODO: region should come from context of nodes_params['stackname']
+    # TODO: transform functions into methods of a class to pass region and/or connection in the constructor
     elb_name = find_load_balancer(nodes_params['stackname'])
     blue, green = divide_by_color(nodes_params)
 
+    LOG.info("Blue phase on %s: %s", elb_name, _instance_ids(blue))
     deregister(elb_name, blue)
     wait_deregistered_all(elb_name, blue)
     parallel_work(single_node_work, blue)
@@ -17,6 +26,7 @@ def concurrency_work(single_node_work, nodes_params):
     register(elb_name, blue)
     wait_registered_any(elb_name, blue)
 
+    LOG.info("Green phase on %s: %s", elb_name, _instance_ids(blue))
     deregister(elb_name, green)
     wait_deregistered_all(elb_name, green)
     parallel_work(single_node_work, green)
@@ -44,6 +54,7 @@ def divide_by_color(nodes_params):
     return subset(is_blue), subset(is_green)
 
 def register(elb_name, nodes_params):
+    LOG.info("Registering on %s: %s", elb_name, _instance_ids(nodes_params))
     conn = boto_elb_conn('us-east-1')
     conn.register_instances_with_load_balancer(
         LoadBalancerName=elb_name,
@@ -51,27 +62,27 @@ def register(elb_name, nodes_params):
     )
 
 def deregister(elb_name, nodes_params):
+    LOG.info("Deregistering on %s: %s", elb_name, _instance_ids(nodes_params))
     conn = boto_elb_conn('us-east-1')
-    LOG.info("Deregistering: %s", nodes_params['nodes'].keys())
-    instances = [
-        {'InstanceId': instance_id} for instance_id in nodes_params['nodes'].keys()
-    ]
     conn.deregister_instances_from_load_balancer(
         LoadBalancerName=elb_name,
         Instances=_instances(nodes_params),
     )
 
 def wait_registered_any(elb_name, nodes_params):
+    LOG.info("Waiting for registration of any on %s: %s", elb_name, _instance_ids(nodes_params))
     conn = boto_elb_conn('us-east-1')
     waiter = conn.get_waiter('any_instance_in_service')
     waiter.wait(LoadBalancerName=elb_name, Instances=_instances(nodes_params))
 
 def wait_registered_all(elb_name, nodes_params):
+    LOG.info("Waiting for registration of all on %s: %s", elb_name, _instance_ids(nodes_params))
     conn = boto_elb_conn('us-east-1')
     waiter = conn.get_waiter('instance_in_service')
     waiter.wait(LoadBalancerName=elb_name, Instances=_instances(nodes_params))
 
 def wait_deregistered_all(elb_name, nodes_params):
+    LOG.info("Waiting for deregistration of all on %s: %s", elb_name, _instance_ids(nodes_params))
     instance_ids = nodes_params['nodes'].keys()
     def condition():
         conn = boto_elb_conn('us-east-1')
@@ -89,4 +100,8 @@ def _registered(health):
     return {result['InstanceId']:result['State']=='InService' for result in health}
 
 def _instances(nodes_params):
-    return [{'InstanceId': instance_id} for instance_id in nodes_params['nodes'].keys()]
+    return [{'InstanceId': instance_id} for instance_id in _instance_ids(nodes_params)]
+
+def _instance_ids(nodes_params):
+    return nodes_params['nodes'].keys()
+

--- a/src/buildercore/bluegreen.py
+++ b/src/buildercore/bluegreen.py
@@ -1,0 +1,37 @@
+#from .context_handler import load_context
+from .core import boto_elb_conn
+from pprint import pprint
+
+def concurrency_work(single_node_work, params):
+    pprint(params)
+    #context = load_context(params['stackname'])
+    #pprint(context)
+    #assert context['elb'], "Only ELB stacks can perform blue-green deployment"
+    
+    lb = find_load_balancer(params['stackname'])
+    #waiter = conn.get_waiter('any_instance_in_service')
+    #instances = [
+    #    {'InstanceId': instance_id} for instance_id in params['nodes'].keys()
+    #]
+    #waiter.wait(LoadBalancerName=lb, Instances=instances)
+    #health = conn.describe_instance_health(LoadBalancerName=lb, Instances=instances)['InstanceStates']
+    #pprint(health)
+    # 1. separate blue from green
+    # 2. deregister blue
+    # 2.1 wait, yes because of connection draining
+    # 3. perform single_node_work in parallel on blue
+    # 4. register blue
+    # 4.1 wait, yes, with waiter any_instance_in_service
+    # 5. deregister green
+    # 5.1 wait, yes because of connection draining
+    # 6. perform single_node_work in parallel on green
+    # 7. register green
+    # 7.1 wait, yes, with all_instances_in_service
+
+def find_load_balancer(stackname):
+    conn = boto_elb_conn('us-east-1')
+    names = [lb['LoadBalancerName'] for lb in conn.describe_load_g()['LoadBalancerDescriptions']]
+    tags = conn.describe_tags(LoadBalancerNames=names)['TagDescriptions']
+    balancers = [lb['LoadBalancerName'] for lb in tags if {'Key':'Cluster', 'Value': stackname} in lb['Tags']]
+    assert len(balancers) == 1, "Expected to find exactly 1 load balancer, but found %s" % balancers
+    return balancers[0]

--- a/src/buildercore/bluegreen.py
+++ b/src/buildercore/bluegreen.py
@@ -10,8 +10,8 @@ from .utils import ensure, call_while
 
 LOG = logging.getLogger(__name__)
 
-class BlueGreenConcurrency():
-    def __init__(self, region='us-east-1'):
+class BlueGreenConcurrency(object):
+    def __init__(self, region):
         self.conn = boto_elb_conn(region)
 
     def __call__(self, single_node_work, nodes_params):

--- a/src/buildercore/bluegreen.py
+++ b/src/buildercore/bluegreen.py
@@ -76,7 +76,9 @@ class BlueGreenConcurrency(object):
             LOG.info("InService: %s", registered)
             return True not in registered.values()
 
-        call_while(condition)
+        # needs to be as responsive as possible,
+        # to start deregistering the green group as soon as a blue server becomes available
+        call_while(condition, interval=1, timeout=600)
 
     def wait_registered_all(self, elb_name, nodes_params):
         LOG.info("Waiting for registration of all on %s: %s", elb_name, self._instance_ids(nodes_params))
@@ -86,7 +88,7 @@ class BlueGreenConcurrency(object):
             LOG.info("InService: %s", registered)
             return False in registered.values()
 
-        call_while(condition)
+        call_while(condition, interval=5, timeout=600)
 
     def wait_deregistered_all(self, elb_name, nodes_params):
         LOG.info("Waiting for deregistration of all on %s: %s", elb_name, self._instance_ids(nodes_params))
@@ -96,7 +98,7 @@ class BlueGreenConcurrency(object):
             LOG.info("InService: %s", registered)
             return True in registered.values()
 
-        call_while(condition)
+        call_while(condition, interval=5, timeout=600)
 
     def _registered(self, elb_name, nodes_params):
         health = self.conn.describe_instance_health(

--- a/src/buildercore/bluegreen.py
+++ b/src/buildercore/bluegreen.py
@@ -72,12 +72,14 @@ def deregister(elb_name, nodes_params):
 def wait_registered_any(elb_name, nodes_params):
     LOG.info("Waiting for registration of any on %s: %s", elb_name, _instance_ids(nodes_params))
     conn = boto_elb_conn('us-east-1')
+    # TODO: reimplement with call_while because polling interval cannot be customized
     waiter = conn.get_waiter('any_instance_in_service')
     waiter.wait(LoadBalancerName=elb_name, Instances=_instances(nodes_params))
 
 def wait_registered_all(elb_name, nodes_params):
     LOG.info("Waiting for registration of all on %s: %s", elb_name, _instance_ids(nodes_params))
     conn = boto_elb_conn('us-east-1')
+    # TODO: reimplement with call_while because polling interval cannot be customized
     waiter = conn.get_waiter('instance_in_service')
     waiter.wait(LoadBalancerName=elb_name, Instances=_instances(nodes_params))
 

--- a/src/buildercore/bluegreen.py
+++ b/src/buildercore/bluegreen.py
@@ -50,5 +50,15 @@ def deregister(elb_name, nodes_params):
     ]
     conn.deregister_instances_from_load_balancer(
         LoadBalancerName=elb_name,
-        Instances=instances,
+        Instances=_instances(nodes_params),
     )
+
+def register(elb_name, nodes_params):
+    conn = boto_elb_conn('us-east-1')
+    conn.register_instances_from_load_balancer(
+        LoadBalancerName=elb_name,
+        Instances=_instances(nodes_params),
+    )
+
+def _instances(nodes_params):
+    return [{'InstanceId': instance_id} for instance_id in nodes_params['nodes'].keys()]

--- a/src/buildercore/concurrency.py
+++ b/src/buildercore/concurrency.py
@@ -1,0 +1,22 @@
+from . import bluegreen, context_handler
+
+# TODO: move as buildercore.concurrency.concurrency_for
+def concurrency_for(stackname, concurrency_name):
+    """concurrency default is to perform updates one machine at a time.
+
+    Concurrency can be:
+    - serial: one at a time
+    - parallel: all together
+    - blue-green: 50% at a time"""
+
+    if concurrency_name == 'blue-green':
+        context = context_handler.load_context(stackname)
+        return bluegreen.BlueGreenConcurrency(context['project']['aws']['region'])
+    if concurrency_name == 'serial' or concurrency_name == 'parallel':
+        # maybe return a fabric object in the future
+        return concurrency_name
+
+    if concurrency_name is None:
+        return 'parallel'
+
+    raise ValueError("Concurrency %s is not supported" % concurrency_name)

--- a/src/buildercore/context_handler.py
+++ b/src/buildercore/context_handler.py
@@ -5,8 +5,6 @@ from os.path import join
 from . import config, s3
 from .decorators import if_enabled
 
-from .utils import hasallkeys, missingkeys, ensure, exsubdict
-
 import logging
 LOG = logging.getLogger(__name__)
 

--- a/src/buildercore/context_handler.py
+++ b/src/buildercore/context_handler.py
@@ -5,8 +5,6 @@ from os.path import join
 from . import config, s3
 from .decorators import if_enabled
 
-# only needed for _fallback_download_context_from_ec2:
-from . import core, bvars
 from .utils import hasallkeys, missingkeys, ensure, exsubdict
 
 import logging
@@ -24,18 +22,8 @@ def load_context(stackname):
     path = local_context_file(stackname)
     if not os.path.exists(path):
         if not download_from_s3(stackname):
-            _fallback_download_context_from_ec2(stackname)
+            raise RuntimeError("We are missing the context file for %s, even on S3" % stackname)
     return json.load(open(path, 'r'))
-
-def _fallback_download_context_from_ec2(stackname):
-    LOG.warn("Context for %s was not on S3, downloading it from EC2 and uploading it", stackname)
-    with core.stack_conn(stackname):
-        build_vars = dict(bvars.read_from_current_host())
-        context = exsubdict(build_vars, ['node', 'nodename'])
-        required_keys = ['full_hostname', 'domain', 'int_full_hostname', 'int_domain']
-        ensure(hasallkeys(context, required_keys), "Context missing keys %s: %s" %
-               (missingkeys(context, required_keys), context))
-        write_context(stackname, context)
 
 def write_context(stackname, context):
     write_context_locally(stackname, json.dumps(context))

--- a/src/buildercore/core.py
+++ b/src/buildercore/core.py
@@ -20,7 +20,7 @@ from kids.cache import cache as cached
 from slugify import slugify
 
 LOG = logging.getLogger(__name__)
-boto3.set_stream_logger(name='botocore')
+boto3.set_stream_logger(name='botocore', level=logging.INFO)
 
 class DeprecationException(Exception):
     pass

--- a/src/buildercore/core.py
+++ b/src/buildercore/core.py
@@ -107,6 +107,11 @@ def boto_ec2_conn(region):
     return connect_aws('ec2', region)
 
 @cached
+def boto_elb_conn(region):
+    "This uses boto3 because it allows to read tags on ELB and associate them to a stackname"
+    return boto3.client('elb', region)
+
+@cached
 def boto_sns_conn(region):
     return connect_aws('sns', region)
 

--- a/src/buildercore/core.py
+++ b/src/buildercore/core.py
@@ -246,16 +246,6 @@ def stack_all_ec2_nodes(stackname, workfn, username=config.DEPLOY_USER, concurre
 
     ensure(None not in public_ips.values(), "Public ips are not valid: %s", public_ips, exception_class=NoPublicIps)
 
-    # def decorate_with_concurrency():
-    #    if not concurrency:
-    #        return parallel
-    #    if concurrency == 'serial':
-    #        return serial
-    #    if concurrency == 'parallel':
-    #        return parallel
-    #    raise RuntimeError("Concurrency mode not supported: %s" % concurrency)
-
-    #@decorate_with_concurrency()
     def single_node_work():
         try:
             return workfn(**work_kwargs)
@@ -266,6 +256,7 @@ def stack_all_ec2_nodes(stackname, workfn, username=config.DEPLOY_USER, concurre
             else:
                 raise err
 
+    # TODO: extract in buildercore.concurrency
     if not concurrency:
         concurrency = 'parallel'
     if concurrency == 'serial':

--- a/src/buildercore/core.py
+++ b/src/buildercore/core.py
@@ -269,20 +269,20 @@ def stack_all_ec2_nodes(stackname, workfn, username=config.DEPLOY_USER, concurre
     if not concurrency:
         concurrency = 'parallel'
     if concurrency == 'serial':
-        return _serial_work(single_node_work, params, public_ips)
+        return serial_work(single_node_work, params)
     if concurrency == 'parallel':
-        return _parallel_work(single_node_work, params, public_ips)
+        return parallel_work(single_node_work, params)
     if callable(concurrency):
         return concurrency(single_node_work, params)
     raise RuntimeError("Concurrency mode not supported: %s" % concurrency)
 
-def _serial_work(single_node_work, params, public_ips):
+def serial_work(single_node_work, params):
     with settings(**params):
-        return execute(serial(single_node_work), hosts=public_ips.values())
+        return execute(serial(single_node_work), hosts=params['public_ips'].values())
 
-def _parallel_work(single_node_work, params, public_ips):
+def parallel_work(single_node_work, params):
     with settings(**params):
-        return execute(parallel(single_node_work), hosts=public_ips.values())
+        return execute(parallel(single_node_work), hosts=params['public_ips'].values())
 
 def current_ec2_node_id():
     """Assumes it is called inside the 'workfn' of a 'stack_all_ec2_nodes'.

--- a/src/buildercore/core.py
+++ b/src/buildercore/core.py
@@ -246,7 +246,7 @@ def stack_all_ec2_nodes(stackname, workfn, username=config.DEPLOY_USER, concurre
 
     ensure(None not in public_ips.values(), "Public ips are not valid: %s", public_ips, exception_class=NoPublicIps)
 
-    #def decorate_with_concurrency():
+    # def decorate_with_concurrency():
     #    if not concurrency:
     #        return parallel
     #    if concurrency == 'serial':

--- a/src/buildercore/s3.py
+++ b/src/buildercore/s3.py
@@ -1,7 +1,8 @@
 import os
 import boto
+from boto import s3
 from boto.s3.key import Key
-from . import core, config
+from . import config
 from kids.cache import cache as cached
 
 import logging
@@ -10,7 +11,7 @@ LOG = logging.getLogger(__name__)
 
 def connect_s3():
     # we'll need to deal with this assumption
-    return core.connect_aws('s3', 'us-east-1')  # Location.USWest2)
+    return s3.connect_to_region('us-east-1')  # Location.USWest2)
 
 @cached
 def builder_bucket():

--- a/src/buildercore/trop.py
+++ b/src/buildercore/trop.py
@@ -454,9 +454,6 @@ def _add_bucket_policy(template, bucket_title, bucket_name):
     ))
 
 def render_elb(context, template, ec2_instances):
-    ensure(any([context['full_hostname'], context['int_full_hostname']]),
-           "An ELB must have either an external or an internal DNS entry")
-
     elb_is_public = True if context['full_hostname'] else False
     listeners_policy_names = []
 
@@ -536,8 +533,9 @@ def render_elb(context, template, ec2_instances):
         elb_ports
     )) # list of strings or dicts
 
-    dns = external_dns_elb if elb_is_public else internal_dns_elb
-    template.add_resource(dns(context))
+    if any([context['full_hostname'], context['int_full_hostname']]):
+        dns = external_dns_elb if elb_is_public else internal_dns_elb
+        template.add_resource(dns(context))
 
 def render_cloudfront(context, template, origin_hostname):
     allowed_cnames = [

--- a/src/cfn.py
+++ b/src/cfn.py
@@ -6,6 +6,7 @@ from fabric.contrib import files
 import aws, utils
 from decorators import requires_project, requires_aws_stack, requires_steady_stack, echo_output, setdefault, debugtask, timeit
 from buildercore import core, cfngen, utils as core_utils, bootstrap, project, checks, lifecycle as core_lifecycle, context_handler
+from buildercore.concurrency import concurrency_for
 from buildercore.core import stack_conn, stack_pem, stack_all_ec2_nodes
 from buildercore.decorators import PredicateException
 from buildercore.config import DEPLOY_USER, BOOTSTRAP_USER, FabricException
@@ -287,7 +288,7 @@ def cmd(stackname, command=None, username=DEPLOY_USER, clean_output=False, concu
             (run, {'command': command}),
             username=username,
             abort_on_prompts=True,
-            concurrency=concurrency)
+            concurrency=concurrency_for(stackname, concurrency))
 
 @task
 def project_list():

--- a/src/deploy.py
+++ b/src/deploy.py
@@ -3,7 +3,7 @@
 from fabric.api import task
 from decorators import requires_branch_deployable_project, echo_output, setdefault, deffile, requires_aws_stack, timeit
 import utils
-from buildercore import core, bootstrap, cfngen, project, bluegreen
+from buildercore import core, bootstrap, cfngen, project, bluegreen, context_handler
 import buildvars
 
 import logging
@@ -56,6 +56,7 @@ def switch_revision_update_instance(stackname, revision=None, concurrency='seria
     - parallel
     - blue-green"""
     buildvars.switch_revision(stackname, revision)
+    context = context_handler.load_context(stackname)
     if concurrency == 'blue-green':
-        concurrency = bluegreen.BlueGreenConcurrency('us-east-1')
+        concurrency = bluegreen.BlueGreenConcurrency(context['project']['aws']['region'])
     bootstrap.update_stack(stackname, concurrency=concurrency)

--- a/src/deploy.py
+++ b/src/deploy.py
@@ -57,5 +57,5 @@ def switch_revision_update_instance(stackname, revision=None, concurrency='seria
     - blue-green"""
     buildvars.switch_revision(stackname, revision)
     if concurrency == 'blue-green':
-        concurrency = bluegreen.concurrency_work
+        concurrency = bluegreen.BlueGreenConcurrency()
     bootstrap.update_stack(stackname, concurrency=concurrency)

--- a/src/deploy.py
+++ b/src/deploy.py
@@ -57,5 +57,5 @@ def switch_revision_update_instance(stackname, revision=None, concurrency='seria
     - blue-green"""
     buildvars.switch_revision(stackname, revision)
     if concurrency == 'blue-green':
-        concurrency = bluegreen.BlueGreenConcurrency()
+        concurrency = bluegreen.BlueGreenConcurrency('us-east-1')
     bootstrap.update_stack(stackname, concurrency=concurrency)

--- a/src/deploy.py
+++ b/src/deploy.py
@@ -50,7 +50,7 @@ def deploy(pname, instance_id=None, branch='master', part_filter=None):
 @requires_aws_stack
 def switch_revision_update_instance(stackname, revision=None, concurrency='serial'):
     """concurrency default is to perform updates one machine at a time.
-    
+
     Concurrency can be:
     - serial
     - parallel
@@ -59,4 +59,3 @@ def switch_revision_update_instance(stackname, revision=None, concurrency='seria
     if concurrency == 'blue-green':
         concurrency = bluegreen.concurrency_work
     bootstrap.update_stack(stackname, concurrency=concurrency)
-

--- a/src/integration_tests/test_provisioning.py
+++ b/src/integration_tests/test_provisioning.py
@@ -38,7 +38,7 @@ class TestProvisioning(base.BaseCase):
             lifecycle.stop(stackname)
             lifecycle.start(stackname)
 
-            cfn.cmd(stackname, "ls -l", username=BOOTSTRAP_USER, concurrency='parallel')
+            cfn.cmd(stackname, "ls -l /", username=BOOTSTRAP_USER, concurrency='parallel')
 
 class TestDeployment(base.BaseCase):
     def setUp(self):
@@ -49,9 +49,10 @@ class TestDeployment(base.BaseCase):
         for stackname in self.stacknames:
             cfn.ensure_destroyed(stackname)
 
-    def _test_blue_green_operations(self):
+    # takes too long, tens of minutes
+    def test_blue_green_operations(self):
         with settings(abort_on_prompts=True):
-            project = 'project-with-cluster'
+            project = 'project-with-cluster-integration-tests'
             stackname = '%s--%s' % (project, self.environment)
 
             cfn.ensure_destroyed(stackname)
@@ -59,4 +60,5 @@ class TestDeployment(base.BaseCase):
             cfngen.generate_stack(project, stackname=stackname)
             bootstrap.create_stack(stackname)
 
-            # operate with bluegreen module
+            output = cfn.cmd(stackname, 'ls -l /', username=BOOTSTRAP_USER, concurrency='blue-green')
+            print output

--- a/src/integration_tests/test_provisioning.py
+++ b/src/integration_tests/test_provisioning.py
@@ -49,7 +49,6 @@ class TestDeployment(base.BaseCase):
         for stackname in self.stacknames:
             cfn.ensure_destroyed(stackname)
 
-    # takes too long, tens of minutes
     def test_blue_green_operations(self):
         with settings(abort_on_prompts=True):
             project = 'project-with-cluster-integration-tests'

--- a/src/integration_tests/test_provisioning.py
+++ b/src/integration_tests/test_provisioning.py
@@ -7,12 +7,15 @@ from buildercore.config import BOOTSTRAP_USER
 import buildvars
 import cfn
 
+def generate_environment_name():
+    """to avoid multiple people clashing while running their builds
+       and new builds clashing with older ones"""
+    return check_output('whoami').rstrip() + datetime.utcnow().strftime("%Y%m%d%H%M%S")
+
 class TestProvisioning(base.BaseCase):
     def setUp(self):
         self.stacknames = []
-        # to avoid multiple people clashing while running their builds
-        # and new builds clashing with older ones
-        self.environment = check_output('whoami').rstrip() + datetime.utcnow().strftime("%Y%m%d%H%M%S")
+        self.environment = generate_environment_name()
 
     def tearDown(self):
         for stackname in self.stacknames:
@@ -24,7 +27,7 @@ class TestProvisioning(base.BaseCase):
             stackname = '%s--%s' % (project, self.environment)
 
             cfn.ensure_destroyed(stackname)
-            self.stacknames.append(stackname) # ensures stack is destroyed
+            self.stacknames.append(stackname)
 
             cfngen.generate_stack(project, stackname=stackname)
             bootstrap.create_stack(stackname)
@@ -36,3 +39,24 @@ class TestProvisioning(base.BaseCase):
             lifecycle.start(stackname)
 
             cfn.cmd(stackname, "ls -l", username=BOOTSTRAP_USER, concurrency='parallel')
+
+class TestDeployment(base.BaseCase):
+    def setUp(self):
+        self.stacknames = []
+        self.environment = generate_environment_name()
+
+    def tearDown(self):
+        for stackname in self.stacknames:
+            cfn.ensure_destroyed(stackname)
+
+    def _test_blue_green_operations(self):
+        with settings(abort_on_prompts=True):
+            project = 'project-with-cluster'
+            stackname = '%s--%s' % (project, self.environment)
+
+            cfn.ensure_destroyed(stackname)
+            self.stacknames.append(stackname)
+            cfngen.generate_stack(project, stackname=stackname)
+            bootstrap.create_stack(stackname)
+
+            # operate with bluegreen module

--- a/src/tests/fixtures/projects/dummy-project.yaml
+++ b/src/tests/fixtures/projects/dummy-project.yaml
@@ -273,6 +273,24 @@ project-with-cluster:
         elb: 
             protocol: http
 
+project-with-cluster-integration-tests:
+    repo: ssh://git@github.com/elifesciences/dummy3
+    subdomain: project-with-cluster
+    # no dummy domains since we really create this on CloudFormation
+    domain: false
+    intdomain: false
+    aws:
+        ports:
+            - 80
+            - 22
+        ec2:
+            cluster-size: 2
+        elb: 
+            protocol: http
+            healthcheck:
+                protocol: tcp
+                port: 22
+
 project-with-db-params:
     repo: ssh://git@github.com/elifesciences/dummy3
     aws:

--- a/src/tests/test_buildercore_bluegreen.py
+++ b/src/tests/test_buildercore_bluegreen.py
@@ -1,0 +1,25 @@
+from buildercore import bluegreen
+from . import base
+from mock import patch, MagicMock
+
+class Primitives(base.BaseCase):
+    @patch('buildercore.bluegreen.boto_elb_conn')
+    def test_find_load_balancer(self, elb_conn):
+        conn = MagicMock()
+        elb_conn.return_value = conn
+        conn.describe_load_balancers.return_value = {
+            'LoadBalancerDescriptions': [
+                { 'LoadBalancerName': 'dummy1-ElasticL-ABCDEFGHI' }
+            ]
+        }
+        conn.describe_tags.return_value = {
+            'TagDescriptions' : [
+                {
+                    'LoadBalancerName': 'dummy1-ElasticL-ABCDEFGHI',
+                    'Tags': [
+                        {'Key': 'Cluster', 'Value': 'dummy1--test'},
+                    ]
+                }
+            ]
+        }
+        elb = bluegreen.find_load_balancer('dummy1--test')

--- a/src/tests/test_buildercore_bluegreen.py
+++ b/src/tests/test_buildercore_bluegreen.py
@@ -101,6 +101,50 @@ class Primitives(base.BaseCase):
             Instances=[{'InstanceId': 'i-10000001'}, {'InstanceId': 'i-10000002'}]
         )
 
+    def test_wait_registered_any(self):
+        nodes_params = {
+            'nodes': OrderedDict([
+                ('i-10000001', 1),
+                ('i-10000002', 2),
+            ]),
+            # ...
+        }
+        self.conn.describe_instance_health.return_value = {
+            'InstanceStates': [
+                {
+                    'InstanceId': 'i-10000001',
+                    'State': 'InService',
+                },
+                {
+                    'InstanceId': 'i-10000002',
+                    'State': 'OutOfService',
+                },
+            ],
+        }
+        self.concurrency.wait_registered_any('dummy1-ElasticL-ABCDEFGHI', nodes_params)
+
+    def test_wait_registered_all(self):
+        nodes_params = {
+            'nodes': OrderedDict([
+                ('i-10000001', 1),
+                ('i-10000002', 2),
+            ]),
+            # ...
+        }
+        self.conn.describe_instance_health.return_value = {
+            'InstanceStates': [
+                {
+                    'InstanceId': 'i-10000001',
+                    'State': 'InService',
+                },
+                {
+                    'InstanceId': 'i-10000002',
+                    'State': 'InService',
+                },
+            ],
+        }
+        self.concurrency.wait_registered_all('dummy1-ElasticL-ABCDEFGHI', nodes_params)
+
     def test_wait_deregistered_all(self):
         nodes_params = {
             'nodes': OrderedDict([

--- a/src/tests/test_buildercore_bluegreen.py
+++ b/src/tests/test_buildercore_bluegreen.py
@@ -24,3 +24,45 @@ class Primitives(base.BaseCase):
         }
         name = bluegreen.find_load_balancer('dummy1--test')
         self.assertEquals(name, 'dummy1-ElasticL-ABCDEFGHI')
+
+    def test_divide_by_color(self):
+        params = {
+            'key_filename': './dummy1--test.pem',
+            'nodes': {
+                'i-10000001': 1,
+                'i-10000002': 2,
+            },
+            'public_ips': {
+                'i-10000001': '127.0.0.1',
+                'i-10000002': '127.0.0.2',
+            },
+            'stackname': 'dummy1--test',
+            'user': 'ubuntu'
+        }
+        self.assertEquals(
+            bluegreen.divide_by_color(params),
+            (
+                {
+                    'key_filename': './dummy1--test.pem',
+                    'nodes': {
+                        'i-10000001': 1,
+                    },
+                    'public_ips': {
+                        'i-10000001': '127.0.0.1',
+                    },
+                    'stackname': 'dummy1--test',
+                    'user': 'ubuntu'
+                },
+                {
+                    'key_filename': './dummy1--test.pem',
+                    'nodes': {
+                        'i-10000002': 2,
+                    },
+                    'public_ips': {
+                        'i-10000002': '127.0.0.2',
+                    },
+                    'stackname': 'dummy1--test',
+                    'user': 'ubuntu'
+                }
+            )
+        )

--- a/src/tests/test_buildercore_bluegreen.py
+++ b/src/tests/test_buildercore_bluegreen.py
@@ -94,7 +94,7 @@ class Primitives(base.BaseCase):
             # ...
         }
         bluegreen.register('dummy1-ElasticL-ABCDEFGHI', nodes_params)
-        conn.register_instances_from_load_balancer.assert_called_once_with(
+        conn.register_instances_with_load_balancer.assert_called_once_with(
             LoadBalancerName='dummy1-ElasticL-ABCDEFGHI',
             Instances=[{'InstanceId': 'i-10000001'}, {'InstanceId': 'i-10000002'}]
         )

--- a/src/tests/test_buildercore_bluegreen.py
+++ b/src/tests/test_buildercore_bluegreen.py
@@ -10,6 +10,7 @@ class Primitives(base.BaseCase):
         elb_conn_factory = patcher.start()
         self.conn = MagicMock()
         elb_conn_factory.return_value = self.conn
+        self.concurrency = bluegreen.BlueGreenConcurrency('us-east-1')
 
     def test_find_load_balancer(self):
         self.conn.describe_load_balancers.return_value = {
@@ -27,7 +28,7 @@ class Primitives(base.BaseCase):
                 }
             ]
         }
-        name = bluegreen.find_load_balancer('dummy1--test')
+        name = self.concurrency.find_load_balancer('dummy1--test')
         self.assertEquals(name, 'dummy1-ElasticL-ABCDEFGHI')
 
     def test_divide_by_color(self):
@@ -45,7 +46,7 @@ class Primitives(base.BaseCase):
             'user': 'ubuntu'
         }
         self.assertEquals(
-            bluegreen.divide_by_color(nodes_params),
+            self.concurrency.divide_by_color(nodes_params),
             (
                 {
                     'key_filename': './dummy1--test.pem',
@@ -80,7 +81,7 @@ class Primitives(base.BaseCase):
             ]),
             # ...
         }
-        bluegreen.deregister('dummy1-ElasticL-ABCDEFGHI', nodes_params)
+        self.concurrency.deregister('dummy1-ElasticL-ABCDEFGHI', nodes_params)
         self.conn.deregister_instances_from_load_balancer.assert_called_once_with(
             LoadBalancerName='dummy1-ElasticL-ABCDEFGHI',
             Instances=[{'InstanceId': 'i-10000001'}, {'InstanceId': 'i-10000002'}]
@@ -94,7 +95,7 @@ class Primitives(base.BaseCase):
             ]),
             # ...
         }
-        bluegreen.register('dummy1-ElasticL-ABCDEFGHI', nodes_params)
+        self.concurrency.register('dummy1-ElasticL-ABCDEFGHI', nodes_params)
         self.conn.register_instances_with_load_balancer.assert_called_once_with(
             LoadBalancerName='dummy1-ElasticL-ABCDEFGHI',
             Instances=[{'InstanceId': 'i-10000001'}, {'InstanceId': 'i-10000002'}]
@@ -120,4 +121,4 @@ class Primitives(base.BaseCase):
                 },
             ],
         }
-        bluegreen.wait_deregistered_all('dummy1-ElasticL-ABCDEFGHI', nodes_params)
+        self.concurrency.wait_deregistered_all('dummy1-ElasticL-ABCDEFGHI', nodes_params)

--- a/src/tests/test_buildercore_bluegreen.py
+++ b/src/tests/test_buildercore_bluegreen.py
@@ -99,6 +99,30 @@ class Primitives(base.BaseCase):
             Instances=[{'InstanceId': 'i-10000001'}, {'InstanceId': 'i-10000002'}]
         )
 
+    @patch('buildercore.bluegreen.boto_elb_conn')
+    def test_wait_deregistered_all(self, elb_conn_factory):
+        conn = self._conn_mock(elb_conn_factory)
+        nodes_params = {
+            'nodes': OrderedDict([
+                ('i-10000001', 1),
+                ('i-10000002', 2),
+            ]),
+            # ...
+        }
+        conn.describe_instance_health.return_value = {
+            'InstanceStates': [
+                {
+                    'InstanceId': 'i-10000001',
+                    'State': 'OutOfService',
+                },
+                {
+                    'InstanceId': 'i-10000002',
+                    'State': 'OutOfService',
+                },
+            ],
+        }
+        bluegreen.wait_deregistered_all('dummy1-ElasticL-ABCDEFGHI', nodes_params)
+
     def _conn_mock(self, elb_conn_factory):
         conn = MagicMock()
         elb_conn_factory.return_value = conn

--- a/src/tests/test_buildercore_bluegreen.py
+++ b/src/tests/test_buildercore_bluegreen.py
@@ -22,4 +22,5 @@ class Primitives(base.BaseCase):
                 }
             ]
         }
-        elb = bluegreen.find_load_balancer('dummy1--test')
+        name = bluegreen.find_load_balancer('dummy1--test')
+        self.assertEquals(name, 'dummy1-ElasticL-ABCDEFGHI')

--- a/src/tests/test_buildercore_bluegreen.py
+++ b/src/tests/test_buildercore_bluegreen.py
@@ -9,11 +9,11 @@ class Primitives(base.BaseCase):
         conn = self._conn_mock(elb_conn_factory)
         conn.describe_load_balancers.return_value = {
             'LoadBalancerDescriptions': [
-                { 'LoadBalancerName': 'dummy1-ElasticL-ABCDEFGHI' }
+                {'LoadBalancerName': 'dummy1-ElasticL-ABCDEFGHI'}
             ]
         }
         conn.describe_tags.return_value = {
-            'TagDescriptions' : [
+            'TagDescriptions': [
                 {
                     'LoadBalancerName': 'dummy1-ElasticL-ABCDEFGHI',
                     'Tags': [

--- a/src/tests/test_buildercore_project.py
+++ b/src/tests/test_buildercore_project.py
@@ -10,7 +10,7 @@ ALL_PROJECTS = [
     'just-some-sns', 'project-with-sqs', 'project-with-s3',
     'project-with-ext', 'project-with-cloudfront', 'project-with-cloudfront-minimal',
     'project-with-cloudfront-error-pages', 'project-with-cloudfront-origins', 'project-with-cluster',
-    'project-with-db-params',
+    'project-with-cluster-integration-tests', 'project-with-db-params',
 ]
 
 class TestProject(base.BaseCase):


### PR DESCRIPTION
Blue-green deployment operates on half the nodes into a cluster at a time, providing:
- (almost) atomic deploy: no multiple versions present at the same time in production
- maximum speed of deploy: only twice the amount of time to deploy on a single node
but sacrificing:
- resource efficiency: during deploy only half the instances remain in use
- simplicity: it's a more involved process to explicitly register and deregister instances from the load balancer

We need this for journal, to avoid the problems described in https://elifesciences.atlassian.net/browse/ELPP-2584?focusedCommentId=22515&page=com.atlassian.jira.plugin.system.issuetabpanels:comment-tabpanel#comment-22515 where HTML coming from a new server loads assets from a server that still has the old code.

Three concurrency models emerge:
- serial: do work on one server at a time
- parallel: do work on all servers at the same time
- blue-green: do work on 50% of the servers, then the other 50%.