### PR TITLE
Trying to replace Python 2.7 PPA

### DIFF
--- a/scripts/bootstrap.sh
+++ b/scripts/bootstrap.sh
@@ -48,9 +48,9 @@ install_git=false
 # Salt to avoid changing it while it is running
 python_version=$(dpkg-query -W --showformat='${Version}' python2.7) # e.g. 2.7.5-5ubuntu3
 if dpkg --compare-versions "$python_version" lt 2.7.12; then
-    add-apt-repository -y ppa:fkrull/deadsnakes-python2.7
+    add-apt-repository ppa:jonathonf/python-2.7
     # the above should do the below but if it doesn't the rest will fail
-    # apt-key adv --keyserver keyserver.ubuntu.com --recv-keys 5BB92C09DB82666C
+    # apt-key adv --keyserver keyserver.ubuntu.com --recv-keys ...unknown key id...
     upgrade_python=true
 fi
 

--- a/scripts/bootstrap.sh
+++ b/scripts/bootstrap.sh
@@ -48,9 +48,12 @@ install_git=false
 # Salt to avoid changing it while it is running
 python_version=$(dpkg-query -W --showformat='${Version}' python2.7) # e.g. 2.7.5-5ubuntu3
 if dpkg --compare-versions "$python_version" lt 2.7.12; then
+    # provides python2.7[.13] package and some dependencies
     add-apt-repository ppa:jonathonf/python-2.7
-    # the above should do the below but if it doesn't the rest will fail
-    # apt-key adv --keyserver keyserver.ubuntu.com --recv-keys ...unknown key id...
+    # provides a recent python-urllib3 (1.13.1-2) because:
+    # libpython2.7-stdlib : Breaks: python-urllib3 (< 1.9.1-3) but 1.7.1-1ubuntu4 is to be installed
+    # due to the previous PPA
+    add-apt-repository ppa:ross-kallisti/python-urllib3
     upgrade_python=true
 fi
 

--- a/scripts/bootstrap.sh
+++ b/scripts/bootstrap.sh
@@ -48,6 +48,9 @@ install_git=false
 # Salt to avoid changing it while it is running
 python_version=$(dpkg-query -W --showformat='${Version}' python2.7) # e.g. 2.7.5-5ubuntu3
 if dpkg --compare-versions "$python_version" lt 2.7.12; then
+    # we used this, which is not available anymore, to provide a more recent Python 2.7
+    # let's remove it to avoid apt-get update errors
+    rm -f /etc/apt/sources.list.d/fkrull-deadsnakes-python2_7-trusty.list
     # provides python2.7[.13] package and some dependencies
     add-apt-repository ppa:jonathonf/python-2.7
     # provides a recent python-urllib3 (1.13.1-2) because:


### PR DESCRIPTION
The current one seems not available anymore. This solution causes other problems during bootstrap.sh execution