### PR TITLE
Balance lax--end2end

### DIFF
--- a/projects/elife.yaml
+++ b/projects/elife.yaml
@@ -168,6 +168,7 @@ master-server:
 
 lax:
     subdomain: lax # lax.elifesciences.org
+    intdomain: False
     repo: https://github.com/elifesciences/lax.git
     formula-repo: https://github.com/elifesciences/lax-formula
     aws:
@@ -194,24 +195,22 @@ lax:
                 multi-az: true
             ext:
                 size: 10 # GB
-        # balanced entry won't be valid until we specify intdomain: False
-        # as the load balancer can't have both the internal and external DNS entries pointing to it
-        #balanced:
-        #    description: testing out load balancing for high availability
-        #    rds:
-        #        storage: 5
-        #        multi-az: true
-        #    ext:
-        #        size: 10 # GB
-        #    elb:
-        #        protocol:
-        #            - https
-        #        additional_listeners:
-        #            bot_lax_adaptor:
-        #                protocol: https
-        #                port: 8001
-        #        healthcheck:
-        #            path: /api/v2/ping
+        balanced:
+            description: testing out load balancing for high availability
+            rds:
+                storage: 5
+                multi-az: true
+            ext:
+                size: 10 # GB
+            elb:
+                protocol:
+                    - https
+                additional_listeners:
+                    bot_lax_adaptor:
+                        protocol: https
+                        port: 8001
+                healthcheck:
+                    path: /api/v2/ping
     vagrant:
         box: bento/ubuntu-16.04
         ports:

--- a/projects/elife.yaml
+++ b/projects/elife.yaml
@@ -186,8 +186,19 @@ lax:
             description: RDS backed
             rds:
                 storage: 5
+                # TODO: apply as it must be identical to prod
+                #multi-az: true
             ext:
                 size: 10 # GB
+            elb:
+                protocol:
+                    - https
+                additional_listeners:
+                    bot_lax_adaptor:
+                        protocol: https
+                        port: 8001
+                healthcheck:
+                    path: /api/v2/ping
         prod:
             description: RDS backed
             rds:

--- a/src/buildercore/cfngen.py
+++ b/src/buildercore/cfngen.py
@@ -333,7 +333,7 @@ def regenerate_stack(pname, **more_context):
 
 
 UPDATABLE_TITLE_PATTERNS = ['^CloudFront.*', '^ElasticLoadBalancer.*', '^EC2Instance.*', '.*Bucket$', '.*BucketPolicy', '^StackSecurityGroup$', '^ELBSecurityGroup$', '^CnameDNS.+$', '^AttachedDB$', '^AttachedDBSubnet$', '^ExtraStorage.+$', '^MountPoint.+$', '^IntDNS$']
-REMOVABLE_TITLE_PATTERNS = ['^CnameDNS\\d+$', '^ExtDNS$', '^ExtraStorage.+$', '^MountPoint.+$', '^.+Queue$', '^EC2Instance.+$']
+REMOVABLE_TITLE_PATTERNS = ['^CnameDNS\\d+$', '^ExtDNS$', '^ExtraStorage.+$', '^MountPoint.+$', '^.+Queue$', '^EC2Instance.+$', '^IntDNS$']
 EC2_NOT_UPDATABLE_PROPERTIES = ['ImageId', 'Tags', 'UserData']
 
 def template_delta(pname, context):

--- a/src/buildercore/cfngen.py
+++ b/src/buildercore/cfngen.py
@@ -332,7 +332,9 @@ def regenerate_stack(pname, **more_context):
     return context, delta_plus, delta_minus
 
 
+# can't add ExtDNS: it changes dynamically when we start/stop instances and should not be touched after creation
 UPDATABLE_TITLE_PATTERNS = ['^CloudFront.*', '^ElasticLoadBalancer.*', '^EC2Instance.*', '.*Bucket$', '.*BucketPolicy', '^StackSecurityGroup$', '^ELBSecurityGroup$', '^CnameDNS.+$', '^AttachedDB$', '^AttachedDBSubnet$', '^ExtraStorage.+$', '^MountPoint.+$', '^IntDNS$']
+
 REMOVABLE_TITLE_PATTERNS = ['^CnameDNS\\d+$', '^ExtDNS$', '^ExtraStorage.+$', '^MountPoint.+$', '^.+Queue$', '^EC2Instance.+$', '^IntDNS$']
 EC2_NOT_UPDATABLE_PROPERTIES = ['ImageId', 'Tags', 'UserData']
 

--- a/src/buildercore/lifecycle.py
+++ b/src/buildercore/lifecycle.py
@@ -132,6 +132,7 @@ def update_dns(stackname):
     if context.get('elb', False):
         # ELB has its own DNS, EC2 nodes will autoregister
         LOG.info("Multiple nodes, EC2 nodes will autoregister to ELB, nothing to do")
+        # TODO: time to implement this as there may be an old A record around...
         return
 
     LOG.info("External full hostname: %s", context['full_hostname'])


### PR DESCRIPTION
- lax--balanced is valid again
- IntDNS is removable so projects can drop their elife.internal hostname