### PR TITLE
Allow missing context file

### DIFF
--- a/src/buildercore/context_handler.py
+++ b/src/buildercore/context_handler.py
@@ -20,7 +20,7 @@ def load_context(stackname):
     path = local_context_file(stackname)
     if not os.path.exists(path):
         if not download_from_s3(stackname):
-            raise RuntimeError("We are missing the context file for %s, even on S3" % stackname)
+            raise MissingContextFile("We are missing the context file for %s, even on S3" % stackname)
     return json.load(open(path, 'r'))
 
 def write_context(stackname, context):
@@ -52,3 +52,6 @@ def download_from_s3(stackname, refresh=False):
         os.unlink(expected_path)
     s3.download(key, expected_path)
     return True
+
+class MissingContextFile(RuntimeError):
+    pass

--- a/src/cfn.py
+++ b/src/cfn.py
@@ -181,13 +181,19 @@ def _pick_node(instance_list, node):
     return instance
 
 def _check_want_to_be_running(stackname, autostart=False):
-    context = context_handler.load_context(stackname)
-    if 'ec2' in context:
-        # early check can only be made if the instance actually declares
-        # ec2 True/False in its context
-        # otherwise, don't make assumptions and go ahead
-        if not context['ec2']:
-            return False
+    try:
+        context = context_handler.load_context(stackname)
+    
+        if 'ec2' in context:
+            # early check can only be made if the instance actually declares
+            # ec2 True/False in its context
+            # otherwise, don't make assumptions and go ahead
+            if not context['ec2']:
+                return False
+
+    except context_handler.MissingContextFile as e:
+        LOG.warn(e)
+
     instance_list = core.find_ec2_instances(stackname, allow_empty=True)
     num_instances = len(instance_list)
     if num_instances >= 1:

--- a/src/cfn.py
+++ b/src/cfn.py
@@ -183,7 +183,7 @@ def _pick_node(instance_list, node):
 def _check_want_to_be_running(stackname, autostart=False):
     try:
         context = context_handler.load_context(stackname)
-    
+
         if 'ec2' in context:
             # early check can only be made if the instance actually declares
             # ec2 True/False in its context


### PR DESCRIPTION
We have old servers like master-server--2016-07-22 that have no context file stored on S3. Strange, we could repair them, but in general we may have the problem if the settings impose to not upload the context in the S3 bucket; at the moment 'not uploading anything to S3' is the only builder setting supported for organizations different from eLife as the bucket name is hardcoded

This is an attempt to be more conservative and still allow `bldr ssh`
and `bldr update` to work. However we may want a different direction
like making context files mandatory (hence if you have no S3 upload you
have to use the builder from a single place) and repair the missing
ones we do not have.