### PR TITLE
Tweaks to template_delta

### DIFF
--- a/src/buildercore/cfngen.py
+++ b/src/buildercore/cfngen.py
@@ -350,13 +350,19 @@ def template_delta(pname, context):
                 title_in_new['Properties'][property_name] = None
         return title_in_old != title_in_new
 
+    def legacy_title(title):
+        # some titles were originally EC2Instance rather than EC2Instance1, EC2Instance2 and so on
+        return title.strip("1234567890")
+
     resources = {
         title: r for (title, r) in template['Resources'].items()
-        if (title not in old_template['Resources'] and 'EC2Instance' not in title)
+        if (title not in old_template['Resources']
+            and (legacy_title(title) not in old_template)
+            and ('EC2Instance' not in title))
         or (_title_is_updatable(title) and _title_has_been_updated(title, 'Resources'))
     }
     outputs = {
-        title: o for (title, o) in template['Outputs'].items()
+        title: o for (title, o) in template.get('Outputs', {}).items()
         if (title not in old_template['Outputs'] and not _related_to_ec2(o))
         or (_title_is_updatable(title) and _title_has_been_updated(title, 'Outputs'))
     }

--- a/src/cfn.py
+++ b/src/cfn.py
@@ -67,13 +67,18 @@ def update_template(stackname):
     Moreover, EC2 instances must be running while this is executed or their
     resources like PublicIP will be inaccessible"""
 
-    core_lifecycle.start(stackname)
 
     (pname, _) = core.parse_stackname(stackname)
     more_context = cfngen.choose_config(stackname)
-
+    
     context, delta = cfngen.regenerate_stack(pname, **more_context)
+
+    if context['ec2']:
+        core_lifecycle.start(stackname)
     LOG.info("%s", pformat(delta))
+    if not delta['Resources'] and not delta['Outputs']:
+        LOG.info("Nothing to update")
+        return
     utils.confirm('Confirming changes to the stack template?')
 
     context_handler.write_context(stackname, context)

--- a/src/cfn.py
+++ b/src/cfn.py
@@ -67,10 +67,9 @@ def update_template(stackname):
     Moreover, EC2 instances must be running while this is executed or their
     resources like PublicIP will be inaccessible"""
 
-
     (pname, _) = core.parse_stackname(stackname)
     more_context = cfngen.choose_config(stackname)
-    
+
     context, delta = cfngen.regenerate_stack(pname, **more_context)
 
     if context['ec2']:


### PR DESCRIPTION
- Not necessary to start EC2 instances for projects that do not have EC2 instances
- Legacy titles should not be replaced
Some titles like MountPoint1 and ExtraStorage1 were originally MountPoint
and ExtraStorage. If the legacy resources are around, we don't add
identical ones with a standard name, but instead we skip them