### PR TITLE
Some updates to templates needed for elife-bot

### DIFF
--- a/src/buildercore/cfngen.py
+++ b/src/buildercore/cfngen.py
@@ -332,6 +332,8 @@ def template_delta(pname, context):
             template['Resources']['ExtraStorage']['Properties']['AvailabilityZone']['Fn::GetAtt'][0] = 'EC2Instance'
         if 'MountPoint' in template['Resources']:
             template['Resources']['MountPoint']['Properties']['InstanceId']['Ref'] = 'EC2Instance'
+        if 'IntDNS' in template['Resources']:
+            template['Resources']['IntDNS']['Properties']['ResourceRecords'][0]['Fn::GetAtt'][0] = 'EC2Instance'
     # end backward compatibility code
 
     def _title_has_been_updated(title, section):

--- a/src/buildercore/trop.py
+++ b/src/buildercore/trop.py
@@ -428,6 +428,7 @@ def render_s3(context, template):
 
         if context['s3'][bucket_name]['public']:
             _add_bucket_policy(template, bucket_title, bucket_name)
+            props['AccessControl'] = s3.PublicRead
 
         template.add_resource(s3.Bucket(
             bucket_title,

--- a/src/tests/test_buildercore_trop.py
+++ b/src/tests/test_buildercore_trop.py
@@ -290,6 +290,18 @@ class TestBuildercoreTrop(base.BaseCase):
 
         self.assertEqual(
             {
+                'Type': 'AWS::S3::Bucket',
+                'DeletionPolicy': 'Delete',
+                'Properties': {
+                    'AccessControl': 'PublicRead',
+                    'BucketName': 'widgets-just-access-prod',
+                },
+            },
+            data['Resources']['WidgetsJustAccessProdBucket']
+        )
+
+        self.assertEqual(
+            {
                 'Type': 'AWS::S3::BucketPolicy',
                 'Properties': {
                     'Bucket': 'widgets-just-access-prod',


### PR DESCRIPTION
- AccessControl should be specified for public buckets, Without this, HTTP requests to objects return 403 rather then 404.
- IntDNS can be added to legacy templates using EC2Instance rather than    EC2Instance1