### PR TITLE
VPC ip range needlessly strict

### DIFF
--- a/projects/elife.yaml
+++ b/projects/elife.yaml
@@ -596,7 +596,7 @@ journal-cms:
             - 22
             - 443
             - 80:
-                cidr-ip: 10.0.2.0/24 # access via VPC ip range only
+                cidr-ip: 10.0.0.0/16 # access via VPC ip range only
         sqs:
             # journal-cms--prod, journal-cms--end2end, etc.
             journal-cms--{instance}:
@@ -855,7 +855,7 @@ medium:
         ports:
             - 22
             - 80:
-                cidr-ip: 10.0.2.0/24 # internal access only
+                cidr-ip: 10.0.0.0/16 # internal access only
     aws-alt:
         clustered:
             ec2:
@@ -908,7 +908,7 @@ search:
         ports:
             - 22
             - 80:
-                cidr-ip: 10.0.2.0/24 # internal access only
+                cidr-ip: 10.0.0.0/16 # internal access only
         sqs:
             # search--prod, search--end2end, etc.
             search--{instance}:


### PR DESCRIPTION
The real range is 10.0.0.0/16, this is only one subnet (in us-east-1d). Created a problem for balancing lax as the ELBs are in two different subnets (respectively in two different availability zones).
Not urgent nor quick to perform, but I want to keep track of it so PR.