### PR TITLE
Avoid ssh:// prefix in git commands

### DIFF
--- a/src/buildercore/bootstrap.py
+++ b/src/buildercore/bootstrap.py
@@ -450,6 +450,8 @@ def update_ec2_stack(stackname, concurrency):
 
         if is_master:
             builder_private_repo = pdata['private-repo']
+            if builder_private_repo.startswith('ssh://'):
+                builder_private_repo = builder_private_repo[6:]
             run_script('init-master.sh', stackname, builder_private_repo)
             run_script('update-master.sh', stackname, builder_private_repo)
 

--- a/src/buildercore/project/repo.py
+++ b/src/buildercore/project/repo.py
@@ -18,4 +18,4 @@ def access(repo_url):
     return {
         'https': http_access,
         'ssh': ssh_access,
-    }[protocol](repo_url)
+    }[protocol](bits[1])

--- a/src/remote_master.py
+++ b/src/remote_master.py
@@ -11,6 +11,8 @@ from buildercore import project
 from decorators import mastertask
 
 def install_formula(pname, formula_url):
+    if formula_url.startswith("ssh://"):
+        formula_url = formula_url[6:]
     return local("/bin/bash /opt/builder/scripts/update-master-formula.sh %s %s" % (pname, formula_url))
 
 def install_update_all_project_formulas():


### PR DESCRIPTION
git 2.x (or maybe it's the fact that we are using Gitlab) seems to fail when ssh:// prefix is use before git@host.com:path/to/repo

These errors were found while provisioning a new master server on a Digirati account

(not sure yet if this is the right fix)