### PR TITLE
donotmerge - optimised iiif project config

### DIFF
--- a/projects/elife.yaml
+++ b/projects/elife.yaml
@@ -947,82 +947,41 @@ iiif:
         type: t2.medium
         ports:
             - 22
-            - 80
-            - 443
+            - 80:
+                cidr-ip: 10.0.0.0/16 # ELB only
+        ec2:
+            cluster-size: 2
+        elb:
+            protocol: 
+                - https
+            healthcheck:
+                path: /
+        cloudfront:
+            subdomains: 
+                - "{instance}--cdn-iiif"
+            headers:
+                - Host
+        ext:
+            size: 30 # GB
     aws-alt:
-        # for testing new versions
+        adhoc:
+            description: a single ec2 iiif server available over HTTPS. no ELB, no CDN.
+            ports:
+                - 22
+                - 80:
+                    cidr-ip: 10.0.0.0/16 # ELB only
+                - 443
+            ec2:
+                cluster-size: 1
+            elb: []
+            cloudfront: []
+            ext: []
         ci:
-            ports:
-                - 22
-                - 80:
-                    cidr-ip: 10.0.0.0/16 # ELB only
-            ec2:
-                cluster-size: 2
-            ext:
-                size: 30 # GB
-            elb:
-                protocol: 
-                    - https
-                healthcheck:
-                    path: /
-        end2end:
-            ports:
-                - 22
-                - 80:
-                    cidr-ip: 10.0.0.0/16 # ELB only
-            ec2:
-                cluster-size: 2
-                #suppressed: [1]
-            ext:
-                size: 30 # GB
-            elb:
-                protocol: 
-                    - https
-                healthcheck:
-                    path: /
-            cloudfront:
-                subdomains: 
-                    - "{instance}--cdn-iiif"
-                headers:
-                    - Host
-        # manual tests
-        continuumtest:
-            ports:
-                - 22
-                - 80:
-                    cidr-ip: 10.0.0.0/16 # ELB only
-            ec2:
-                cluster-size: 2
-            elb:
-                protocol: 
-                    - https
-                healthcheck:
-                    path: /
-            cloudfront:
-                subdomains: 
-                    - "{instance}--cdn-iiif"
-                headers:
-                    - Host
-        prod:
-            ports:
-                - 22
-                - 80:
-                    cidr-ip: 10.0.0.0/16 # ELB only
-            ec2:
-                cluster-size: 2
-            ext:
-                size: 30 # GB
-            elb:
-                protocol: 
-                    - https
-                healthcheck:
-                    path: /
-            cloudfront:
-                subdomains: 
-                    - "{instance}--cdn-iiif"
-                    - iiif
-                headers:
-                    - Host
+            description: for testing new versions. no CDN.
+            cloudfront: []
+        continuumtest: 
+            description: manual tests
+            ext: []
     vagrant:
         ports:
             1261: 80


### PR DESCRIPTION
it seems like the normal case for iiif is to be clustered and behind an elb with an external volume.

* iiif, shifts the common attributes in alt configs into default config
* adds a simplified 'adhoc' alt config with no cdn, elb, ext vol, etc
* removed gutted alt-configs.

this PR is just for feedback, I haven't tested the changes. I have a sneaking suspicion the project merging will detect the presence of the empty (but not absent) keys and merge in the project defaults.