### PR TITLE
Some EC2 properties should be immutable, ports shouldn't

### DIFF
--- a/src/buildercore/cfngen.py
+++ b/src/buildercore/cfngen.py
@@ -312,7 +312,7 @@ def template_delta(pname, context):
     Most of the existing resources are treated as immutable and not put in the delta. Some that support updates like CloudFront are instead included"""
     old_template = read_template(context['stackname'])
     template = json.loads(render_template(context))
-    updatable_title_prefixes = ['^CloudFront.*', '^ElasticLoadBalancer.*', '^EC2Instance.*', '.*Bucket$', '.*BucketPolicy']
+    updatable_title_patterns = ['^CloudFront.*', '^ElasticLoadBalancer.*', '^EC2Instance.*', '.*Bucket$', '.*BucketPolicy', '^StackSecurityGroup$', '^ELBSecurityGroup$']
     ec2_not_updatable_properties = ['ImageId', 'Tags', 'UserData']
 
     def _related_to_ec2(output):
@@ -324,7 +324,7 @@ def template_delta(pname, context):
         return False
 
     def _title_is_updatable(title):
-        return len([p for p in updatable_title_prefixes if re.match(p, title)]) > 0
+        return len([p for p in updatable_title_patterns if re.match(p, title)]) > 0
     # start backward compatibility code
     # back for when EC2Instance was the title rather than EC2Instance1
     if 'EC2Instance' in old_template['Resources']:

--- a/src/buildercore/cfngen.py
+++ b/src/buildercore/cfngen.py
@@ -313,6 +313,7 @@ def template_delta(pname, context):
     old_template = read_template(context['stackname'])
     template = json.loads(render_template(context))
     updatable_title_prefixes = ['^CloudFront.*', '^ElasticLoadBalancer.*', '^EC2Instance.*', '.*Bucket$', '.*BucketPolicy']
+    ec2_not_updatable_properties = ['ImageId', 'Tags', 'UserData']
 
     def _related_to_ec2(output):
         if 'Value' in output:
@@ -344,10 +345,9 @@ def template_delta(pname, context):
         # ignore UserData changes, it's not useful to update them and cause
         # a needless reboot
         if title_in_old['Type'] == 'AWS::EC2::Instance':
-            title_in_old['Properties']['UserData'] = None
-            title_in_new['Properties']['UserData'] = None
-            title_in_old['Properties']['Tags'] = None
-            title_in_new['Properties']['Tags'] = None
+            for property_name in ec2_not_updatable_properties:
+                title_in_old['Properties'][property_name] = None
+                title_in_new['Properties'][property_name] = None
         return title_in_old != title_in_new
 
     resources = {


### PR DESCRIPTION
We have no way to update them without forced reboots (outside of builder's control) or even recreation from the AMI. Therefore, the update_template task will ignore them rather than propose to update them.

However, we can update without fear the security groups of EC2 instances and of ELB. No more fiddling with the console coupled with a commit to builder, the procedure we aim for is simply:
1. update projects/elife.yaml `ports` configuration for a project
1. `./bldr update_template:stackname--environment`
1. check if what you see is what you want
1. hit Enter