### PR TITLE
CNAMEs for external domains

### DIFF
--- a/projects/elife.yaml
+++ b/projects/elife.yaml
@@ -91,6 +91,7 @@ defaults:
         cloudfront: 
             # cloudfront defaults only used if a 'cloudfront' section present in project
             subdomains-without-dns: []
+            domains: []
             origins: {}
             certificate_id: ASCAIRXYIRFBOR5QSDP5M
             cookies: []
@@ -225,9 +226,11 @@ journal:
                 stickiness:
                     type: cookie
                     cookie-name: journal
-                protocol: 
+                protocol:
                     - https
                     - http
+                domains:
+                    - elifejournal.net
             cloudfront:
                 subdomains:
                     - "{instance}--cdn-journal"
@@ -278,6 +281,8 @@ journal:
                     - prod
                     - ""
                     - www
+                    # to overwrite a previously used DNS entry
+                    - dummydoesnotexistsplaceholder
                 headers:
                     - X-Requested-With
                     - Host
@@ -291,6 +296,15 @@ journal:
                         # ELB with no active instances
                         503: "/5xx.html"
                     protocol: http
+            subdomains:
+                - elifesciences.net
+                - e-lifesciences.org
+                - e-lifesciences.net
+                - elifejournal.net
+                - e-lifejournal.org
+                - e-lifejournal.com
+                - e-lifejournal.net
+                - elifejournal.org
     vagrant:
         ram: 4096
         ports:

--- a/src/buildercore/cfngen.py
+++ b/src/buildercore/cfngen.py
@@ -197,12 +197,12 @@ def build_context_cloudfront(context, parameterize):
         context['cloudfront'] = False
 
 def build_context_subdomains(context):
-    def complete_domain(h):
-        is_complete = h.count(".") > 0
+    def complete_domain(host):
+        is_complete = host.count(".") > 0
         if is_complete:
-            return h
+            return host
         else:
-            return h + '.' + context['project']['domain'] # something + '.' + elifesciences.org
+            return host + '.' + context['project']['domain'] # something + '.' + elifesciences.org
     context['subdomains'] = [complete_domain(s) for s in context['project']['aws'].get('subdomains', [])]
 
 def choose_config(stackname):

--- a/src/buildercore/cfngen.py
+++ b/src/buildercore/cfngen.py
@@ -165,7 +165,7 @@ def build_context_elb(context):
             'subnets': [
                 context['project']['aws']['subnet-id'],
                 context['project']['aws']['redundant-subnet-id']
-            ]
+            ],
         })
 
 def build_context_cloudfront(context, parameterize):
@@ -197,7 +197,13 @@ def build_context_cloudfront(context, parameterize):
         context['cloudfront'] = False
 
 def build_context_subdomains(context):
-    context['subdomains'] = [s + '.' + context['project']['domain'] for s in context['project']['aws'].get('subdomains', [])]
+    def complete_domain(h):
+        is_complete = h.count(".") > 0
+        if is_complete:
+            return h
+        else:
+            return h + '.' + context['project']['domain'] # something + '.' + elifesciences.org
+    context['subdomains'] = [complete_domain(s) for s in context['project']['aws'].get('subdomains', [])]
 
 def choose_config(stackname):
     (pname, instance_id) = core.parse_stackname(stackname)

--- a/src/buildercore/trop.py
+++ b/src/buildercore/trop.py
@@ -729,14 +729,10 @@ def add_outputs(context, template):
 def cnames(context):
     "additional CNAME DNS entries pointing to full_hostname"
     assert isinstance(context['domain'], str), "A 'domain' must be specified for CNAMEs to be built"
-    def hostedzone(hostname):
-        if hostname.count(".") == 1: # example.net
-            return hostname + "."
-        else:
-            return context['domain'] + "."
+
     def entry(hostname, i):
         # TODO: i should become i + 1 so that it starts from 1 like for other resources
-        # pattern-library--prod needs to be migrated to this
+        # pattern-library--prod and journal--prod need to be migrated to this 1-based index if we do it
         if hostname.count(".") == 1:
             # must be an alias as it is a 2nd-level domain like elifesciences.net
             hostedzone = hostname + "."
@@ -752,7 +748,7 @@ def cnames(context):
                 )
             )
         else:
-            hostedzone = context['domain'] + "." 
+            hostedzone = context['domain'] + "."
             return route53.RecordSetType(
                 R53_CNAME_TITLE % (i),
                 HostedZoneName=hostedzone,

--- a/src/tests/fixtures/projects/dummy-project.yaml
+++ b/src/tests/fixtures/projects/dummy-project.yaml
@@ -125,7 +125,7 @@ dummy2:
         rds:
             storage: 10
         subdomains:
-            - "official"
+            - official
     aws-alt:
         # uses an rds backend and different ami
         alt-config1:
@@ -275,6 +275,8 @@ project-with-cluster:
             cluster-size: 2
         elb: 
             protocol: http
+        subdomains:
+            - project.tv
 
 project-with-stickiness:
     repo: ssh://git@github.com/elifesciences/dummy3

--- a/src/tests/test_buildercore_trop.py
+++ b/src/tests/test_buildercore_trop.py
@@ -202,6 +202,21 @@ class TestBuildercoreTrop(base.BaseCase):
         self.assertIn('AliasTarget', dns.keys())
         self.assertEqual(dns['Name'], 'prod--project-with-cluster.example.org')
         self.assertIn('DomainName', outputs.keys())
+        self.assertIn('CnameDNS0', resources.keys())
+        self.assertEqual(
+            {
+                'AliasTarget': {
+                    'DNSName': {
+                        'Fn::GetAtt': ['ElasticLoadBalancer', 'DNSName']
+                    },
+                    'HostedZoneId': {'Fn::GetAtt': ['ElasticLoadBalancer', 'CanonicalHostedZoneNameID']}
+                },
+                'HostedZoneName': 'project.tv.',
+                'Name': 'project.tv',
+                'Type': 'A'
+            },
+            resources['CnameDNS0']['Properties']
+        )
 
     def test_additional_cnames(self):
         extra = {


### PR DESCRIPTION
We are now able to set up CNAMEs (actually the proprietary AWS extension called `Aliases`) that come from a different domain. They are set up in their own (already existing) hosted zone and are distinguished from subdomains because they contain '.'