### PR TITLE
Separating creates from edits

### DIFF
--- a/src/buildercore/cfngen.py
+++ b/src/buildercore/cfngen.py
@@ -350,7 +350,10 @@ UPDATABLE_TITLE_PATTERNS = ['^CloudFront.*', '^ElasticLoadBalancer.*', '^EC2Inst
 REMOVABLE_TITLE_PATTERNS = ['^CnameDNS\\d+$', '^ExtDNS$', '^ExtraStorage.+$', '^MountPoint.+$', '^.+Queue$', '^EC2Instance.+$', '^IntDNS$']
 EC2_NOT_UPDATABLE_PROPERTIES = ['ImageId', 'Tags', 'UserData']
 
-Delta = namedtuple('Delta', ['plus', 'edit', 'minus'])
+class Delta(namedtuple('Delta', ['plus', 'edit', 'minus'])):
+    @property
+    def non_empty(self):
+        return self.plus['Resources'] or self.plus['Outputs'] or self.edit['Resources'] or self.edit['Outputs'] or self.minus['Resources'] or self.minus['Outputs']
 
 def template_delta(pname, context):
     """given an already existing template, regenerates it and produces a delta containing only the new resources.

--- a/src/buildercore/cfngen.py
+++ b/src/buildercore/cfngen.py
@@ -443,25 +443,25 @@ def template_delta(pname, context):
         }
     )
 
-def merge_delta(stackname, delta_plus, delta_edit, delta_minus):
+def merge_delta(stackname, delta):
     """Merges the new resources in delta in the local copy of the Cloudformation  template"""
     template = read_template(stackname)
-    apply_delta(template, delta_plus, delta_edit, delta_minus)
+    apply_delta(template, delta)
     write_template(stackname, json.dumps(template))
     return template
 
-def apply_delta(template, delta_plus, delta_edit, delta_minus):
-    for component in delta_plus:
+def apply_delta(template, delta):
+    for component in delta.plus:
         ensure(component in ["Resources", "Outputs"], "Template component %s not recognized", component)
         data = template.get(component, {})
-        data.update(delta_plus[component])
+        data.update(delta.plus[component])
         template[component] = data
-    for component in delta_edit:
+    for component in delta.edit:
         ensure(component in ["Resources", "Outputs"], "Template component %s not recognized", component)
         data = template.get(component, {})
-        data.update(delta_edit[component])
+        data.update(delta.edit[component])
         template[component] = data
-    for component in delta_minus:
+    for component in delta.minus:
         ensure(component in ["Resources", "Outputs"], "Template component %s not recognized", component)
-        for title in delta_minus[component]:
+        for title in delta.minus[component]:
             del template[component][title]

--- a/src/cfn.py
+++ b/src/cfn.py
@@ -82,7 +82,7 @@ def update_template(stackname):
 
     context_handler.write_context(stackname, context)
 
-    if delta.plus['Resources'] or delta.plus['Outputs'] or delta.edit['Resources'] or delta.edit['Outputs'] or delta.minus['Resources'] or delta.minus['Outputs']:
+    if delta.non_empty:
         new_template = cfngen.merge_delta(stackname, delta)
         bootstrap.update_template(stackname, new_template)
         # the /etc/buildvars.json file may need to be updated

--- a/src/cfn.py
+++ b/src/cfn.py
@@ -71,19 +71,19 @@ def update_template(stackname):
     (pname, _) = core.parse_stackname(stackname)
     more_context = cfngen.choose_config(stackname)
 
-    context, delta_plus, delta_edit, delta_minus, current_context = cfngen.regenerate_stack(pname, **more_context)
+    context, delta, current_context = cfngen.regenerate_stack(pname, **more_context)
 
     if _are_there_existing_servers(current_context):
         core_lifecycle.start(stackname)
-    LOG.info("Create: %s", pformat(delta_plus))
-    LOG.info("Update: %s", pformat(delta_edit))
-    LOG.info("Delete: %s", pformat(delta_minus))
+    LOG.info("Create: %s", pformat(delta.plus))
+    LOG.info("Update: %s", pformat(delta.edit))
+    LOG.info("Delete: %s", pformat(delta.minus))
     utils.confirm('Confirming changes to the stack template? This will rewrite the context and the CloudFormation template')
 
     context_handler.write_context(stackname, context)
 
-    if delta_plus['Resources'] or delta_plus['Outputs'] or delta_edit['Resources'] or delta_edit['Outputs'] or delta_minus['Resources'] or delta_minus['Outputs']:
-        new_template = cfngen.merge_delta(stackname, delta_plus, delta_edit, delta_minus)
+    if delta_plus['Resources'] or delta.plus['Outputs'] or delta.edit['Resources'] or delta.edit['Outputs'] or delta.minus['Resources'] or delta.minus['Outputs']:
+        new_template = cfngen.merge_delta(stackname, delta.plus, delta.edit, delta.minus)
         bootstrap.update_template(stackname, new_template)
         # the /etc/buildvars.json file may need to be updated
         buildvars.refresh(stackname, context)

--- a/src/cfn.py
+++ b/src/cfn.py
@@ -71,18 +71,19 @@ def update_template(stackname):
     (pname, _) = core.parse_stackname(stackname)
     more_context = cfngen.choose_config(stackname)
 
-    context, delta_plus, delta_minus, current_context = cfngen.regenerate_stack(pname, **more_context)
+    context, delta_plus, delta_edit, delta_minus, current_context = cfngen.regenerate_stack(pname, **more_context)
 
     if _are_there_existing_servers(current_context):
         core_lifecycle.start(stackname)
-    LOG.info("Create/update: %s", pformat(delta_plus))
+    LOG.info("Create: %s", pformat(delta_plus))
+    LOG.info("Update: %s", pformat(delta_edit))
     LOG.info("Delete: %s", pformat(delta_minus))
     utils.confirm('Confirming changes to the stack template? This will rewrite the context and the CloudFormation template')
 
     context_handler.write_context(stackname, context)
 
-    if delta_plus['Resources'] or delta_plus['Outputs'] or delta_minus['Resources'] or delta_minus['Outputs']:
-        new_template = cfngen.merge_delta(stackname, delta_plus, delta_minus)
+    if delta_plus['Resources'] or delta_plus['Outputs'] or delta_edit['Resources'] or delta_edit['Outputs'] or delta_minus['Resources'] or delta_minus['Outputs']:
+        new_template = cfngen.merge_delta(stackname, delta_plus, delta_edit, delta_minus)
         bootstrap.update_template(stackname, new_template)
         # the /etc/buildvars.json file may need to be updated
         buildvars.refresh(stackname, context)

--- a/src/cfn.py
+++ b/src/cfn.py
@@ -82,8 +82,8 @@ def update_template(stackname):
 
     context_handler.write_context(stackname, context)
 
-    if delta_plus['Resources'] or delta.plus['Outputs'] or delta.edit['Resources'] or delta.edit['Outputs'] or delta.minus['Resources'] or delta.minus['Outputs']:
-        new_template = cfngen.merge_delta(stackname, delta.plus, delta.edit, delta.minus)
+    if delta.plus['Resources'] or delta.plus['Outputs'] or delta.edit['Resources'] or delta.edit['Outputs'] or delta.minus['Resources'] or delta.minus['Outputs']:
+        new_template = cfngen.merge_delta(stackname, delta)
         bootstrap.update_template(stackname, new_template)
         # the /etc/buildvars.json file may need to be updated
         buildvars.refresh(stackname, context)

--- a/src/tests/test_buildercore_cfngen.py
+++ b/src/tests/test_buildercore_cfngen.py
@@ -36,9 +36,16 @@ class TestBuildercoreCfngen(base.BaseCase):
 
         self.switch_in_test_settings()
 
+class TestUpdates(base.BaseCase):
+    def setUp(self):
+        self.test_region = 'us-east-1'
+
+    def tearDown(self):
+        pass
+
     def test_empty_template_delta(self):
         context = self._base_context()
-        (delta_plus, delta_minus) = cfngen.template_delta('dummy1', context)
+        (delta_plus, delta_edit, delta_minus) = cfngen.template_delta('dummy1', context)
         self.assertEqual(delta_plus, {'Outputs': {}, 'Resources': {}})
 
     def test_template_delta_includes_cloudfront(self):
@@ -58,13 +65,13 @@ class TestBuildercoreCfngen(base.BaseCase):
             "errors": None,
             "default-ttl": 300,
         }
-        (delta_plus, delta_minus) = cfngen.template_delta('dummy1', context)
+        (delta_plus, delta_edit, delta_minus) = cfngen.template_delta('dummy1', context)
         self.assertEqual(delta_plus['Resources'].keys(), ['CloudFrontCDN', 'CloudFrontCDNDNS1', 'ExtDNS'])
         self.assertEqual(delta_plus['Outputs'].keys(), ['DomainName'])
 
     def test_template_delta_does_not_include_cloudfront_if_there_are_no_modifications(self):
         context = self._base_context('project-with-cloudfront-minimal')
-        (delta_plus, delta_minus) = cfngen.template_delta('project-with-cloudfront-minimal', context)
+        (delta_plus, delta_edit, delta_minus) = cfngen.template_delta('project-with-cloudfront-minimal', context)
         self.assertEqual(delta_plus['Resources'].keys(), [])
         self.assertEqual(delta_plus['Outputs'].keys(), [])
 
@@ -72,7 +79,7 @@ class TestBuildercoreCfngen(base.BaseCase):
         "we do not want to mess with running VMs"
         context = self._base_context()
         context['ec2']['cluster_size'] = 2
-        (delta_plus, delta_minus) = cfngen.template_delta('dummy1', context)
+        (delta_plus, delta_edit, delta_minus) = cfngen.template_delta('dummy1', context)
         self.assertEqual(delta_plus['Resources'].keys(), [])
         self.assertEqual(delta_plus['Outputs'].keys(), [])
 
@@ -80,15 +87,15 @@ class TestBuildercoreCfngen(base.BaseCase):
         "we accept to reboot VMs if an instance type change is requested"
         context = self._base_context()
         context['ec2']['type'] = 't2.xlarge'
-        (delta_plus, delta_minus) = cfngen.template_delta('dummy1', context)
-        self.assertEqual(delta_plus['Resources'].keys(), ['EC2Instance1'])
-        self.assertEqual(delta_plus['Outputs'].keys(), [])
+        (delta_plus, delta_edit, delta_minus) = cfngen.template_delta('dummy1', context)
+        self.assertEqual(delta_edit['Resources'].keys(), ['EC2Instance1'])
+        self.assertEqual(delta_edit['Outputs'].keys(), [])
 
     def test_template_delta_does_not_include_ec2_immutable_properties_like_image(self):
         "we don't want random reboot or recreations of instances"
         context = self._base_context()
         context['ec2']['ami'] = 'ami-1234567'
-        (delta_plus, delta_minus) = cfngen.template_delta('dummy1', context)
+        (delta_plus, delta_edit, delta_minus) = cfngen.template_delta('dummy1', context)
         self.assertEqual(delta_plus['Resources'].keys(), [])
         self.assertEqual(delta_plus['Outputs'].keys(), [])
 
@@ -96,24 +103,24 @@ class TestBuildercoreCfngen(base.BaseCase):
         "it's useful to open and close ports"
         context = self._base_context()
         context['project']['aws']['ports'] = [110]
-        (delta_plus, delta_minus) = cfngen.template_delta('dummy1', context)
-        self.assertEqual(delta_plus['Resources'].keys(), ['StackSecurityGroup'])
-        self.assertEqual(delta_plus['Outputs'].keys(), [])
+        (delta_plus, delta_edit, delta_minus) = cfngen.template_delta('dummy1', context)
+        self.assertEqual(delta_edit['Resources'].keys(), ['StackSecurityGroup'])
+        self.assertEqual(delta_edit['Outputs'].keys(), [])
 
     def test_template_delta_includes_parts_of_rds(self):
         "we want to update RDS instances in place to avoid data loss"
         context = self._base_context('dummy2')
         context['project']['aws']['rds']['multi-az'] = True
-        (delta_plus, delta_minus) = cfngen.template_delta('dummy2', context)
-        self.assertEqual(delta_plus['Resources'].keys(), ['AttachedDB'])
-        self.assertEqual(delta_plus['Resources']['AttachedDB']['Properties']['MultiAZ'], 'true')
-        self.assertEqual(delta_plus['Outputs'].keys(), [])
+        (delta_plus, delta_edit, delta_minus) = cfngen.template_delta('dummy2', context)
+        self.assertEqual(delta_edit['Resources'].keys(), ['AttachedDB'])
+        self.assertEqual(delta_edit['Resources']['AttachedDB']['Properties']['MultiAZ'], 'true')
+        self.assertEqual(delta_edit['Outputs'].keys(), [])
 
     def test_template_delta_doesnt_unnecessarily_update_rds(self):
         "we don't want to update RDS instances more than necessary, since it takes time and may cause reboots or replacements"
         context = self._base_context('dummy2')
         updated_context = self._base_context('dummy2', in_memory=True, existing_context=context)
-        (delta_plus, delta_minus) = cfngen.template_delta('dummy2', updated_context)
+        (delta_plus, delta_edit, delta_minus) = cfngen.template_delta('dummy2', updated_context)
         self.assertEqual(delta_plus['Resources'].keys(), [])
         self.assertEqual(delta_minus['Resources'].keys(), [])
         self.assertEqual(delta_plus['Outputs'].keys(), [])
@@ -125,28 +132,28 @@ class TestBuildercoreCfngen(base.BaseCase):
         context['cloudfront']['subdomains'] = [
             "custom-subdomain.example.org"
         ]
-        (delta_plus, delta_minus) = cfngen.template_delta('project-with-cloudfront-minimal', context)
-        self.assertEqual(delta_plus['Resources'].keys(), ['CloudFrontCDN', 'CloudFrontCDNDNS1'])
-        self.assertEqual(delta_plus['Resources']['CloudFrontCDNDNS1']['Properties']['Name'], 'custom-subdomain.example.org.')
-        self.assertEqual(delta_plus['Outputs'].keys(), [])
+        (delta_plus, delta_edit, delta_minus) = cfngen.template_delta('project-with-cloudfront-minimal', context)
+        self.assertEqual(delta_edit['Resources'].keys(), ['CloudFrontCDN', 'CloudFrontCDNDNS1'])
+        self.assertEqual(delta_edit['Resources']['CloudFrontCDNDNS1']['Properties']['Name'], 'custom-subdomain.example.org.')
+        self.assertEqual(delta_edit['Outputs'].keys(), [])
 
     def test_template_delta_includes_parts_of_elb(self):
         "we want to update ELBs in place given how long it takes to recreate them"
         context = self._base_context('project-with-cluster')
         context['elb']['healthcheck']['protocol'] = 'tcp'
-        (delta_plus, delta_minus) = cfngen.template_delta('project-with-cluster', context)
-        self.assertEqual(delta_plus['Resources'].keys(), ['ElasticLoadBalancer'])
-        self.assertEqual(delta_plus['Resources']['ElasticLoadBalancer']['Properties']['HealthCheck']['Target'], 'TCP:80')
-        self.assertEqual(delta_plus['Outputs'].keys(), [])
+        (delta_plus, delta_edit, delta_minus) = cfngen.template_delta('project-with-cluster', context)
+        self.assertEqual(delta_edit['Resources'].keys(), ['ElasticLoadBalancer'])
+        self.assertEqual(delta_edit['Resources']['ElasticLoadBalancer']['Properties']['HealthCheck']['Target'], 'TCP:80')
+        self.assertEqual(delta_edit['Outputs'].keys(), [])
 
     def test_template_delta_includes_elb_security_group(self):
         "for consistency with EC2 security groups"
         context = self._base_context('project-with-cluster')
         context['elb']['protocol'] = 'https'
         context['elb']['certificate'] = 'DUMMY_CERTIFICATE'
-        (delta_plus, delta_minus) = cfngen.template_delta('project-with-cluster', context)
-        self.assertEqual(delta_plus['Resources'].keys(), ['ElasticLoadBalancer', 'ELBSecurityGroup'])
-        self.assertEqual(delta_plus['Outputs'].keys(), [])
+        (delta_plus, delta_edit, delta_minus) = cfngen.template_delta('project-with-cluster', context)
+        self.assertEqual(delta_edit['Resources'].keys(), ['ElasticLoadBalancer', 'ELBSecurityGroup'])
+        self.assertEqual(delta_edit['Outputs'].keys(), [])
 
     def test_template_delta_includes_new_external_volumes(self):
         "we want to add additional volumes to projects that are getting their main volume filled"
@@ -155,7 +162,7 @@ class TestBuildercoreCfngen(base.BaseCase):
             'size': 10,
             'device': '/dev/sdh',
         }
-        (delta_plus, delta_minus) = cfngen.template_delta('dummy1', context)
+        (delta_plus, delta_edit, delta_minus) = cfngen.template_delta('dummy1', context)
         self.assertEqual(delta_plus['Resources'].keys(), ['MountPoint1', 'ExtraStorage1'])
         self.assertEqual(delta_plus['Resources']['ExtraStorage1']['Properties']['Size'], '10')
         self.assertEqual(delta_plus['Resources']['MountPoint1']['Properties']['Device'], '/dev/sdh')
@@ -164,19 +171,20 @@ class TestBuildercoreCfngen(base.BaseCase):
     def test_template_delta_includes_removal_of_subdomains(self):
         context = self._base_context('dummy2')
         context['subdomains'] = []
-        (delta_plus, delta_minus) = cfngen.template_delta('dummy2', context)
+        (delta_plus, delta_edit, delta_minus) = cfngen.template_delta('dummy2', context)
         self.assertEqual(delta_minus['Resources'].keys(), ['CnameDNS1'])
         self.assertEqual(delta_minus['Outputs'].keys(), [])
 
-    def test_apply_delta_may_add_and_remove_resources(self):
+    def test_apply_delta_may_add_edit_and_remove_resources(self):
         template = {
             'Resources': {
                 'A': 1,
                 'B': 2,
+                'C': 3,
             }
         }
-        cfngen.apply_delta(template, delta_plus={'Resources': {'C': 3}}, delta_minus={'Resources': {'B': 2}})
-        self.assertEqual(template, {'Resources': {'A': 1, 'C': 3}})
+        cfngen.apply_delta(template, delta_plus={'Resources': {'D': 4}}, delta_edit={'Resources': {'C': 30}}, delta_minus={'Resources': {'B': 2}})
+        self.assertEqual(template, {'Resources': {'A': 1, 'C': 30, 'D': 4}})
 
     def test_apply_delta_may_add_components_which_werent_there(self):
         template = {
@@ -184,7 +192,7 @@ class TestBuildercoreCfngen(base.BaseCase):
                 'A': 1,
             }
         }
-        cfngen.apply_delta(template, delta_plus={'Outputs': {'B': 2}}, delta_minus={})
+        cfngen.apply_delta(template, delta_plus={'Outputs': {'B': 2}}, delta_edit={}, delta_minus={})
         self.assertEqual(template, {'Resources': {'A': 1}, 'Outputs': {'B': 2}})
 
     def _base_context(self, project_name='dummy1', in_memory=False, existing_context=None):

--- a/src/tests/test_buildercore_cfngen.py
+++ b/src/tests/test_buildercore_cfngen.py
@@ -183,7 +183,7 @@ class TestUpdates(base.BaseCase):
                 'C': 3,
             }
         }
-        cfngen.apply_delta(template, delta_plus={'Resources': {'D': 4}}, delta_edit={'Resources': {'C': 30}}, delta_minus={'Resources': {'B': 2}})
+        cfngen.apply_delta(template, cfngen.Delta({'Resources': {'D': 4}}, {'Resources': {'C': 30}}, {'Resources': {'B': 2}}))
         self.assertEqual(template, {'Resources': {'A': 1, 'C': 30, 'D': 4}})
 
     def test_apply_delta_may_add_components_which_werent_there(self):
@@ -192,7 +192,7 @@ class TestUpdates(base.BaseCase):
                 'A': 1,
             }
         }
-        cfngen.apply_delta(template, delta_plus={'Outputs': {'B': 2}}, delta_edit={}, delta_minus={})
+        cfngen.apply_delta(template, cfngen.Delta({'Outputs': {'B': 2}}, {}, {}))
         self.assertEqual(template, {'Resources': {'A': 1}, 'Outputs': {'B': 2}})
 
     def _base_context(self, project_name='dummy1', in_memory=False, existing_context=None):


### PR DESCRIPTION
(removed resources are already separate)
A first step in visualizing edits more closely, showing a single field that has changed rather than the whole resource.