### PR TITLE
Replacing EC2 instances only

### DIFF
--- a/src/buildercore/cfngen.py
+++ b/src/buildercore/cfngen.py
@@ -341,7 +341,7 @@ def regenerate_stack(pname, **more_context):
     write_template(more_context['stackname'], json.dumps(current_template))
     context = build_context(pname, existing_context=current_context, **more_context)
     delta_plus, delta_minus = template_delta(pname, context)
-    return context, delta_plus, delta_minus
+    return context, delta_plus, delta_minus, current_context
 
 
 # can't add ExtDNS: it changes dynamically when we start/stop instances and should not be touched after creation

--- a/src/buildercore/cfngen.py
+++ b/src/buildercore/cfngen.py
@@ -412,12 +412,12 @@ def template_delta(pname, context):
     }
     delta_plus_outputs = {
         title: o for (title, o) in template.get('Outputs', {}).items()
-        if (title not in old_template['Outputs'] and not _related_to_ec2(o))
+        if (title not in old_template.get('Outputs', {}) and not _related_to_ec2(o))
         or (_title_is_updatable(title) and _title_has_been_updated(title, 'Outputs'))
     }
 
     delta_minus_resources = {r: v for r, v in old_template['Resources'].iteritems() if r not in template['Resources'] and _title_is_removable(r)}
-    delta_minus_outputs = {o: v for o, v in old_template['Outputs'].iteritems() if o not in template['Outputs']}
+    delta_minus_outputs = {o: v for o, v in old_template.get('Outputs', {}).iteritems() if o not in template.get('Outputs', {})}
 
     return (
         {

--- a/src/cfn.py
+++ b/src/cfn.py
@@ -73,7 +73,8 @@ def update_template(stackname):
 
     context, delta_plus, delta_minus = cfngen.regenerate_stack(pname, **more_context)
 
-    if context['ec2']:
+    are_there_existing_servers = context['ec2'] and len(context['ec2'].get('suppressed', [])) < context['ec2'].get('cluster-size', 1)
+    if are_there_existing_servers:
         core_lifecycle.start(stackname)
     LOG.info("Create/update: %s", pformat(delta_plus))
     LOG.info("Delete: %s", pformat(delta_minus))

--- a/src/cfn.py
+++ b/src/cfn.py
@@ -73,8 +73,7 @@ def update_template(stackname):
 
     context, delta_plus, delta_minus = cfngen.regenerate_stack(pname, **more_context)
 
-    are_there_existing_servers = context['ec2'] and len(context['ec2'].get('suppressed', [])) < context['ec2'].get('cluster-size', 1)
-    if are_there_existing_servers:
+    if _are_there_existing_servers(context):
         core_lifecycle.start(stackname)
     LOG.info("Create/update: %s", pformat(delta_plus))
     LOG.info("Delete: %s", pformat(delta_minus))
@@ -195,16 +194,19 @@ def _pick_node(instance_list, node):
     core_utils.ensure(instance.ip_address is not None, "Selected instance does not have a public ip address, are you sure it's running?")
     return instance
 
+
+def _are_there_existing_servers(context):
+    if not 'ec2' in context:
+        # very old stack, canned response
+        return True
+
+    return context['ec2'] and len(context['ec2'].get('suppressed', [])) < context['ec2'].get('cluster-size', 1)
+
 def _check_want_to_be_running(stackname, autostart=False):
     try:
         context = context_handler.load_context(stackname)
-
-        if 'ec2' in context:
-            # early check can only be made if the instance actually declares
-            # ec2 True/False in its context
-            # otherwise, don't make assumptions and go ahead
-            if not context['ec2']:
-                return False
+        if not _are_there_existing_servers(context): 
+            return False
 
     except context_handler.MissingContextFile as e:
         LOG.warn(e)

--- a/src/cfn.py
+++ b/src/cfn.py
@@ -71,9 +71,9 @@ def update_template(stackname):
     (pname, _) = core.parse_stackname(stackname)
     more_context = cfngen.choose_config(stackname)
 
-    context, delta_plus, delta_minus = cfngen.regenerate_stack(pname, **more_context)
+    context, delta_plus, delta_minus, current_context = cfngen.regenerate_stack(pname, **more_context)
 
-    if _are_there_existing_servers(context):
+    if _are_there_existing_servers(current_context):
         core_lifecycle.start(stackname)
     LOG.info("Create/update: %s", pformat(delta_plus))
     LOG.info("Delete: %s", pformat(delta_minus))
@@ -205,7 +205,7 @@ def _are_there_existing_servers(context):
 def _check_want_to_be_running(stackname, autostart=False):
     try:
         context = context_handler.load_context(stackname)
-        if not _are_there_existing_servers(context): 
+        if not _are_there_existing_servers(context):
             return False
 
     except context_handler.MissingContextFile as e:


### PR DESCRIPTION
This should already work for cluster-size > 1 as we can suppress one instance at a time. It needed some tweaking for cluster-size == 1 as some data structure become empty.

Intended flow for single server:
1. add new configurations like `ec2.ami` to a project
1. update `projects/elife.yaml` adding `ec2.suppressed: [1]` which means the first node should be removed from the template. Also `intdomain` and `domain` should be set to `false` if present, as they point to the EC2 instance and must be removed too.
1. run `update_template`
1. remove /etc/salt/pki/master/minions/$minion_name from Salt master
1. remove `suppressed` and restore `intdomain`/`domain`
1. run `update_template` which should create the new instance

For multiple servers:
1. add new configurations like `ec2.ami` to a project
1. update `projects/elife.yaml` adding `ec2.suppressed: [1]` which means the first node should be removed from the template. Domains point to the ELB so no change for them.
1. run `update_template`
1. remove /etc/salt/pki/master/minions/$minion_name from Salt master
1. remove `suppressed`
1. run `update_template` which should create the new instance
1. repeat, with `ec2.suppressed: [2]` and so on.