### PR TITLE
Avoid needless RDS updates

### DIFF
--- a/src/buildercore/trop.py
+++ b/src/buildercore/trop.py
@@ -229,6 +229,7 @@ def render_rds(context, template):
     # rds parameter group. None or a Ref
     param_group_ref = rdsdbparams(context, template)
 
+    tags = [t for t in instance_tags(context) if t.Key != 'Owner']
     # db instance
     data = {
         'DBName': lu('rds_dbname'), # dbname generated from instance id.
@@ -247,7 +248,7 @@ def render_rds(context, template):
         'MasterUserPassword': lu('rds_password'),
         'BackupRetentionPeriod': lu('project.aws.rds.backup-retention'),
         'DeletionPolicy': 'Snapshot',
-        "Tags": instance_tags(context),
+        "Tags": tags,
         "AllowMajorVersionUpgrade": False, # default? not specified.
         "AutoMinorVersionUpgrade": True, # default
     }

--- a/src/tests/test_buildercore_cfngen.py
+++ b/src/tests/test_buildercore_cfngen.py
@@ -104,8 +104,7 @@ class TestBuildercoreCfngen(base.BaseCase):
         "we want to update RDS instances in place to avoid data loss"
         context = self._base_context('dummy2')
         context['project']['aws']['rds']['multi-az'] = True
-        # TODO: wrong stack name, check also the other tests
-        (delta_plus, delta_minus) = cfngen.template_delta('project-with-cloudfront-minimal', context)
+        (delta_plus, delta_minus) = cfngen.template_delta('dummy2', context)
         self.assertEqual(delta_plus['Resources'].keys(), ['AttachedDB'])
         self.assertEqual(delta_plus['Resources']['AttachedDB']['Properties']['MultiAZ'], 'true')
         self.assertEqual(delta_plus['Outputs'].keys(), [])

--- a/src/tests/test_buildercore_trop.py
+++ b/src/tests/test_buildercore_trop.py
@@ -23,6 +23,14 @@ class TestBuildercoreTrop(base.BaseCase):
         self.assertEqual(context['rds_instance_id'], "dummy3-test")
         data = self._parse_json(trop.render(context))
         self.assertTrue(isinstance(data['Resources']['AttachedDB'], dict))
+        self.assertEqual(
+            data['Resources']['AttachedDB']['Properties']['Tags'],
+            [
+                {'Key': 'Project', 'Value': 'dummy3'},
+                {'Key': 'Name', 'Value': 'dummy3--test'},
+                {'Key': 'Environment', 'Value': 'test'},
+            ]
+        )
 
     def test_rds_param_groups(self):
         extra = {


### PR DESCRIPTION
Two sources of RDS updates to be performed every time `./bldr update_template` is called, with no upside but the danger of reboot or replacement:
- changing the `MasterUserPassword`
- changing the `Owner` Tag

The update should be idempotent, if you run it the second time it shouldn't show anything in the diff.