### PR TITLE
Reduce blue-green deployment timeouts

### DIFF
--- a/src/buildercore/bluegreen.py
+++ b/src/buildercore/bluegreen.py
@@ -78,7 +78,7 @@ class BlueGreenConcurrency(object):
 
         # needs to be as responsive as possible,
         # to start deregistering the green group as soon as a blue server becomes available
-        call_while(condition, interval=1, timeout=600)
+        call_while(condition, interval=1, timeout=60)
 
     def wait_registered_all(self, elb_name, nodes_params):
         LOG.info("Waiting for registration of all on %s: %s", elb_name, self._instance_ids(nodes_params))
@@ -88,7 +88,7 @@ class BlueGreenConcurrency(object):
             LOG.info("InService: %s", registered)
             return False in registered.values()
 
-        call_while(condition, interval=5, timeout=600)
+        call_while(condition, interval=5, timeout=60)
 
     def wait_deregistered_all(self, elb_name, nodes_params):
         LOG.info("Waiting for deregistration of all on %s: %s", elb_name, self._instance_ids(nodes_params))
@@ -98,7 +98,7 @@ class BlueGreenConcurrency(object):
             LOG.info("InService: %s", registered)
             return True in registered.values()
 
-        call_while(condition, interval=5, timeout=600)
+        call_while(condition, interval=5, timeout=60)
 
     def _registered(self, elb_name, nodes_params):
         health = self.conn.describe_instance_health(


### PR DESCRIPTION
Waiting on instances to get notices on the ELB after they have been added or removed. 10 minutes is ridiculously long and in case one of those health checks fail we want to know sooner.