### PR TITLE
Updating generic-cdn to keep it identical to prod

### DIFF
--- a/projects/elife.yaml
+++ b/projects/elife.yaml
@@ -417,6 +417,7 @@ generic-cdn:
                 articles:
                     hostname: "{instance}-elife-published.s3.amazonaws.com"
                     pattern: articles/*
+            default-ttl: 86400 # seconds
             headers:
                 - Origin
 

--- a/src/buildercore/cfngen.py
+++ b/src/buildercore/cfngen.py
@@ -406,7 +406,10 @@ def merge_delta(stackname, delta_plus, delta_minus):
 def apply_delta(template, delta_plus, delta_minus):
     for component in delta_plus:
         ensure(component in ["Resources", "Outputs"], "Template component %s not recognized", component)
-        template[component].update(delta_plus[component])
+        if component in template:
+            template[component].update(delta_plus[component])
+        else:
+            template[component] = delta_plus[component]
     for component in delta_minus:
         ensure(component in ["Resources", "Outputs"], "Template component %s not recognized", component)
         for title in delta_minus[component]:

--- a/src/buildercore/cfngen.py
+++ b/src/buildercore/cfngen.py
@@ -406,10 +406,9 @@ def merge_delta(stackname, delta_plus, delta_minus):
 def apply_delta(template, delta_plus, delta_minus):
     for component in delta_plus:
         ensure(component in ["Resources", "Outputs"], "Template component %s not recognized", component)
-        if component in template:
-            template[component].update(delta_plus[component])
-        else:
-            template[component] = delta_plus[component]
+        data = template.get(component, {})
+        data.update(delta_plus[component])
+        template[component] = data
     for component in delta_minus:
         ensure(component in ["Resources", "Outputs"], "Template component %s not recognized", component)
         for title in delta_minus[component]:

--- a/src/cfn.py
+++ b/src/cfn.py
@@ -181,6 +181,9 @@ def _pick_node(instance_list, node):
     return instance
 
 def _check_want_to_be_running(stackname, autostart=False):
+    context = context_handler.load_context(stackname)
+    if not context['ec2']:
+        return False
     instance_list = core.find_ec2_instances(stackname, allow_empty=True)
     num_instances = len(instance_list)
     if num_instances >= 1:

--- a/src/tests/test_buildercore_cfngen.py
+++ b/src/tests/test_buildercore_cfngen.py
@@ -159,6 +159,15 @@ class TestBuildercoreCfngen(base.BaseCase):
         cfngen.apply_delta(template, delta_plus={'Resources': {'C': 3}}, delta_minus={'Resources': {'B': 2}})
         self.assertEqual(template, {'Resources': {'A': 1, 'C': 3}})
 
+    def test_apply_delta_may_add_components_which_werent_there(self):
+        template = {
+            'Resources': {
+                'A': 1,
+            }
+        }
+        cfngen.apply_delta(template, delta_plus={'Outputs': {'B': 2}}, delta_minus={})
+        self.assertEqual(template, {'Resources': {'A': 1}, 'Outputs': {'B': 2}})
+
     def _base_context(self, project_name='dummy1'):
         stackname = '%s--test' % project_name
         context = cfngen.build_context(project_name, stackname=stackname)


### PR DESCRIPTION
generic-cdn--prod is not managed by builder and has a DefaultTTL of 86400 (1 day). Applying it to other environments