### PR TITLE
Executing cmd on a single node

### DIFF
--- a/src/buildercore/core.py
+++ b/src/buildercore/core.py
@@ -223,7 +223,7 @@ def stack_conn(stackname, username=config.DEPLOY_USER, **kwargs):
 class NoPublicIps(Exception):
     pass
 
-def stack_all_ec2_nodes(stackname, workfn, username=config.DEPLOY_USER, concurrency=None, **kwargs):
+def stack_all_ec2_nodes(stackname, workfn, username=config.DEPLOY_USER, concurrency=None, node=None, **kwargs):
     """Executes work on all the EC2 nodes of stackname.
     Optionally connects with the specified username"""
     work_kwargs = {}
@@ -233,6 +233,8 @@ def stack_all_ec2_nodes(stackname, workfn, username=config.DEPLOY_USER, concurre
     data = stack_data(stackname)
     public_ips = {ec2['id']: ec2['ip_address'] for ec2 in data}
     nodes = {ec2['id']: int(ec2['tags']['Node']) if 'Node' in ec2['tags'] else 1 for ec2 in data}
+    if node:
+        nodes = {k:v for k,v in nodes.items() if v == node}
     params = _ec2_connection_params(stackname, username)
     params.update(kwargs)
 

--- a/src/buildercore/core.py
+++ b/src/buildercore/core.py
@@ -234,7 +234,7 @@ def stack_all_ec2_nodes(stackname, workfn, username=config.DEPLOY_USER, concurre
     public_ips = {ec2['id']: ec2['ip_address'] for ec2 in data}
     nodes = {ec2['id']: int(ec2['tags']['Node']) if 'Node' in ec2['tags'] else 1 for ec2 in data}
     if node:
-        nodes = {k:v for k,v in nodes.items() if v == node}
+        nodes = {k: v for k, v in nodes.items() if v == node}
     params = _ec2_connection_params(stackname, username)
     params.update(kwargs)
 

--- a/src/cfn.py
+++ b/src/cfn.py
@@ -306,7 +306,7 @@ def _user(use_bootstrap_user):
 
 @task
 @requires_aws_stack
-def cmd(stackname, command=None, username=DEPLOY_USER, clean_output=False, concurrency=None):
+def cmd(stackname, command=None, username=DEPLOY_USER, clean_output=False, concurrency=None, node=None):
     if command is None:
         abort("Please specify a command e.g. ./bldr cmd:%s,ls" % stackname)
     LOG.info("Connecting to: %s", stackname)
@@ -330,7 +330,9 @@ def cmd(stackname, command=None, username=DEPLOY_USER, clean_output=False, concu
                 (run, {'command': command}),
                 username=username,
                 abort_on_prompts=True,
-                concurrency=concurrency_for(stackname, concurrency))
+                concurrency=concurrency_for(stackname, concurrency),
+                node=node
+            )
     except FabricException as e:
         LOG.error(e.message)
         exit(2)

--- a/src/cfn.py
+++ b/src/cfn.py
@@ -306,6 +306,7 @@ def _user(use_bootstrap_user):
 
 @task
 @requires_aws_stack
+# pylint: disable-msg=too-many-arguments
 def cmd(stackname, command=None, username=DEPLOY_USER, clean_output=False, concurrency=None, node=None):
     if command is None:
         abort("Please specify a command e.g. ./bldr cmd:%s,ls" % stackname)

--- a/src/integration_tests/test_provisioning.py
+++ b/src/integration_tests/test_provisioning.py
@@ -58,6 +58,7 @@ class TestProvisioning(base.BaseCase):
             lifecycle.start(stackname)
 
             cfn.cmd(stackname, "ls -l /", username=BOOTSTRAP_USER, concurrency='parallel')
+            cfn.cmd(stackname, "ls -l /", username=BOOTSTRAP_USER, concurrency='parallel', node=1)
 
             cfn.download_file(stackname, "/bin/ls", "ls", use_bootstrap_user="true")
             self.assertTrue(os.path.isfile("./ls"))


### PR DESCRIPTION
Useful for example when in Lax's build we execute a `./backup.sh` local command to dump the database before deploy. We should do that on a single node, no reason to do it twice.

cmd is such a basic operation that are many variations that can be passed in. Most of them have sensible defaults at least.