### PR TITLE
Redirects project

### DIFF
--- a/projects/elife.yaml
+++ b/projects/elife.yaml
@@ -964,15 +964,18 @@ redirects:
             - 443
     aws-alt:
         prod:
-            subdomains:
-                - elifesciences.net
-                - e-lifesciences.org
-                - e-lifesciences.net
-                - elifejournal.net
-                - e-lifejournal.org
-                - e-lifejournal.com
-                - e-lifejournal.net
-                - elifejournal.org
+            cloudfront:
+                subdomains:
+                    - elifesciences.net
+                    - e-lifesciences.org
+                    - e-lifesciences.net
+                    - elifejournal.net
+                    - e-lifejournal.org
+                    - e-lifejournal.com
+                    - e-lifejournal.net
+                    - elifejournal.org
+                headers:
+                    - Host
 
     vagrant:
         ports:

--- a/projects/elife.yaml
+++ b/projects/elife.yaml
@@ -294,15 +294,6 @@ journal:
                         # ELB with no active instances
                         503: "/5xx.html"
                     protocol: http
-            subdomains:
-                - elifesciences.net
-                - e-lifesciences.org
-                - e-lifesciences.net
-                - elifejournal.net
-                - e-lifejournal.org
-                - e-lifejournal.com
-                - e-lifejournal.net
-                - elifejournal.org
     vagrant:
         ram: 4096
         ports:

--- a/projects/elife.yaml
+++ b/projects/elife.yaml
@@ -962,6 +962,18 @@ redirects:
             - 22
             - 80
             - 443
+    aws-alt:
+        prod:
+            subdomains:
+                - elifesciences.net
+                - e-lifesciences.org
+                - e-lifesciences.net
+                - elifejournal.net
+                - e-lifejournal.org
+                - e-lifejournal.com
+                - e-lifejournal.net
+                - elifejournal.org
+
     vagrant:
         ports:
             1262: 80

--- a/projects/elife.yaml
+++ b/projects/elife.yaml
@@ -965,6 +965,8 @@ redirects:
     aws-alt:
         prod:
             cloudfront:
+                # TODO: change with newly released one
+                certificate_id: ASCAIRXYIRFBOR5QSDP5M
                 subdomains:
                     - elifesciences.net
                     - e-lifesciences.org

--- a/projects/elife.yaml
+++ b/projects/elife.yaml
@@ -959,3 +959,18 @@ iiif:
     vagrant:
         ports:
             1261: 80
+
+redirects:
+    description: redirect various domains to the canonical elifesciences.org
+    subdomain: redirects
+    intdomain: null
+    formula-repo: https://github.com/elifesciences/redirects-formula
+    aws:
+        type: t2.nano
+        ports:
+            - 22
+            - 80
+            - 443
+    vagrant:
+        ports:
+            1262: 80

--- a/projects/elife.yaml
+++ b/projects/elife.yaml
@@ -965,8 +965,7 @@ redirects:
     aws-alt:
         prod:
             cloudfront:
-                # TODO: change with newly released one
-                certificate_id: ASCAIRXYIRFBOR5QSDP5M
+                certificate_id: ASCAIEHY4AGS453E4IUJK
                 subdomains:
                     - elifesciences.net
                     - e-lifesciences.org

--- a/scripts/new-project.sh
+++ b/scripts/new-project.sh
@@ -72,5 +72,5 @@ sed -i "s/\$appname/$appname/g" README.md
 # init the repo
 git init
 git add .
-git ci -am "initial commit"
+git commit -am "initial commit"
 

--- a/src/buildercore/cfngen.py
+++ b/src/buildercore/cfngen.py
@@ -396,7 +396,7 @@ def template_delta(pname, context):
         }
     )
 
-def merge_delta(stackname, delta_plus, delta_minus={}):
+def merge_delta(stackname, delta_plus, delta_minus):
     """Merges the new resources in delta in the local copy of the Cloudformation  template"""
     template = read_template(stackname)
     apply_delta(template, delta_plus, delta_minus)

--- a/src/buildercore/cfngen.py
+++ b/src/buildercore/cfngen.py
@@ -396,11 +396,18 @@ def template_delta(pname, context):
         }
     )
 
-def merge_delta(stackname, delta):
+def merge_delta(stackname, delta_plus, delta_minus={}):
     """Merges the new resources in delta in the local copy of the Cloudformation  template"""
     template = read_template(stackname)
-    for component in delta:
-        ensure(component in ["Resources", "Outputs"], "Template component %s not recognized", component)
-        template[component].update(delta[component])
+    apply_delta(template, delta_plus, delta_minus)
     write_template(stackname, json.dumps(template))
     return template
+
+def apply_delta(template, delta_plus, delta_minus):
+    for component in delta_plus:
+        ensure(component in ["Resources", "Outputs"], "Template component %s not recognized", component)
+        template[component].update(delta_plus[component])
+    for component in delta_minus:
+        ensure(component in ["Resources", "Outputs"], "Template component %s not recognized", component)
+        for title in delta_minus[component]:
+            del template[component][title]

--- a/src/buildercore/cfngen.py
+++ b/src/buildercore/cfngen.py
@@ -383,7 +383,7 @@ def template_delta(pname, context):
         or (_title_is_updatable(title) and _title_has_been_updated(title, 'Outputs'))
     }
 
-    delta_minus_resources = {r:v for r, v in old_template['Resources'].iteritems() if r not in template['Resources'] and re.match(removable_title_pattern, r)}
+    delta_minus_resources = {r: v for r, v in old_template['Resources'].iteritems() if r not in template['Resources'] and re.match(removable_title_pattern, r)}
 
     return (
         {

--- a/src/buildercore/trop.py
+++ b/src/buildercore/trop.py
@@ -738,7 +738,7 @@ def cnames(context):
             hostedzone = hostname + "."
             ensure(context['elb'], "2nd-level domains aliases are only supported for ELBs")
             return route53.RecordSetType(
-                R53_CNAME_TITLE % (i),
+                R53_CNAME_TITLE % (i+1),
                 HostedZoneName=hostedzone,
                 Name=hostname,
                 Type="A",
@@ -750,7 +750,7 @@ def cnames(context):
         else:
             hostedzone = context['domain'] + "."
             return route53.RecordSetType(
-                R53_CNAME_TITLE % (i),
+                R53_CNAME_TITLE % (i+1),
                 HostedZoneName=hostedzone,
                 Name=hostname,
                 Type="CNAME",

--- a/src/buildercore/trop.py
+++ b/src/buildercore/trop.py
@@ -738,7 +738,7 @@ def cnames(context):
             hostedzone = hostname + "."
             ensure(context['elb'], "2nd-level domains aliases are only supported for ELBs")
             return route53.RecordSetType(
-                R53_CNAME_TITLE % (i+1),
+                R53_CNAME_TITLE % (i + 1),
                 HostedZoneName=hostedzone,
                 Name=hostname,
                 Type="A",
@@ -750,7 +750,7 @@ def cnames(context):
         else:
             hostedzone = context['domain'] + "."
             return route53.RecordSetType(
-                R53_CNAME_TITLE % (i+1),
+                R53_CNAME_TITLE % (i + 1),
                 HostedZoneName=hostedzone,
                 Name=hostname,
                 Type="CNAME",

--- a/src/cfn.py
+++ b/src/cfn.py
@@ -74,14 +74,14 @@ def update_template(stackname):
 
     if context['ec2']:
         core_lifecycle.start(stackname)
-    LOG.info("ADD: %s", pformat(delta_plus))
-    LOG.info("REMOVE: %s", pformat(delta_minus))
+    LOG.info("Create/update: %s", pformat(delta_plus))
+    LOG.info("Delete: %s", pformat(delta_minus))
     utils.confirm('Confirming changes to the stack template? This will rewrite the context and the CloudFormation template')
 
     context_handler.write_context(stackname, context)
 
-    if delta_plus['Resources'] or delta_plus['Outputs']:
-        new_template = cfngen.merge_delta(stackname, delta_plus)
+    if delta_plus['Resources'] or delta_plus['Outputs'] or delta_minus['Resources'] or delta_minus['Outputs']:
+        new_template = cfngen.merge_delta(stackname, delta_plus, delta_minus)
         bootstrap.update_template(stackname, new_template)
     else:
         # attempting to apply an empty change set would result in an error

--- a/src/cfn.py
+++ b/src/cfn.py
@@ -70,17 +70,18 @@ def update_template(stackname):
     (pname, _) = core.parse_stackname(stackname)
     more_context = cfngen.choose_config(stackname)
 
-    context, delta = cfngen.regenerate_stack(pname, **more_context)
+    context, delta_plus, delta_minus = cfngen.regenerate_stack(pname, **more_context)
 
     if context['ec2']:
         core_lifecycle.start(stackname)
-    LOG.info("%s", pformat(delta))
+    LOG.info("ADD: %s", pformat(delta_plus))
+    LOG.info("REMOVE: %s", pformat(delta_minus))
     utils.confirm('Confirming changes to the stack template? This will rewrite the context and the CloudFormation template')
 
     context_handler.write_context(stackname, context)
 
-    if delta['Resources'] or delta['Outputs']:
-        new_template = cfngen.merge_delta(stackname, delta)
+    if delta_plus['Resources'] or delta_plus['Outputs']:
+        new_template = cfngen.merge_delta(stackname, delta_plus)
         bootstrap.update_template(stackname, new_template)
     else:
         # attempting to apply an empty change set would result in an error

--- a/src/tests/test_buildercore_cfngen.py
+++ b/src/tests/test_buildercore_cfngen.py
@@ -146,7 +146,7 @@ class TestBuildercoreCfngen(base.BaseCase):
         context = self._base_context('dummy2')
         context['subdomains'] = []
         (delta_plus, delta_minus) = cfngen.template_delta('dummy2', context)
-        self.assertEqual(delta_minus['Resources'].keys(), ['CnameDNS0'])
+        self.assertEqual(delta_minus['Resources'].keys(), ['CnameDNS1'])
         self.assertEqual(delta_minus['Outputs'].keys(), [])
 
     def test_apply_delta_may_add_and_remove_resources(self):

--- a/src/tests/test_buildercore_cfngen.py
+++ b/src/tests/test_buildercore_cfngen.py
@@ -38,8 +38,8 @@ class TestBuildercoreCfngen(base.BaseCase):
 
     def test_empty_template_delta(self):
         context = self._base_context()
-        delta = cfngen.template_delta('dummy1', context)
-        self.assertEqual(delta, {'Outputs': {}, 'Resources': {}})
+        (delta_plus, delta_minus) = cfngen.template_delta('dummy1', context)
+        self.assertEqual(delta_plus, {'Outputs': {}, 'Resources': {}})
 
     def test_template_delta_includes_cloudfront(self):
         "we can add CDNs (that takes an hour or more) without downtime"
@@ -58,47 +58,47 @@ class TestBuildercoreCfngen(base.BaseCase):
             "errors": None,
             "default-ttl": 300,
         }
-        delta = cfngen.template_delta('dummy1', context)
-        self.assertEqual(delta['Resources'].keys(), ['CloudFrontCDN', 'CloudFrontCDNDNS1', 'ExtDNS'])
-        self.assertEqual(delta['Outputs'].keys(), ['DomainName'])
+        (delta_plus, delta_minus) = cfngen.template_delta('dummy1', context)
+        self.assertEqual(delta_plus['Resources'].keys(), ['CloudFrontCDN', 'CloudFrontCDNDNS1', 'ExtDNS'])
+        self.assertEqual(delta_plus['Outputs'].keys(), ['DomainName'])
 
     def test_template_delta_does_not_include_cloudfront_if_there_are_no_modifications(self):
         context = self._base_context('project-with-cloudfront-minimal')
-        delta = cfngen.template_delta('project-with-cloudfront-minimal', context)
-        self.assertEqual(delta['Resources'].keys(), [])
-        self.assertEqual(delta['Outputs'].keys(), [])
+        (delta_plus, delta_minus) = cfngen.template_delta('project-with-cloudfront-minimal', context)
+        self.assertEqual(delta_plus['Resources'].keys(), [])
+        self.assertEqual(delta_plus['Outputs'].keys(), [])
 
     def test_template_delta_does_not_normally_include_ec2(self):
         "we do not want to mess with running VMs"
         context = self._base_context()
         context['ec2']['cluster_size'] = 2
-        delta = cfngen.template_delta('dummy1', context)
-        self.assertEqual(delta['Resources'].keys(), [])
-        self.assertEqual(delta['Outputs'].keys(), [])
+        (delta_plus, delta_minus) = cfngen.template_delta('dummy1', context)
+        self.assertEqual(delta_plus['Resources'].keys(), [])
+        self.assertEqual(delta_plus['Outputs'].keys(), [])
 
     def test_template_delta_includes_ec2_instance_type(self):
         "we accept to reboot VMs if an instance type change is requested"
         context = self._base_context()
         context['ec2']['type'] = 't2.xlarge'
-        delta = cfngen.template_delta('dummy1', context)
-        self.assertEqual(delta['Resources'].keys(), ['EC2Instance1'])
-        self.assertEqual(delta['Outputs'].keys(), [])
+        (delta_plus, delta_minus) = cfngen.template_delta('dummy1', context)
+        self.assertEqual(delta_plus['Resources'].keys(), ['EC2Instance1'])
+        self.assertEqual(delta_plus['Outputs'].keys(), [])
 
     def test_template_delta_does_not_include_ec2_immutable_properties_like_image(self):
         "we don't want random reboot or recreations of instances"
         context = self._base_context()
         context['ec2']['ami'] = 'ami-1234567'
-        delta = cfngen.template_delta('dummy1', context)
-        self.assertEqual(delta['Resources'].keys(), [])
-        self.assertEqual(delta['Outputs'].keys(), [])
+        (delta_plus, delta_minus) = cfngen.template_delta('dummy1', context)
+        self.assertEqual(delta_plus['Resources'].keys(), [])
+        self.assertEqual(delta_plus['Outputs'].keys(), [])
 
     def test_template_delta_includes_ec2_security_group(self):
         "it's useful to open and close ports"
         context = self._base_context()
         context['project']['aws']['ports'] = [110]
-        delta = cfngen.template_delta('dummy1', context)
-        self.assertEqual(delta['Resources'].keys(), ['StackSecurityGroup'])
-        self.assertEqual(delta['Outputs'].keys(), [])
+        (delta_plus, delta_minus) = cfngen.template_delta('dummy1', context)
+        self.assertEqual(delta_plus['Resources'].keys(), ['StackSecurityGroup'])
+        self.assertEqual(delta_plus['Outputs'].keys(), [])
 
     def test_template_delta_includes_parts_of_cloudfront(self):
         "we want to update CDNs in place given how long it takes to recreate them"
@@ -106,28 +106,28 @@ class TestBuildercoreCfngen(base.BaseCase):
         context['cloudfront']['subdomains'] = [
             "custom-subdomain"
         ]
-        delta = cfngen.template_delta('project-with-cloudfront-minimal', context)
-        self.assertEqual(delta['Resources'].keys(), ['CloudFrontCDN', 'CloudFrontCDNDNS1'])
-        self.assertEqual(delta['Resources']['CloudFrontCDNDNS1']['Properties']['Name'], 'custom-subdomain.example.org.')
-        self.assertEqual(delta['Outputs'].keys(), [])
+        (delta_plus, delta_minus) = cfngen.template_delta('project-with-cloudfront-minimal', context)
+        self.assertEqual(delta_plus['Resources'].keys(), ['CloudFrontCDN', 'CloudFrontCDNDNS1'])
+        self.assertEqual(delta_plus['Resources']['CloudFrontCDNDNS1']['Properties']['Name'], 'custom-subdomain.example.org.')
+        self.assertEqual(delta_plus['Outputs'].keys(), [])
 
     def test_template_delta_includes_parts_of_elb(self):
         "we want to update ELBs in place given how long it takes to recreate them"
         context = self._base_context('project-with-cluster')
         context['elb']['healthcheck']['protocol'] = 'tcp'
-        delta = cfngen.template_delta('project-with-cluster', context)
-        self.assertEqual(delta['Resources'].keys(), ['ElasticLoadBalancer'])
-        self.assertEqual(delta['Resources']['ElasticLoadBalancer']['Properties']['HealthCheck']['Target'], 'TCP:80')
-        self.assertEqual(delta['Outputs'].keys(), [])
+        (delta_plus, delta_minus) = cfngen.template_delta('project-with-cluster', context)
+        self.assertEqual(delta_plus['Resources'].keys(), ['ElasticLoadBalancer'])
+        self.assertEqual(delta_plus['Resources']['ElasticLoadBalancer']['Properties']['HealthCheck']['Target'], 'TCP:80')
+        self.assertEqual(delta_plus['Outputs'].keys(), [])
 
     def test_template_delta_includes_elb_security_group(self):
         "for consistency with EC2 security groups"
         context = self._base_context('project-with-cluster')
         context['elb']['protocol'] = 'https'
         context['elb']['certificate'] = 'DUMMY_CERTIFICATE'
-        delta = cfngen.template_delta('project-with-cluster', context)
-        self.assertEqual(delta['Resources'].keys(), ['ElasticLoadBalancer', 'ELBSecurityGroup'])
-        self.assertEqual(delta['Outputs'].keys(), [])
+        (delta_plus, delta_minus) = cfngen.template_delta('project-with-cluster', context)
+        self.assertEqual(delta_plus['Resources'].keys(), ['ElasticLoadBalancer', 'ELBSecurityGroup'])
+        self.assertEqual(delta_plus['Outputs'].keys(), [])
 
     def test_template_delta_includes_new_external_volumes(self):
         "we want to add additional volumes to projects that are getting their main volume filled"
@@ -136,11 +136,19 @@ class TestBuildercoreCfngen(base.BaseCase):
             'size': 10,
             'device': '/dev/sdh',
         }
-        delta = cfngen.template_delta('dummy1', context)
-        self.assertEqual(delta['Resources'].keys(), ['MountPoint1', 'ExtraStorage1'])
-        self.assertEqual(delta['Resources']['ExtraStorage1']['Properties']['Size'], '10')
-        self.assertEqual(delta['Resources']['MountPoint1']['Properties']['Device'], '/dev/sdh')
-        self.assertEqual(delta['Outputs'].keys(), [])
+        (delta_plus, delta_minus) = cfngen.template_delta('dummy1', context)
+        self.assertEqual(delta_plus['Resources'].keys(), ['MountPoint1', 'ExtraStorage1'])
+        self.assertEqual(delta_plus['Resources']['ExtraStorage1']['Properties']['Size'], '10')
+        self.assertEqual(delta_plus['Resources']['MountPoint1']['Properties']['Device'], '/dev/sdh')
+        self.assertEqual(delta_plus['Outputs'].keys(), [])
+
+    def test_template_delta_includes_removal_of_subdomains(self):
+        context = self._base_context('dummy2')
+        context['subdomains'] = []
+        (delta_plus, delta_minus) = cfngen.template_delta('dummy2', context)
+        self.assertEqual(delta_minus['Resources'].keys(), ['CnameDNS0'])
+        self.assertEqual(delta_minus['Outputs'].keys(), [])
+
 
     def _base_context(self, project_name='dummy1'):
         stackname = '%s--test' % project_name

--- a/src/tests/test_buildercore_cfngen.py
+++ b/src/tests/test_buildercore_cfngen.py
@@ -149,6 +149,15 @@ class TestBuildercoreCfngen(base.BaseCase):
         self.assertEqual(delta_minus['Resources'].keys(), ['CnameDNS0'])
         self.assertEqual(delta_minus['Outputs'].keys(), [])
 
+    def test_apply_delta_may_add_and_remove_resources(self):
+        template = {
+            'Resources': {
+                'A': 1,
+                'B': 2,
+            }
+        }
+        cfngen.apply_delta(template, delta_plus={'Resources': {'C': 3}}, delta_minus={'Resources': {'B': 2}})
+        self.assertEqual(template, {'Resources': {'A': 1, 'C': 3}})
 
     def _base_context(self, project_name='dummy1'):
         stackname = '%s--test' % project_name

--- a/src/tests/test_buildercore_trop.py
+++ b/src/tests/test_buildercore_trop.py
@@ -202,7 +202,7 @@ class TestBuildercoreTrop(base.BaseCase):
         self.assertIn('AliasTarget', dns.keys())
         self.assertEqual(dns['Name'], 'prod--project-with-cluster.example.org')
         self.assertIn('DomainName', outputs.keys())
-        self.assertIn('CnameDNS0', resources.keys())
+        self.assertIn('CnameDNS1', resources.keys())
         self.assertEqual(
             {
                 'AliasTarget': {
@@ -215,9 +215,9 @@ class TestBuildercoreTrop(base.BaseCase):
                 'Name': 'project.tv',
                 'Type': 'A'
             },
-            resources['CnameDNS0']['Properties']
+            resources['CnameDNS1']['Properties']
         )
-        self.assertIn('CnameDNS1', resources.keys())
+        self.assertIn('CnameDNS2', resources.keys())
         self.assertEqual(
             {
                 'AliasTarget': {
@@ -230,7 +230,7 @@ class TestBuildercoreTrop(base.BaseCase):
                 'Name': 'example.org',
                 'Type': 'A'
             },
-            resources['CnameDNS1']['Properties']
+            resources['CnameDNS2']['Properties']
         )
 
     def test_additional_cnames(self):
@@ -241,8 +241,8 @@ class TestBuildercoreTrop(base.BaseCase):
         cfn_template = trop.render(context)
         data = self._parse_json(cfn_template)
         resources = data['Resources']
-        self.assertIn('CnameDNS0', resources.keys())
-        dns = resources['CnameDNS0']['Properties']
+        self.assertIn('CnameDNS1', resources.keys())
+        dns = resources['CnameDNS1']['Properties']
         self.assertEqual(
             dns,
             {


### PR DESCRIPTION
- Support removal of resources in CloudFormation templates
- CNAMEs title should be starting from 1 like other titles
- Configuration for redirects project
- Added domains to future redirects--prod instance
- `git ci` was not recognized as a command

Already used to remove the domains from `journal--prod`, instances of `redirects` have not been created yet because they need the configuration to reach the salt master first.