### PR TITLE
Support for custom CNAMEs

### DIFF
--- a/projects/elife.yaml
+++ b/projects/elife.yaml
@@ -98,6 +98,7 @@ defaults:
             headers: []
             errors: null
             default-ttl: 0 # seconds
+        subdomains: []
     aws-alt:
         fresh:
             description: uses a plain Ubuntu basebox instead of an ami
@@ -303,7 +304,12 @@ pattern-library:
         type: t2.small
         ports:
             - 22
+            - 80
             - 443
+    aws-alt:
+        prod:
+            subdomains:
+                - ui-patterns
     vagrant:
         ram: 2048
         ports:

--- a/src/buildercore/cfngen.py
+++ b/src/buildercore/cfngen.py
@@ -150,6 +150,7 @@ def build_context(pname, **more_context): # pylint: disable=too-many-locals
         context['s3'][bucket_name].update(configuration if configuration else {})
 
     build_context_cloudfront(context, parameterize=_parameterize)
+    build_context_subdomains(context)
 
     return context
 
@@ -194,6 +195,9 @@ def build_context_cloudfront(context, parameterize):
         }
     else:
         context['cloudfront'] = False
+
+def build_context_subdomains(context):
+    context['subdomains'] = [s + '.' + context['project']['domain'] for s in context['project']['aws'].get('subdomains', [])]
 
 def choose_config(stackname):
     (pname, instance_id) = core.parse_stackname(stackname)
@@ -312,7 +316,7 @@ def template_delta(pname, context):
     Most of the existing resources are treated as immutable and not put in the delta. Some that support updates like CloudFront are instead included"""
     old_template = read_template(context['stackname'])
     template = json.loads(render_template(context))
-    updatable_title_patterns = ['^CloudFront.*', '^ElasticLoadBalancer.*', '^EC2Instance.*', '.*Bucket$', '.*BucketPolicy', '^StackSecurityGroup$', '^ELBSecurityGroup$']
+    updatable_title_patterns = ['^CloudFront.*', '^ElasticLoadBalancer.*', '^EC2Instance.*', '.*Bucket$', '.*BucketPolicy', '^StackSecurityGroup$', '^ELBSecurityGroup$', '^CnameDNS.+$']
     ec2_not_updatable_properties = ['ImageId', 'Tags', 'UserData']
 
     def _related_to_ec2(output):

--- a/src/tests/fixtures/dummy1-project.json
+++ b/src/tests/fixtures/dummy1-project.json
@@ -28,7 +28,8 @@
         "redundant-subnet-cidr": "10.0.2.0/24", 
         "ports": [
             22
-        ]
+        ],
+        "subdomains": []
     }, 
     "vagrant": {
         "box": "ubuntu/trusty64", 

--- a/src/tests/fixtures/dummy2-project.json
+++ b/src/tests/fixtures/dummy2-project.json
@@ -48,7 +48,8 @@
                     "cidr-ip": "0.0.0.0/0"
                 }
             }
-        ]
+        ],
+        "subdomains": ["official"]
     }, 
     "aws-alt": {
         "fresh": {
@@ -89,7 +90,8 @@
                     }
                 }
             ], 
-            "description": "uses a plain Ubuntu basebox instead of an ami"
+            "description": "uses a plain Ubuntu basebox instead of an ami",
+            "subdomains": ["official"]
         }, 
         "alt-config1": {
             "ec2": {
@@ -128,7 +130,8 @@
                         "cidr-ip": "0.0.0.0/0"
                     }
                 }
-            ]
+            ],
+            "subdomains": ["official"]
         }
     }, 
     "vagrant": {

--- a/src/tests/fixtures/dummy3-project.json
+++ b/src/tests/fixtures/dummy3-project.json
@@ -28,7 +28,8 @@
         "redundant-subnet-cidr": "10.0.2.0/24", 
         "ports": [
             22
-        ]
+        ],
+        "subdomains": []
     }, 
     "aws-alt": {
         "fresh": {
@@ -49,7 +50,8 @@
             "ports": [
                 22
             ], 
-            "description": "uses a plain Ubuntu basebox instead of an ami"
+            "description": "uses a plain Ubuntu basebox instead of an ami",
+            "subdomains": []
         }, 
         "alt-config1": {
             "ec2": {
@@ -86,7 +88,8 @@
             }, 
             "ports": [
                 80
-            ]
+            ],
+            "subdomains": []
         }
     }, 
     "meta": {

--- a/src/tests/fixtures/projects/dummy-project.yaml
+++ b/src/tests/fixtures/projects/dummy-project.yaml
@@ -81,6 +81,7 @@ defaults:
             headers: []
             errors: null
             default-ttl: 300 # seconds
+        subdomains: []
     aws-alt:
         fresh:
             description: uses a plain Ubuntu basebox instead of an ami
@@ -123,6 +124,8 @@ dummy2:
             ami: ami-111111
         rds:
             storage: 10
+        subdomains:
+            - "official"
     aws-alt:
         # uses an rds backend and different ami
         alt-config1:

--- a/src/tests/test_buildercore_project.py
+++ b/src/tests/test_buildercore_project.py
@@ -59,7 +59,7 @@ class TestProjectData(base.BaseCase):
             expected_data = json.load(open(expected_path, 'r'))
             project_data = project.project_data(pname)
             project_data = utils.remove_ordereddict(project_data)
-            self.assertEqual(expected_data, project_data, 'failed %s' % pname)
+            self.assertEqual(expected_data, project_data)
 
     # snippets
 

--- a/src/tests/test_buildercore_trop.py
+++ b/src/tests/test_buildercore_trop.py
@@ -203,6 +203,27 @@ class TestBuildercoreTrop(base.BaseCase):
         self.assertEqual(dns['Name'], 'prod--project-with-cluster.example.org')
         self.assertIn('DomainName', outputs.keys())
 
+    def test_additional_cnames(self):
+        extra = {
+            'stackname': 'dummy2--prod',
+        }
+        context = cfngen.build_context('dummy2', **extra)
+        cfn_template = trop.render(context)
+        data = self._parse_json(cfn_template)
+        resources = data['Resources']
+        self.assertIn('CnameDNS0', resources.keys())
+        dns = resources['CnameDNS0']['Properties']
+        self.assertEqual(
+            dns,
+            {
+                'HostedZoneName': 'example.org.',
+                'Name': 'official.example.org',
+                'ResourceRecords': ['prod--dummy2.example.org'],
+                'TTL': '60',
+                'Type': 'CNAME',
+            }
+        )
+
     def test_stickiness_template(self):
         extra = {
             'stackname': 'project-with-stickiness--prod',


### PR DESCRIPTION
I once tried to do this automatically for production, but it's too restricting. Easier to specify the subdomains in an explicit way.

In this case, we add ui-patterns.elifesciences.org as a CNAME to prod--ui-patterns.elifesciences.org