### PR TITLE
adds a default mysql setting to the minion config file.

### DIFF
--- a/scripts/bootstrap.sh
+++ b/scripts/bootstrap.sh
@@ -127,6 +127,7 @@ else
 fi
 
 echo "$minion_id" > /etc/salt/minion_id
+echo "mysql.unix_socket: '/var/run/mysqld/mysqld.sock'" > /etc/salt/minion.d/mysql-defaults.conf
 
 #  service restart necessary as we've changed the minion's configuration
 service salt-minion restart


### PR DESCRIPTION
mysql disallows remote connections by default in 16.04 for tighter security and this will allow us to do away with salt's connection_username: ... type settings for mysql.

tested on vagrant on 16.04 and 14.04 and on 14.04 with and without the `connection_*: ...` fields in the `mysql_user:` states. this should be backwards compatible.