### PR TITLE
Error messages that do not make your eyes bleed

### DIFF
--- a/src/buildercore/config.py
+++ b/src/buildercore/config.py
@@ -92,6 +92,7 @@ ROOTLOG.addHandler(H1)
 ROOTLOG.addHandler(H2)
 
 LOG = logging.getLogger(__name__)
+logging.getLogger('paramiko.transport').setLevel(logging.ERROR);
 
 #
 # remote

--- a/src/buildercore/config.py
+++ b/src/buildercore/config.py
@@ -92,7 +92,7 @@ ROOTLOG.addHandler(H1)
 ROOTLOG.addHandler(H2)
 
 LOG = logging.getLogger(__name__)
-logging.getLogger('paramiko.transport').setLevel(logging.ERROR);
+logging.getLogger('paramiko.transport').setLevel(logging.ERROR)
 
 #
 # remote

--- a/src/buildercore/config.py
+++ b/src/buildercore/config.py
@@ -181,7 +181,7 @@ def app(settings_path=None):
     if not settings_path:
         # set default here so tests can change the value of SETTINGS_FILE
         settings_path = SETTINGS_FILE
-    LOG.info("using settings path %r", settings_path)
+    LOG.debug("using settings path %r", settings_path)
     return parse(load(settings_path))
 
 def feature_enabled(feature):

--- a/src/buildercore/core.py
+++ b/src/buildercore/core.py
@@ -257,8 +257,12 @@ def stack_all_ec2_nodes(stackname, workfn, username=config.DEPLOY_USER, concurre
             else:
                 raise err
         except config.FabricException as remote_e:
-            message = "[%s] %s" % (current_ip(), remote_e.message.replace("\n", "    "))
-            raise SystemExit(message)
+            message = remote_e.message.replace("\n", "    ")
+            LOG.error(message)
+            # not useful to specify more, this will be printed out 
+            # but we are already logging it (and printing it on stderr)
+            # which is better
+            raise SystemExit("")
 
     # something less stateful like a context manager?
     output['aborts'] = False

--- a/src/buildercore/core.py
+++ b/src/buildercore/core.py
@@ -129,7 +129,7 @@ def connect_aws_with_pname(pname, service):
     "convenience"
     pdata = project.project_data(pname)
     region = pdata['aws']['region']
-    LOG.info('connecting to a %s instance in region %s', pname, region)
+    LOG.debug('connecting to a %s instance in region %s', pname, region)
     return connect_aws(service, region)
 
 def connect_aws_with_stack(stackname, service):
@@ -143,12 +143,12 @@ def find_ec2_instances(stackname, state='running', node_ids=None, allow_empty=Fa
     conn = connect_aws_with_stack(stackname, 'ec2')
     filters = _all_nodes_filter(stackname, node_ids=node_ids)
     all_ec2_instances = conn.get_only_instances(filters=filters)
-    LOG.info("all_ec2_instances returned instances %s", [(e.id, e.state) for e in all_ec2_instances])
+    LOG.debug("all_ec2_instances returned instances %s", [(e.id, e.state) for e in all_ec2_instances])
     if state:
         ec2_instances = [i for i in all_ec2_instances if i.state == state]
     else:
         ec2_instances = all_ec2_instances
-    LOG.info("find_ec2_instances with filters %s returned instances %s", filters, [e.id for e in ec2_instances])
+    LOG.debug("find_ec2_instances with filters %s returned instances %s", filters, [e.id for e in ec2_instances])
     if not allow_empty and not ec2_instances:
         raise NoRunningInstances("found no running ec2 instances for %r. The stack nodes may have been stopped, but here we were requiring them to be running" % stackname)
     return ec2_instances
@@ -242,7 +242,7 @@ def stack_all_ec2_nodes(stackname, workfn, username=config.DEPLOY_USER, concurre
     params.update({'public_ips': public_ips})
     params.update({'nodes': nodes})
 
-    LOG.info("Executing %s on all ec2 nodes (%s), concurrency %s", workfn, public_ips, concurrency)
+    LOG.info("Executing on all ec2 nodes (%s), concurrency %s", public_ips, concurrency)
 
     ensure(None not in public_ips.values(), "Public ips are not valid: %s", public_ips, exception_class=NoPublicIps)
 

--- a/src/buildercore/core.py
+++ b/src/buildercore/core.py
@@ -14,6 +14,7 @@ import boto3
 from contextlib import contextmanager
 from fabric.api import settings, execute, env, parallel, serial
 from fabric.exceptions import NetworkError
+from fabric.state import output
 import importlib
 import logging
 from kids.cache import cache as cached
@@ -255,6 +256,12 @@ def stack_all_ec2_nodes(stackname, workfn, username=config.DEPLOY_USER, concurre
                 return workfn(**work_kwargs)
             else:
                 raise err
+        except config.FabricException as remote_e:
+            message = "[%s] %s" % (current_ip(), remote_e.message.replace("\n", "    "))
+            raise SystemExit(message)
+
+    # something less stateful like a context manager?
+    output['aborts'] = False
 
     # TODO: extract in buildercore.concurrency
     if not concurrency:

--- a/src/buildercore/core.py
+++ b/src/buildercore/core.py
@@ -256,10 +256,9 @@ def stack_all_ec2_nodes(stackname, workfn, username=config.DEPLOY_USER, concurre
                 return workfn(**work_kwargs)
             else:
                 raise err
-        except config.FabricException as remote_e:
-            message = remote_e.message.replace("\n", "    ")
-            LOG.error(message)
-            # not useful to specify more, this will be printed out 
+        except config.FabricException as err:
+            LOG.error(str(err).replace("\n", "    "))
+            # not useful to specify more, this will be printed out
             # but we are already logging it (and printing it on stderr)
             # which is better
             raise SystemExit("")

--- a/src/cfn.py
+++ b/src/cfn.py
@@ -296,7 +296,7 @@ def cmd(stackname, command=None, username=DEPLOY_USER, clean_output=False, concu
                 username=username,
                 abort_on_prompts=True,
                 concurrency=concurrency_for(stackname, concurrency))
-    except Exception as e:
+    except FabricException as e:
         LOG.error(e.message)
         exit(2)
 

--- a/src/cfn.py
+++ b/src/cfn.py
@@ -297,9 +297,8 @@ def cmd(stackname, command=None, username=DEPLOY_USER, clean_output=False, concu
                 abort_on_prompts=True,
                 concurrency=concurrency_for(stackname, concurrency))
     except Exception as e:
-        print "Exception during cmd(): %s" % e.message
-        import sys
-        sys.exit(1)
+        LOG.error(e.message)
+        exit(2)
 
 @task
 def project_list():

--- a/src/cfn.py
+++ b/src/cfn.py
@@ -288,13 +288,18 @@ def cmd(stackname, command=None, username=DEPLOY_USER, clean_output=False, concu
         fabric.state.output['running'] = False
         custom_settings['output_prefix'] = False
 
-    with settings(**custom_settings):
-        return stack_all_ec2_nodes(
-            stackname,
-            (run, {'command': command}),
-            username=username,
-            abort_on_prompts=True,
-            concurrency=concurrency_for(stackname, concurrency))
+    try:
+        with settings(**custom_settings):
+            return stack_all_ec2_nodes(
+                stackname,
+                (run, {'command': command}),
+                username=username,
+                abort_on_prompts=True,
+                concurrency=concurrency_for(stackname, concurrency))
+    except Exception as e:
+        print "Exception during cmd(): %s" % e.message
+        import sys
+        sys.exit(1)
 
 @task
 def project_list():


### PR DESCRIPTION
The parallel execution and error checking has got out of hand, I put in too much noise for sure. We go from this (before):
```
$ bldr cmd:iiif--continuumtest,"echo ERROR; exit 12"
2017-06-02 15:40:10,843 - INFO - MainProcess - buildercore.config - using settings path u'/home/giorgio/code/builder/settings.yml'
2017-06-02 15:40:11,016 - INFO - MainProcess - cfn - Connecting to: iiif--continuumtest
2017-06-02 15:40:11,016 - INFO - MainProcess - buildercore.core - connecting to a iiif instance in region us-east-1
2017-06-02 15:40:11,759 - INFO - MainProcess - buildercore.core - all_ec2_instances returned instances [(u'i-01908276d1948cfe1', u'running'), (u'i-04e115af337755ff7', u'running')]
2017-06-02 15:40:11,759 - INFO - MainProcess - buildercore.core - find_ec2_instances with filters {'tag:aws:cloudformation:stack-name': ['iiif--continuumtest']} returned instances [u'i-01908276d1948cfe1', u'i-04e115af337755ff7']
2017-06-02 15:40:11,995 - INFO - MainProcess - buildercore.core - all_ec2_instances returned instances [(u'i-01908276d1948cfe1', u'running'), (u'i-04e115af337755ff7', u'running')]
2017-06-02 15:40:11,996 - INFO - MainProcess - buildercore.core - find_ec2_instances with filters {'tag:aws:cloudformation:stack-name': ['iiif--continuumtest']} returned instances [u'i-01908276d1948cfe1', u'i-04e115af337755ff7']
2017-06-02 15:40:11,996 - INFO - MainProcess - buildercore.core - Executing <function run at 0x7f31d54f8de8> on all ec2 nodes ({u'i-04e115af337755ff7': u'54.87.207.173', u'i-01908276d1948cfe1': u'54.88.136.230'}), concurrency parallel
[54.87.207.173] Executing task 'single_node_work'
[54.88.136.230] Executing task 'single_node_work'
[54.87.207.173] run: echo ERROR; exit 12
[54.88.136.230] run: echo ERROR; exit 12
2017-06-02 15:40:12,753 - INFO - 54.88.136.230 - paramiko.transport - Connected (version 2.0, client OpenSSH_6.6.1p1)
2017-06-02 15:40:12,822 - INFO - 54.87.207.173 - paramiko.transport - Connected (version 2.0, client OpenSSH_6.6.1p1)
2017-06-02 15:40:13,511 - INFO - 54.88.136.230 - paramiko.transport - Authentication (publickey) successful!
2017-06-02 15:40:13,721 - INFO - 54.87.207.173 - paramiko.transport - Authentication (publickey) successful!
[54.88.136.230] out: ERROR
[54.88.136.230] out:


Fatal error: run() received nonzero return code 12 while executing!

Requested: echo ERROR; exit 12
Executed: /bin/bash -l -c "echo ERROR; exit 12"

Aborting.
!!! Parallel execution exception under host u'54.88.136.230':
Process 54.88.136.230:
Traceback (most recent call last):
  File "/usr/lib/python2.7/multiprocessing/process.py", line 258, in _bootstrap
    self.run()
  File "/usr/lib/python2.7/multiprocessing/process.py", line 114, in run
    self._target(*self._args, **self._kwargs)
  File "/home/giorgio/code/builder/venv/local/lib/python2.7/site-packages/fabric/tasks.py", line 241, in inner
    submit(task.run(*args, **kwargs))
  File "/home/giorgio/code/builder/venv/local/lib/python2.7/site-packages/fabric/tasks.py", line 173, in run
    return self.wrapped(*args, **kwargs)
  File "/home/giorgio/code/builder/venv/local/lib/python2.7/site-packages/fabric/decorators.py", line 185, in inner
    return func(*args, **kwargs)
  File "/home/giorgio/code/builder/src/buildercore/core.py", line 251, in single_node_work
    return workfn(**work_kwargs)
  File "/home/giorgio/code/builder/venv/local/lib/python2.7/site-packages/fabric/network.py", line 683, in host_prompting_wrapper
    return func(*args, **kwargs)
  File "/home/giorgio/code/builder/venv/local/lib/python2.7/site-packages/fabric/operations.py", line 1090, in run
    shell_escape=shell_escape, capture_buffer_size=capture_buffer_size,
  File "/home/giorgio/code/builder/venv/local/lib/python2.7/site-packages/fabric/operations.py", line 954, in _run_command
    error(message=msg, stdout=out, stderr=err)
  File "/home/giorgio/code/builder/venv/local/lib/python2.7/site-packages/fabric/utils.py", line 358, in error
    return func(message)
  File "/home/giorgio/code/builder/venv/local/lib/python2.7/site-packages/fabric/utils.py", line 54, in abort
    raise env.abort_exception(msg)
FabricException: run() received nonzero return code 12 while executing!

Requested: echo ERROR; exit 12
Executed: /bin/bash -l -c "echo ERROR; exit 12"
[54.87.207.173] out: ERROR
[54.87.207.173] out:


Fatal error: run() received nonzero return code 12 while executing!

Requested: echo ERROR; exit 12
Executed: /bin/bash -l -c "echo ERROR; exit 12"

Aborting.
!!! Parallel execution exception under host u'54.87.207.173':
Process 54.87.207.173:
Traceback (most recent call last):
  File "/usr/lib/python2.7/multiprocessing/process.py", line 258, in _bootstrap
    self.run()
  File "/usr/lib/python2.7/multiprocessing/process.py", line 114, in run
    self._target(*self._args, **self._kwargs)
  File "/home/giorgio/code/builder/venv/local/lib/python2.7/site-packages/fabric/tasks.py", line 241, in inner
    submit(task.run(*args, **kwargs))
  File "/home/giorgio/code/builder/venv/local/lib/python2.7/site-packages/fabric/tasks.py", line 173, in run
    return self.wrapped(*args, **kwargs)
  File "/home/giorgio/code/builder/venv/local/lib/python2.7/site-packages/fabric/decorators.py", line 185, in inner
    return func(*args, **kwargs)
  File "/home/giorgio/code/builder/src/buildercore/core.py", line 251, in single_node_work
    return workfn(**work_kwargs)
  File "/home/giorgio/code/builder/venv/local/lib/python2.7/site-packages/fabric/network.py", line 683, in host_prompting_wrapper
    return func(*args, **kwargs)
  File "/home/giorgio/code/builder/venv/local/lib/python2.7/site-packages/fabric/operations.py", line 1090, in run
    shell_escape=shell_escape, capture_buffer_size=capture_buffer_size,
  File "/home/giorgio/code/builder/venv/local/lib/python2.7/site-packages/fabric/operations.py", line 954, in _run_command
    error(message=msg, stdout=out, stderr=err)
  File "/home/giorgio/code/builder/venv/local/lib/python2.7/site-packages/fabric/utils.py", line 358, in error
    return func(message)
  File "/home/giorgio/code/builder/venv/local/lib/python2.7/site-packages/fabric/utils.py", line 54, in abort
    raise env.abort_exception(msg)
FabricException: run() received nonzero return code 12 while executing!

Requested: echo ERROR; exit 12
Executed: /bin/bash -l -c "echo ERROR; exit 12"

Fatal error: One or more hosts failed while executing task 'single_node_work'

Underlying exception:
    run() received nonzero return code 12 while executing!

    Requested: echo ERROR; exit 12
    Executed: /bin/bash -l -c "echo ERROR; exit 12"

Aborting.
Traceback (most recent call last):
  File "/home/giorgio/code/builder/venv/local/lib/python2.7/site-packages/fabric/main.py", line 756, in main
    *args, **kwargs
  File "/home/giorgio/code/builder/venv/local/lib/python2.7/site-packages/fabric/tasks.py", line 426, in execute
    results['<local-only>'] = task.run(*args, **new_kwargs)
  File "/home/giorgio/code/builder/venv/local/lib/python2.7/site-packages/fabric/tasks.py", line 173, in run
    return self.wrapped(*args, **kwargs)
  File "/home/giorgio/code/builder/src/decorators.py", line 99, in call
    return func(stackname, *args, **kwargs)
  File "/home/giorgio/code/builder/src/cfn.py", line 297, in cmd
    concurrency=concurrency_for(stackname, concurrency))
  File "/home/giorgio/code/builder/src/buildercore/core.py", line 265, in stack_all_ec2_nodes
    return parallel_work(single_node_work, params)
  File "/home/giorgio/code/builder/src/buildercore/core.py", line 276, in parallel_work
    return execute(parallel(single_node_work), hosts=params['public_ips'].values())
  File "/home/giorgio/code/builder/venv/local/lib/python2.7/site-packages/fabric/tasks.py", line 418, in execute
    error(err, exception=d['results'])
  File "/home/giorgio/code/builder/venv/local/lib/python2.7/site-packages/fabric/utils.py", line 358, in error
    return func(message)
  File "/home/giorgio/code/builder/venv/local/lib/python2.7/site-packages/fabric/utils.py", line 54, in abort
    raise env.abort_exception(msg)
buildercore.config.FabricException: One or more hosts failed while executing task 'single_node_work'

Underlying exception:
    run() received nonzero return code 12 while executing!

    Requested: echo ERROR; exit 12
    Executed: /bin/bash -l -c "echo ERROR; exit 12"
``` 
to this (after):
```
$ bldr cmd:iiif--continuumtest,"echo ERROR; exit 12"
2017-06-02 15:40:52,517 - INFO - MainProcess - cfn - Connecting to: iiif--continuumtest
2017-06-02 15:40:53,117 - INFO - MainProcess - buildercore.core - Executing on all ec2 nodes ({u'i-04e115af337755ff7': u'54.87.207.173', u'i-01908276d1948cfe1': u'54.88.136.230'}), concurrency parallel
[54.87.207.173] Executing task 'single_node_work'
[54.88.136.230] Executing task 'single_node_work'
[54.88.136.230] run: echo ERROR; exit 12
[54.87.207.173] run: echo ERROR; exit 12
[54.87.207.173] out: ERROR
[54.87.207.173] out: 

2017-06-02 15:40:54,725 - ERROR - 54.87.207.173 - buildercore.core - run() received nonzero return code 12 while executing!        Requested: echo ERROR; exit 12    Executed: /bin/bash -l -c "echo ERROR; exit 12"

[54.88.136.230] out: ERROR
[54.88.136.230] out: 

2017-06-02 15:40:54,742 - ERROR - 54.88.136.230 - buildercore.core - run() received nonzero return code 12 while executing!        Requested: echo ERROR; exit 12    Executed: /bin/bash -l -c "echo ERROR; exit 12"

2017-06-02 15:40:54,762 - ERROR - MainProcess - cfn - One or more hosts failed while executing task 'single_node_work'
```
These messages are shown in builds, and they mislead and hide the real error in all the noise.