### PR TITLE
Building custom example.top files

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -326,13 +326,18 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
         end
 
         # bootstrap Saltstack
-        project.vm.provision("shell", path: "scripts/bootstrap.sh", \
-            keep_color: true, privileged: true, \
+        project.vm.provision("shell",
+            path: "scripts/bootstrap.sh", \
+            keep_color: true, \
+            privileged: true, \
             args: [PRJ["salt"], INSTANCE_NAME, String(IS_MASTER)])
 
         # link up formulas
-        project.vm.provision("shell", path: "scripts/init-vagrant-formulas.sh", \
-            keep_color: true, privileged: true, \
+        project.vm.provision("shell", \
+            path: "scripts/init-vagrant-formulas.sh", \
+            keep_color: true, \
+            privileged: true, \
+            env: { 'BUILDER_TOPFILE': ENV['BUILDER_TOPFILE'] }, \
             args: [INSTANCE_NAME])
 
         # configure the instance as if it were a master server

--- a/scripts/init-formulas.sh
+++ b/scripts/init-formulas.sh
@@ -105,7 +105,7 @@ clone_update() {
     # tell the minion where it can find the formula's state and pillar data
     echo "    - $repo_path/salt/" >> /etc/salt/minion.d/file_roots.conf
 
-    topfile="$repo_path/salt/example.top"
+    topfile="$repo_path/salt/${BUILDER_TOPFILE-example.top}"
 
     # successively overwrites the top file until the last one (project formula) wins
     if [ -e "$topfile" ]; then

--- a/scripts/init-vagrant-formulas.sh
+++ b/scripts/init-vagrant-formulas.sh
@@ -20,7 +20,7 @@ ln -sfn /project/salt/pillar /srv/pillar
 ln -sfn /vagrant/custom-vagrant /srv/custom
 
 # by default the project's top.sls is disabled by file naming. hook that up here
-cd /srv/salt/ && ln -sf example.top top.sls
+cd /srv/salt/ && ln -sf "${BUILDER_TOPFILE-example.top}" top.sls
 
 # vagrant makes all formula dependencies available, including builder base formula
 

--- a/src/buildercore/bootstrap.py
+++ b/src/buildercore/bootstrap.py
@@ -53,6 +53,7 @@ def run_script(script_filename, *script_params, **environment_variables):
 
     def escape_string_parameter(parameter):
         return "'%s'" % parameter
+
     env_string = ['%s=%s' % (k, v) for k, v in environment_variables.items()]
     cmd = ["/bin/bash", remote_script] + map(escape_string_parameter, list(script_params))
     retval = sudo(" ".join(env_string + cmd))
@@ -523,8 +524,11 @@ def update_ec2_stack(stackname, concurrency):
             # to init the builder-private formula, the masterless instance needs
             # the master-builder key
             upload_master_builder_key(master_builder_key)
+            envvars = {
+                'BUILDER_TOPFILE': os.environ.get('BUILDER_TOPFILE', '')
+            }
             # Vagrant's equivalent is 'init-vagrant-formulas.sh'
-            run_script('init-formulas.sh', formula_list, prepo, **{'BUILDER_TOPFILE':os.environ.get('BUILDER_TOPFILE', '')})
+            run_script('init-formulas.sh', formula_list, prepo, **envvars)
 
         if is_master:
             builder_private_repo = pdata['private-repo']

--- a/src/buildercore/bootstrap.py
+++ b/src/buildercore/bootstrap.py
@@ -45,7 +45,7 @@ def put_script(script_filename, remote_script):
     temporary_script = _put_temporary_script(script_filename)
     sudo("mv %s %s && chmod +x %s" % (temporary_script, remote_script, remote_script))
 
-def run_script(script_filename, *script_params):
+def run_script(script_filename, *script_params, **environment_variables):
     """uploads a script for SCRIPTS_PATH and executes it in the /tmp dir with given params.
     ASSUMES YOU ARE CONNECTED TO A STACK"""
     start = datetime.now()
@@ -53,8 +53,9 @@ def run_script(script_filename, *script_params):
 
     def escape_string_parameter(parameter):
         return "'%s'" % parameter
+    env_string = ['%s=%s' % (k, v) for k, v in environment_variables.items()]
     cmd = ["/bin/bash", remote_script] + map(escape_string_parameter, list(script_params))
-    retval = sudo(" ".join(cmd))
+    retval = sudo(" ".join(env_string + cmd))
     sudo("rm " + remote_script) # remove the script after executing it
     end = datetime.now()
     LOG.info("Executed script %s in %2.4f seconds", script_filename, (end - start).total_seconds())
@@ -523,7 +524,7 @@ def update_ec2_stack(stackname, concurrency):
             # the master-builder key
             upload_master_builder_key(master_builder_key)
             # Vagrant's equivalent is 'init-vagrant-formulas.sh'
-            run_script('init-formulas.sh', formula_list, prepo)
+            run_script('init-formulas.sh', formula_list, prepo, **{'BUILDER_TOPFILE':os.environ.get('BUILDER_TOPFILE', '')})
 
         if is_master:
             builder_private_repo = pdata['private-repo']


### PR DESCRIPTION
At times it's useful to pass in a different example.top, as in the case of a building a VM more close to end2end or prod than the default one.

For example, in `journal-formula` we could have a separate `example-critical-css.top` that enables additional state files.