### PR TITLE
Passing prep-stack script in EC2 UserData

### DIFF
--- a/projects/elife.yaml
+++ b/projects/elife.yaml
@@ -957,7 +957,12 @@ iiif:
                 - 80:
                     cidr-ip: 10.0.0.0/16 # ELB only
             ec2:
-                cluster-size: 2
+                #suppressed: [1]
+                overrides:
+                    1:
+                        ext:
+                            type: gp2
+                cluster-size: 4
             ext:
                 size: 30 # GB
             elb:

--- a/projects/elife.yaml
+++ b/projects/elife.yaml
@@ -957,9 +957,12 @@ iiif:
                 - 80:
                     cidr-ip: 10.0.0.0/16 # ELB only
             ec2:
-                #suppressed: [1]
+                #suppressed: [2]
                 overrides:
                     1:
+                        ext:
+                            type: gp2
+                    2:
                         ext:
                             type: gp2
                 cluster-size: 4

--- a/scripts/.clean-server.sh.fragment
+++ b/scripts/.clean-server.sh.fragment
@@ -1,0 +1,17 @@
+if command -v salt-minion > /dev/null; then
+    # salt is installed, probably using an AMI or creating an AMI
+    # https://docs.saltstack.com/en/latest/ref/modules/all/salt.modules.saltutil.html#salt.modules.saltutil.clear_cache
+    service salt-minion stop
+fi
+
+# remove leftover files from AMIs
+rm -rf \
+    /etc/cfn-info.json \
+    /etc/salt/pki/minion/minion_master.pub \
+    /etc/salt/minion \
+    /root/.ssh/* \
+    /home/elife/.ssh/* \
+    /home/ubuntu/.ssh/id_rsa* \
+    /etc/certificates/* \
+    /root/events.log \
+    /var/cache/salt/minion

--- a/scripts/bootstrap.sh
+++ b/scripts/bootstrap.sh
@@ -57,12 +57,12 @@ else
         rm -f /etc/apt/sources.list.d/fkrull-deadsnakes-python2_7-trusty.list
 
         # provides python2.7[.13] package and some dependencies
-        add-apt-repository ppa:jonathonf/python-2.7
+        add-apt-repository -y ppa:jonathonf/python-2.7
 
         # provides a recent python-urllib3 (1.13.1-2) because:
         # libpython2.7-stdlib : Breaks: python-urllib3 (< 1.9.1-3) but 1.7.1-1ubuntu4 is to be installed
         # due to the previous PPA
-        add-apt-repository ppa:ross-kallisti/python-urllib3
+        add-apt-repository -y ppa:ross-kallisti/python-urllib3
         upgrade_python=true
     fi
 fi

--- a/src/buildercore/bootstrap.py
+++ b/src/buildercore/bootstrap.py
@@ -158,7 +158,6 @@ def setup_ec2(stackname, context_ec2):
                 LOG.debug("failed to connect to server ...")
                 return True
         utils.call_while(is_resourcing, interval=3, update_msg='Waiting for /home/ubuntu to be detected ...')
-        prep_ec2_instance()
 
     stack_all_ec2_nodes(stackname, _setup_ec2_node, username=BOOTSTRAP_USER)
 

--- a/src/buildercore/cfngen.py
+++ b/src/buildercore/cfngen.py
@@ -8,11 +8,14 @@ template.
 When an instance of a project is launched on AWS, we need to tweak things a bit
 with no manual steps in some cases, or as few as possible in other cases.
 
-Case 1: Continuous Deployment
-After a successful build and test on the CI server, we want to deploy an instance.
+Case 1: New, standardized environment
+We launch journal--ci, a testing instance for the journal project within the `ci` environment.
 
 Case 2: Ad-hoc instances
-A developer wants a temporary instance deployed for testing or debugging.
+We launch journal--testsomething, a testing instance we will use to check something works as expected.
+
+Case 3: Stack updates
+We want to add an external volume to an EC2 instance to increase available space, so we partially update the CloudFormation template to create it.
 
 """
 import os, json, copy


### PR DESCRIPTION
Successfully changed status of iiif--ci--2 (its `ext` `type` from `standard` to `gp2`) by suppressing the server first, and then recreating with an override.

The only manual step is deleting the minion key from the master-server between the two `update_template` steps.