### PR TITLE
remote_master cuts: do not touch project formulas

### DIFF
--- a/.all-formulas.py
+++ b/.all-formulas.py
@@ -1,0 +1,6 @@
+#!/usr/bin/env python
+# lists all formulas used
+from buildercore import project
+
+for pname, formula_repo in project.all_formulas().iteritems():
+    print "%s,%s" % (pname, formula_repo)

--- a/.gitignore
+++ b/.gitignore
@@ -29,6 +29,7 @@ scripts/customize.sh
 scripts/salt/*.minion
 /custom-vagrant/salt/
 /custom-vagrant/pillar/
+/all-formulas.csv
 
 .no-install-basebox.flag
 .no-vagrant-s3auth.flag

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -304,8 +304,10 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
         # configure the instance as if it were a master server
         if IS_MASTER
             pillar_repo = "https://github.com/elifesciences/builder-private-example"
+            IO.popen("/bin/bash -c \"source venv/bin/activate && PYTHONPATH=src ./.all-formulas.py > all-formulas.csv\"").read
+
             project.vm.provision("shell", path: "scripts/init-master.sh", \
-                keep_color: true, privileged: true, args: [INSTANCE_NAME, pillar_repo])
+                                 keep_color: true, privileged: true, args: [INSTANCE_NAME, pillar_repo, "/vagrant/all-formulas.csv"])
 
             # this script is called regularly on master server to sync project formulas
             project.vm.provision("shell", path: "scripts/update-master.sh", \

--- a/projects/continuum.yaml
+++ b/projects/continuum.yaml
@@ -17,7 +17,7 @@ defaults:
     # repo containing project pillar data (credentials typically)
     # only the master-server will have a copy of this and only the master-server
     # will need permissions to clone it
-    private-repo: ssh://git@github.com/elife-anonymous-user/builder-private
+    private-repo: git@github.com:elife-anonymous-user/builder-private
     # default branch to use when creating new instances
     default-branch: master
     # set of formulas that the project depends upon in addition to its own
@@ -100,7 +100,7 @@ defaults:
         s3: []
  
 master-server:
-    formula-repo: ssh://git@github.com/elifesciences/master-server-formula
+    formula-repo: https://github.com/elifesciences/master-server-formula
     aws:
         ports:
             - 22
@@ -139,7 +139,7 @@ elife-bot:
 
 elife-dashboard:
     subdomain: ppp-dash # ppp-dash.elifesciences.org
-    repo: ssh://git@github.com/elifesciences/elife-dashboard
+    repo: https://github.com/elifesciences/elife-dashboard
     formula-repo: https://github.com/elifesciences/elife-dashboard-formula
     default-branch: develop
     aws:

--- a/projects/elife.yaml
+++ b/projects/elife.yaml
@@ -1111,12 +1111,15 @@ elife-xpub:
     repo: https://github.com/elifesciences/elife-xpub
     formula-repo: git@github.com:elifesciences/elife-xpub-formula
     aws:
+        ec2: 
+            ami: ami-1d4e7a66 # xenial, build 20170811, hvm:ebs-ssd
         type: t2.small
         ports:
             - 22
             - 443
             - 80
     vagrant:
+        box: bento/ubuntu-16.04
         ram: 2048
         ports:
             1201: 80

--- a/projects/elife.yaml
+++ b/projects/elife.yaml
@@ -1071,7 +1071,7 @@ evanthia-simpler-component:
 crm:
     subdomain: crm # crm.elifesciences.org
     repo: https://github.com/elifesciences/drupal-civi
-    formula-repo: ssh://git@github.com/elifesciences/crm-formula
+    formula-repo: git@github.com:elifesciences/crm-formula
     aws:
         type: t2.medium
         ports:

--- a/projects/elife.yaml
+++ b/projects/elife.yaml
@@ -309,13 +309,13 @@ journal:
             cloudfront:
                 subdomains:
                     - "{instance}--cdn-journal"
-                    - beta
+                    - www
                     - elife
                     - prod
                     - ""
-                    - www
                     # to overwrite a previously used DNS entry
                     - dummydoesnotexistsplaceholder
+                    - dummydoesnotexistsplaceholder2
                 headers:
                     - X-Requested-With
                     - Host

--- a/projects/elife.yaml
+++ b/projects/elife.yaml
@@ -15,7 +15,8 @@ defaults:
     # repo containing project pillar data (credentials typically)
     # only the master-server will have a copy of this and only the master-server
     # will need permissions to clone it
-    private-repo: ssh://git@github.com/elifesciences/builder-private
+    # TODO: hunt down ssh:// remotes
+    private-repo: git@github.com:elifesciences/builder-private
     # default branch to use when creating new instances
     default-branch: master
     # in rare cases we have formulas requiring the states of other formulas

--- a/projects/example.yaml
+++ b/projects/example.yaml
@@ -63,7 +63,7 @@ master-server:
     # formula-repo for the 'master-server' project should contain the 
     # confidential pillar data, master config and state top file.
     # TODO: link to further docs
-    formula-repo: ssh://git@github.com/elifesciences/builder-private
+    formula-repo: https://github.com/elifesciences/master-server-formula
     aws:
         ports:
             22: 22

--- a/scripts/init-master.sh
+++ b/scripts/init-master.sh
@@ -143,8 +143,10 @@ fi
 cp /opt/builder-private/etc-salt-master /etc/salt/master
 
 cd /srv
-ln -sf /opt/builder-private/pillar
-ln -sf /opt/builder-private/salt
+# on Vagrant, this overwrite /srv/pillar which contains the pillars from the formula
+#ln -sf /opt/builder-private/pillar
+# on Vagrant, this overwrite /srv/salt which contains the formula
+#ln -sf /opt/builder-private/salt
 
 echo "master server configured"
 

--- a/scripts/init-master.sh
+++ b/scripts/init-master.sh
@@ -11,7 +11,7 @@ set -xv  # output the scripts and interpolated steps
 
 stackname=$1 # who am I? ll: master-server--2016-01-01
 pillar_repo=$2 # what secrets do I know?
-formulas=$3 # which formulas will I use? YAML format
+formulas=$3 # which formulas will I use?
 formula_root="/opt/formulas"
 
 echo "bootstrapping master-minion $stackname"

--- a/scripts/update-master.sh
+++ b/scripts/update-master.sh
@@ -34,7 +34,18 @@ fi
 
 # replace the master config, if it exists, with the builder-private copy ...
 cp /opt/builder-private/etc-salt-master /etc/salt/master
+
+env
 # ... then clone/pull all formula repos and update master config
+cd /opt/formulas
+for formula in `ls`; do
+    cd $formula
+    git reset --hard
+    git clean -d --force
+    git pull --rebase
+    cd ..
+done
+cd /opt/builder
 BLDR_ROLE=master ./bldr remote_master.refresh
 
 service salt-master stop || true

--- a/src/buildercore/bootstrap.py
+++ b/src/buildercore/bootstrap.py
@@ -441,7 +441,7 @@ def update_ec2_stack(stackname, concurrency):
         return
     region = pdata['aws']['region']
     is_master = core.is_master_server_stack(stackname)
-    is_masterless = pdata['aws']['ec2']['masterless']
+    is_masterless = pdata['aws']['ec2'].get('masterless', False)
 
     master_builder_key = None
     if is_masterless:

--- a/src/buildercore/bootstrap.py
+++ b/src/buildercore/bootstrap.py
@@ -22,7 +22,7 @@ from fabric.contrib import files
 from fabric import operations
 from boto.exception import BotoServerError
 from kids.cache import cache as cached
-from buildercore import context_handler
+from buildercore import context_handler, project
 from functools import reduce # pylint:disable=redefined-builtin
 
 import logging
@@ -478,9 +478,8 @@ def update_ec2_stack(stackname, concurrency):
 
         if is_master:
             builder_private_repo = pdata['private-repo']
-            if builder_private_repo.startswith('ssh://'):
-                builder_private_repo = builder_private_repo[6:]
-            run_script('init-master.sh', stackname, builder_private_repo)
+            all_formulas = project.known_formulas()
+            run_script('init-master.sh', stackname, builder_private_repo, ' '.join(all_formulas))
             run_script('update-master.sh', stackname, builder_private_repo)
 
         # this will tell the machine to update itself

--- a/src/buildercore/project/__init__.py
+++ b/src/buildercore/project/__init__.py
@@ -1,5 +1,7 @@
 # from . import core # DONT import core. this project module should be relatively independent
 from collections import OrderedDict
+import re
+import os
 from buildercore import utils, config
 from buildercore.decorators import osissue
 from kids.cache import cache
@@ -127,12 +129,15 @@ def branch_deployable_projects(*args, **kwargs):
 def projects_with_formulas(*args, **kwargs):
     return filtered_projects(lambda pname, pdata: pdata.get('formula-repo'), *args, **kwargs)
 
-# TODO: add builder-base => builder-base-formula
 def all_formulas():
     formulas = OrderedDict()
     for pname in projects_with_formulas():
         pdata = project_data(pname)
         formulas[pname] = pdata['formula-repo']
+        for dep in pdata.get('formula-dependencies', []):
+            dep_name = re.sub('-formula$', '', os.path.basename(dep))
+            formulas[dep_name] = dep
+
     return formulas
 
 def aws_projects(*args, **kwargs):

--- a/src/buildercore/project/__init__.py
+++ b/src/buildercore/project/__init__.py
@@ -127,6 +127,7 @@ def branch_deployable_projects(*args, **kwargs):
 def projects_with_formulas(*args, **kwargs):
     return filtered_projects(lambda pname, pdata: pdata.get('formula-repo'), *args, **kwargs)
 
+# TODO: add builder-base => builder-base-formula
 def all_formulas():
     formulas = OrderedDict()
     for pname in projects_with_formulas():

--- a/src/buildercore/project/__init__.py
+++ b/src/buildercore/project/__init__.py
@@ -1,4 +1,5 @@
 # from . import core # DONT import core. this project module should be relatively independent
+from collections import OrderedDict
 from buildercore import utils, config
 from buildercore.decorators import osissue
 from kids.cache import cache
@@ -125,6 +126,13 @@ def branch_deployable_projects(*args, **kwargs):
 
 def projects_with_formulas(*args, **kwargs):
     return filtered_projects(lambda pname, pdata: pdata.get('formula-repo'), *args, **kwargs)
+
+def all_formulas():
+    formulas = OrderedDict()
+    for pname in projects_with_formulas():
+        pdata = project_data(pname)
+        formulas[pname] = pdata['formula-repo']
+    return formulas
 
 def aws_projects(*args, **kwargs):
     return filtered_projects(lambda pname, pdata: 'aws' in pdata, *args, **kwargs)

--- a/src/buildercore/project/repo.py
+++ b/src/buildercore/project/repo.py
@@ -11,11 +11,15 @@ def ssh_access(url):
 
 def access(repo_url):
     bits = repo_url.split('://', 1)
-    assert len(bits) == 2, "could not find a protocol in url: %r" % repo_url
-    protocol, _ = bits
+    if len(bits) == 1:
+        protocol = 'ssh'
+        remote = repo_url
+    else:
+        assert len(bits) == 2, "could not find a protocol in url: %r" % repo_url
+        protocol, remote = bits
     if protocol == 'http':
         protocol = 'https'
     return {
         'https': http_access,
         'ssh': ssh_access,
-    }[protocol](bits[1])
+    }[protocol](remote)

--- a/src/remote_master.py
+++ b/src/remote_master.py
@@ -15,15 +15,12 @@ def install_formula(pname, formula_url):
         formula_url = formula_url[6:]
     return local("/bin/bash /opt/builder/scripts/update-master-formula.sh %s %s" % (pname, formula_url))
 
-def install_update_all_project_formulas():
-    for pname in project.projects_with_formulas():
-        pdata = project.project_data(pname)
-        formula_url = pdata['formula-repo']
-        install_formula(pname, formula_url)
-
 def install_update_formula_deps():
     pdata = project.project_data('master-server')
     for dep in pdata.get('formula-dependencies', []):
+        # TODO: this is inconsistent as api-dummy-formula could both be present both as
+        # - api-dummy (as project main formula)
+        # - api-dummy-formula (as dependency)
         name = os.path.basename(dep) # ll: 'some-formula' in 'https://github.com/elifesciences/some-formula
         install_formula(name, dep)
 
@@ -66,5 +63,4 @@ def refresh():
     # called as part of the update-master.sh script with the 'master' BLDR ROLE
     # shouldn't be called otherwise
     install_update_formula_deps() # builder base
-    install_update_all_project_formulas() # website, journal, etc
     refresh_config() # rewrite /etc/salt/master yaml

--- a/src/remote_master.py
+++ b/src/remote_master.py
@@ -10,20 +10,6 @@ from fabric.api import local
 from buildercore import project
 from decorators import mastertask
 
-def install_formula(pname, formula_url):
-    if formula_url.startswith("ssh://"):
-        formula_url = formula_url[6:]
-    return local("/bin/bash /opt/builder/scripts/update-master-formula.sh %s %s" % (pname, formula_url))
-
-def install_update_formula_deps():
-    pdata = project.project_data('master-server')
-    for dep in pdata.get('formula-dependencies', []):
-        # TODO: this is inconsistent as api-dummy-formula could both be present both as
-        # - api-dummy (as project main formula)
-        # - api-dummy-formula (as dependency)
-        name = os.path.basename(dep) # ll: 'some-formula' in 'https://github.com/elifesciences/some-formula
-        install_formula(name, dep)
-
 def private_ip():
     cmd = "/sbin/ifconfig eth0 | awk '/inet / { print $2 }' | sed 's/addr://'"
     return str(local(cmd, capture=True))
@@ -62,5 +48,4 @@ def refresh_config():
 def refresh():
     # called as part of the update-master.sh script with the 'master' BLDR ROLE
     # shouldn't be called otherwise
-    install_update_formula_deps() # builder base
     refresh_config() # rewrite /etc/salt/master yaml

--- a/src/remote_master.py
+++ b/src/remote_master.py
@@ -33,12 +33,17 @@ def private_ip():
 
 def private_file_roots():
     return [
-        "/srv/salt/",
+        "/opt/builder-private/salt/",
     ]
 
 def basic_file_roots():
     return [
         "/opt/formulas/builder-base-formula/",
+    ]
+
+def private_pillar_roots():
+    return [
+        "/opt/builder-private/pillar",
     ]
 
 def formula_file_roots():
@@ -50,6 +55,7 @@ def refresh_config():
     with open('/etc/salt/master', 'r') as cfgfile:
         cfg = core_utils.ordered_load(cfgfile)
     cfg['file_roots']['base'] = private_file_roots() + formula_file_roots() + basic_file_roots()
+    cfg['pillar_roots']['base'] = private_pillar_roots()
     cfg['interface'] = private_ip()
 
     with open('/etc/salt/master', 'w') as cfgfile:


### PR DESCRIPTION
- Dumping formula list as CSV and passing it to init-master.sh
- Formulas are initialized through the CSV file
- All formulas are updated when in /opt/formulas
- builder's `remote_master` does not touch ordinary formulas anymore

Incidentally:
- Avoid conflict on /srv/salt, /srv/pillar

Want to get these integrated and live, perhaps with the addition of builder-base-formula, before following up in cutting remote_master's work until it's empty and remove the builder deployment from the master server.