### PR TITLE
ELPP-3167 bldr stop_if_running_for

### DIFF
--- a/src/buildercore/lifecycle.py
+++ b/src/buildercore/lifecycle.py
@@ -86,7 +86,21 @@ def stop_if_next_hour_is_imminent(stackname, minimum_minutes=55):
 
     minimum_running_time = minimum_minutes * 60
     maximum_running_time = maximum_minutes * 60
-    LOG.info("Interval to select nodes to stop: %s-%s", minimum_running_time, maximum_running_time)
+    LOG.info("Interval to select nodes to stop: %s,%s", minimum_running_time, maximum_running_time)
+
+    to_be_stopped = [node_id for (node_id, running_time) in running_times.items() if running_time >= minimum_running_time]
+    LOG.info("Selected for stopping: %s", to_be_stopped)
+    if to_be_stopped:
+        _connection(stackname).stop_instances(to_be_stopped)
+        _wait_all_in_state(stackname, 'stopped', to_be_stopped)
+
+def stop_if_running_for(stackname, minimum_minutes=55):
+    starting_times = last_start_time(stackname)
+    running_times = {node_id: int((datetime.utcnow() - launch_time).total_seconds()) for (node_id, launch_time) in starting_times.items()}
+    LOG.info("Total running times: %s", running_times)
+
+    minimum_running_time = minimum_minutes * 60
+    LOG.info("Interval to select nodes to stop: %s,+oo", minimum_running_time)
 
     to_be_stopped = [node_id for (node_id, running_time) in running_times.items() if running_time >= minimum_running_time]
     LOG.info("Selected for stopping: %s", to_be_stopped)

--- a/src/fabfile.py
+++ b/src/fabfile.py
@@ -21,5 +21,5 @@ import askmaster
 import buildvars
 import project
 from deploy import deploy, switch_revision_update_instance
-from lifecycle import start, stop, last_start_time, stop_if_next_hour_is_imminent, update_dns
+from lifecycle import start, stop, last_start_time, stop_if_next_hour_is_imminent, stop_if_running_for, update_dns
 import masterless

--- a/src/lifecycle.py
+++ b/src/lifecycle.py
@@ -39,6 +39,16 @@ def stop_if_next_hour_is_imminent(stackname, minimum_minutes='55'):
     The assumption is that stacks where this command is used are not needed for long parts of the day/week, and that who needs them will call the start task first."""
     return lifecycle.stop_if_next_hour_is_imminent(stackname, int(minimum_minutes))
 
+@task
+@requires_aws_stack
+@timeit
+def stop_if_running_for(stackname, minimum_minutes='30'):
+    # TODO: can we write a description of the @task somewhere?
+    """If a node has been running for a time greater than minimum_minutes, stop it.
+
+    The assumption is that stacks where this command is used are not needed for long parts of the day/week, and that who needs them will call the start task first."""
+    return lifecycle.stop_if_running_for(stackname, int(minimum_minutes))
+
 @debugtask
 @requires_aws_stack
 def update_dns(stackname):


### PR DESCRIPTION
Useful for turning off EC2 instances as soon as needed, since now they are billed by the second.