### PR TITLE
DefaultTTL set to 0 seconds

### DIFF
--- a/projects/elife.yaml
+++ b/projects/elife.yaml
@@ -97,7 +97,7 @@ defaults:
             compress: true
             headers: []
             errors: null
-            default-ttl: 300 # seconds
+            default-ttl: 0 # seconds
     aws-alt:
         fresh:
             description: uses a plain Ubuntu basebox instead of an ami


### PR DESCRIPTION
If a response does not have an explicit Cache-Control header set, the current behavior is to cache it for 5 minutes, with unpleasant results in the case of the missing assets that we had during deploy.
This behavior is safer than blindly caching everything, and it makes us consider explicitly which headers to set.