### PR TITLE
Removing remote master tweaks

### DIFF
--- a/.master.py
+++ b/.master.py
@@ -1,9 +1,0 @@
-#!/usr/bin/env python
-# renders a master-server's configuration as YAML
-# only argument is the template etc-salt-master file
-import sys
-from buildercore import bootstrap, project
-
-all_formulas = project.known_formulas()
-master_configuration_template=open(sys.argv[1], 'r')
-print bootstrap.render_master_configuration(master_configuration_template, all_formulas).getvalue()

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -24,6 +24,12 @@ def runcmd(cmd)
     return output
 end
 
+def project_cmd(argstr)
+    cmd = "/bin/bash -c \"source venv/bin/activate && ./.project.py #{argstr}\""
+    #prn(cmd)
+    return YAML.load(IO.popen(cmd).read)
+end
+
 def runningvms()
     begin
         v = %x(vboxmanage list runningvms 2> .vagrant-error)
@@ -46,7 +52,7 @@ VAGRANTFILE_API_VERSION = "2"
 VAGRANT_COMMAND = ARGV[0]
 VAGRANT_VERSION = %x(vagrant --version).gsub(/[^\d\.]/, "") # looks like: 1.7.4
 # all *VAGRANT* projects
-ALL_PROJECTS = YAML.load(IO.popen("/bin/bash -c \"source venv/bin/activate && ./.project.py --env=vagrant\"").read)
+ALL_PROJECTS = project_cmd("--env=vagrant")
 
 # essentially gives vagrant a project to use to prevent the prompt
 if ['box'].include? VAGRANT_COMMAND
@@ -136,8 +142,7 @@ if not SUPPORTED_PROJECTS.has_key? INSTANCE_NAME
     abort 
 end
 
-cmd = "/bin/bash -c \"source venv/bin/activate && ./.project.py #{PROJECT_NAME}\""
-PRJ = YAML.load(IO.popen(cmd).read)
+PRJ = project_cmd(PROJECT_NAME)
 
 #PP.pp PRJ
 #abort
@@ -304,10 +309,10 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
         # configure the instance as if it were a master server
         if IS_MASTER
             pillar_repo = "https://github.com/elifesciences/builder-private-example"
-            all_formulas = YAML.load(IO.popen("/bin/bash -c \"source venv/bin/activate && ./.project.py --formula\"").read)
+            all_formulas = project_cmd("--formula")
             project.vm.provision("shell", path: "scripts/init-master.sh", \
                 keep_color: true, privileged: true, args: [INSTANCE_NAME, pillar_repo, all_formulas.join(' ')])
-            master_configuration = IO.popen("/bin/bash -c \"source venv/bin/activate && PYTHONPATH=src ./.master.py etc-salt-master.template | tee etc-salt-master\"").read
+            master_configuration = project_cmd("master-server --task salt-master-config | tee etc-salt-master")
             project.vm.provision("file", source: "./etc-salt-master", destination: "/tmp/etc-salt-master")
             project.vm.provision("shell", inline: "sudo mv /tmp/etc-salt-master /etc/salt/master")
 

--- a/src/buildercore/bootstrap.py
+++ b/src/buildercore/bootstrap.py
@@ -13,7 +13,7 @@ from . import core, utils, config, keypair, bvars
 from collections import OrderedDict
 from datetime import datetime
 from .core import connect_aws_with_stack, stack_pem, stack_all_ec2_nodes, project_data_for_stackname, stack_conn
-from .utils import first, call_while, ensure, subdict
+from .utils import first, call_while, ensure, subdict, yaml_dump
 from .lifecycle import delete_dns
 from .config import BOOTSTRAP_USER
 from fabric.api import sudo, put
@@ -435,21 +435,25 @@ def download_master_configuration(master_stack):
         operations.get(remote_path='/etc/salt/master.template', local_path=fh, use_sudo=True)
     return fh
 
-def render_master_configuration(master_configuration_template, formulas):
+def expand_master_configuration(master_configuration_template, formulas=None):
+    "reads a /etc/salt/master type file in as YAML and returns a processed python dictionary"
     cfg = core_utils.ordered_load(master_configuration_template)
+
+    if not formulas:
+        formulas = project.known_formulas() # *all* formulas
 
     def basename(formula):
         return re.sub('-formula$', '', os.path.basename(formula))
     formula_path = '/opt/formulas/%s/'
 
-    cfg['file_roots']['base'] = ["/opt/builder-private/salt/"] + [formula_path % basename(f) for f in formulas] + ["/opt/formulas/builder-base/"]
+    cfg['file_roots']['base'] = \
+        ["/opt/builder-private/salt/"] + \
+        [formula_path % basename(f) for f in formulas] + \
+        ["/opt/formulas/builder-base/"]
     cfg['pillar_roots']['base'] = ["/opt/builder-private/pillar"]
     # dealt with at the infrastructural level
     cfg['interface'] = '0.0.0.0'
-
-    master_configuration = StringIO()
-    core_utils.ordered_dump(cfg, master_configuration)
-    return master_configuration
+    return cfg
 
 def upload_master_configuration(master_stack, master_configuration):
     with stack_conn(master_stack):
@@ -516,8 +520,8 @@ def update_ec2_stack(stackname, concurrency):
             all_formulas = project.known_formulas()
             run_script('init-master.sh', stackname, builder_private_repo, ' '.join(all_formulas))
             master_configuration_template = download_master_configuration(stackname)
-            master_configuration = render_master_configuration(master_configuration_template, all_formulas)
-            upload_master_configuration(stackname, master_configuration)
+            master_configuration = expand_master_configuration(master_configuration_template, all_formulas)
+            upload_master_configuration(stackname, yaml_dump(master_configuration))
             run_script('update-master.sh', stackname, builder_private_repo)
 
         # this will tell the machine to update itself

--- a/src/buildercore/project/files.py
+++ b/src/buildercore/project/files.py
@@ -20,7 +20,7 @@ def update_project_file(path, value, project_data, project_file):
 
 @testme
 def write_project_file(new_project_data, project_file):
-    data = utils.ordered_dump(new_project_data)
+    data = utils.yaml_dumps(new_project_data)
     # this awful bit of code injects two new lines after before each top level element
     lines = []
     for line in data.split('\n'):
@@ -29,8 +29,7 @@ def write_project_file(new_project_data, project_file):
             lines.append("")
         lines.append(line)
     # all done. convert back to ordereddict
-    #new_project_data = utils.ordered_load(StringIO("\n".join(lines)))
-    open(project_file, 'w').write("\n".join(lines))  # utils.ordered_dump(new_project_data))
+    open(project_file, 'w').write("\n".join(lines))
     return project_file
 
 

--- a/src/buildercore/utils.py
+++ b/src/buildercore/utils.py
@@ -1,5 +1,6 @@
 import pytz
 import os, sys, copy, json, time, random, string
+from StringIO import StringIO
 from functools import wraps
 from datetime import datetime
 import yaml
@@ -216,7 +217,19 @@ def ordered_dump(data, stream=None, dumper_class=yaml.Dumper, default_flow_style
             data.items())
     OrderedDumper.add_representer(OrderedDict, _dict_representer)
     kwds.update({'default_flow_style': default_flow_style, 'indent': indent, 'line_break': line_break})
+    # WARN: if stream is provided, return value is None
     return yaml.dump(data, stream, OrderedDumper, **kwds)
+
+def yaml_dumps(data):
+    "like json.dumps, returns a YAML string"
+    return ordered_dump(data, stream=None)
+
+def yaml_dump(data, stream=None):
+    "writes output to given file-like object or StringIO if stream not provided"
+    if not stream:
+        stream = StringIO()
+    ordered_dump(data, stream)
+    return stream
 
 def remove_ordereddict(data, dangerous=True):
     """turns a nested OrderedDict dict into a regular dictionary.

--- a/src/project.py
+++ b/src/project.py
@@ -12,7 +12,7 @@ def data(pname, output_format=None):
     ensure(output_format in [None, 'json', 'yaml'], "unknown output format %r" % output_format)
     formatters = {
         'json': core_utils.json_dumps,
-        'yaml': core_utils.ordered_dump,
+        'yaml': core_utils.yaml_dumps,
         None: lambda v: v
     }
     formatter = formatters.get(output_format)

--- a/src/tests/test_buildercore_bootstrap.py
+++ b/src/tests/test_buildercore_bootstrap.py
@@ -1,11 +1,13 @@
 from . import base
 from buildercore import bootstrap
+from buildercore.utils import yaml_dumps
 
 class TestBuildercoreBootstrap(base.BaseCase):
     def test_master_configuration(self):
         formulas = ['https://github.com/elifesciences/journal-formula', 'https://github.com/elifesciences/lax-formula']
         master_configuration_template = open('src/tests/fixtures/etc-salt-master.template', 'r')
-        master_configuration = bootstrap.render_master_configuration(master_configuration_template, formulas).getvalue()
+        master_configuration = bootstrap.expand_master_configuration(master_configuration_template, formulas)
+        master_configuration_yaml = yaml_dumps(master_configuration)
         expected_configuration = """auto_accept: true
 interface: 0.0.0.0
 log_level: info
@@ -21,4 +23,4 @@ pillar_roots:
     base:
     - /opt/builder-private/pillar
 """
-        self.assertEqual(master_configuration, expected_configuration)
+        self.assertEqual(master_configuration_yaml, expected_configuration)


### PR DESCRIPTION
* shifted `.master.py` logic into `.project.py` 
* wrapped calls to `.project.py` in Vagrantfile to reduce duplication
* shifted the rendering of master config to YAML out of `bootstrap.py`
* renamed `render_master_configuration` to `expand_master_configuration`
* gave `expand_master_configuration` a sensible default for formula list

this PR feels a bit heavy handed so I want to explain the rationale behind the changes.
1. the snippets of logic in little hidden files accumulates. we would have three now if I hadn't refactored your other PR. they don't appear to be linted, or scrubbed or tested and they live outside of the `src` or `scripts` directory. this time around I've adjusted `.project.py` so it's more obvious how to add more ad-hoc code ('tasks') as we need them.

2. I've never liked the `ordered_load` and `ordered_dump` functions in utils.py. you can still see my disabled `yaml_loads` code waiting for it's chance to be useful one day and `ordered_dump` behaves differently if you pass a stream in as well. I've now made two wrapper functions with explicit return types. 

3. I prefer the rendering/serialization of data done at the last moment if possible. Data is malleable and testable and YAML/JSON serializations of data less so.

4. still a bit blergh about those temporary files in the project root (`etc-salt-master` and `etc-salt-master.template`), I feel builder needs a temporary working directory with a blanket ignore in `.gitignore`. could download files to this directory by default as well... another problem for another time though.

if you're ok with this PR, feel free to merge it and it's parent