### PR TITLE
Introducing RDS start and stop

### DIFF
--- a/projects/elife.yaml
+++ b/projects/elife.yaml
@@ -182,6 +182,10 @@ basebox:
             ami: ami-9eaa1cf6 # Ubuntu 14.04 (correct, but older)
         ports:
             - 22
+    aws-alt:
+        rdstest:
+            rds:
+                storage: 5
     vagrant:
         box: ubuntu/trusty64 # Ubuntu 14.04, deprecated
 

--- a/projects/elife.yaml
+++ b/projects/elife.yaml
@@ -247,7 +247,6 @@ lax:
                 cluster-size: 2
             rds:
                 storage: 5
-                multi-az: true
             ext:
                 size: 10 # GB
             elb:
@@ -1264,7 +1263,6 @@ profiles:
             rds:
                 engine: postgres
                 storage: 5 # GB
-                multi-az: true
             ports:
                 - 22
                 - 80

--- a/src/buildercore/core.py
+++ b/src/buildercore/core.py
@@ -125,17 +125,17 @@ def boto_s3_conn(region):
     return boto3.client('s3', region)
 
 @cached
-def connect_aws_with_pname(pname, service, boto3=False):
+def connect_aws_with_pname(pname, service, with_boto3=False):
     "convenience"
     pdata = project.project_data(pname)
     region = pdata['aws']['region']
     LOG.debug('connecting to a %s instance in region %s', pname, region)
-    if boto3:
+    if with_boto3:
         return boto3.client('rds', region)
     else:
         return connect_aws(service, region)
 
-def connect_aws_with_stack(stackname, service, boto3=False):
+def connect_aws_with_stack(stackname, service, with_boto3=False):
     "convenience"
     pname = project_name_from_stackname(stackname)
     return connect_aws_with_pname(pname, service)
@@ -158,7 +158,7 @@ def find_ec2_instances(stackname, state='running', node_ids=None, allow_empty=Fa
 
 def find_rds_instances(stackname, state='available'):
     "This uses boto3 because it allows to start/stop instances"
-    conn = connect_aws_with_stack(stackname, 'rds', boto3=True)
+    conn = connect_aws_with_stack(stackname, 'rds', with_boto3=True)
     all_rds_instances = conn.describe_db_instances(DBInstanceIdentifier=stackname.replace('--', '-'))['DBInstances']
     return all_rds_instances
 

--- a/src/buildercore/core.py
+++ b/src/buildercore/core.py
@@ -125,14 +125,17 @@ def boto_s3_conn(region):
     return boto3.client('s3', region)
 
 @cached
-def connect_aws_with_pname(pname, service):
+def connect_aws_with_pname(pname, service, boto3=False):
     "convenience"
     pdata = project.project_data(pname)
     region = pdata['aws']['region']
     LOG.debug('connecting to a %s instance in region %s', pname, region)
-    return connect_aws(service, region)
+    if boto3:
+        return boto3.client('rds', region)
+    else:
+        return connect_aws(service, region)
 
-def connect_aws_with_stack(stackname, service):
+def connect_aws_with_stack(stackname, service, boto3=False):
     "convenience"
     pname = project_name_from_stackname(stackname)
     return connect_aws_with_pname(pname, service)
@@ -155,7 +158,7 @@ def find_ec2_instances(stackname, state='running', node_ids=None, allow_empty=Fa
 
 def find_rds_instances(stackname, state='available'):
     "This uses boto3 because it allows to start/stop instances"
-    conn = boto3.client('rds')
+    conn = connect_aws_with_stack(stackname, 'rds', boto3=True)
     all_rds_instances = conn.describe_db_instances(DBInstanceIdentifier=stackname.replace('--', '-'))['DBInstances']
     return all_rds_instances
 

--- a/src/buildercore/core.py
+++ b/src/buildercore/core.py
@@ -153,6 +153,11 @@ def find_ec2_instances(stackname, state='running', node_ids=None, allow_empty=Fa
         raise NoRunningInstances("found no running ec2 instances for %r. The stack nodes may have been stopped, but here we were requiring them to be running" % stackname)
     return ec2_instances
 
+def find_rds_instances(stackname, state='available'):
+    "This uses boto3 because it allows to start/stop instances"
+    conn = boto3.client('rds')
+    all_rds_instances = conn.describe_db_instances(DBInstanceIdentifier=stackname.replace('--', '-'))['DBInstances']
+    return all_rds_instances
 
 def _all_nodes_filter(stackname, node_ids):
     query = {

--- a/src/buildercore/core.py
+++ b/src/buildercore/core.py
@@ -138,7 +138,7 @@ def connect_aws_with_pname(pname, service, with_boto3=False):
 def connect_aws_with_stack(stackname, service, with_boto3=False):
     "convenience"
     pname = project_name_from_stackname(stackname)
-    return connect_aws_with_pname(pname, service)
+    return connect_aws_with_pname(pname, service, with_boto3)
 
 def find_ec2_instances(stackname, state='running', node_ids=None, allow_empty=False):
     "returns list of ec2 instances data for a *specific* stackname"

--- a/src/buildercore/lifecycle.py
+++ b/src/buildercore/lifecycle.py
@@ -88,7 +88,7 @@ def stop(stackname, services=None):
     if 'ec2' in services:
         ec2_to_be_stopped = _select_nodes_with_state('running', ec2_states)
     if 'rds' in services:
-        rds_to_be_stopped = _select_nodes_with_state('available', ec2_states)
+        rds_to_be_stopped = _select_nodes_with_state('available', rds_states)
     _stop(stackname, ec2_to_be_stopped, rds_to_be_stopped)
 
 def last_ec2_start_time(stackname):

--- a/src/buildercore/lifecycle.py
+++ b/src/buildercore/lifecycle.py
@@ -17,7 +17,7 @@ LOG = logging.getLogger(__name__)
 def start(stackname):
     "Puts all EC2 nodes of stackname into the 'started' state. Idempotent"
 
-    # update local copy of of context from s3
+    # update local copy of context from s3
     download_from_s3(stackname, refresh=True)
 
     states = _nodes_states(stackname)
@@ -71,20 +71,6 @@ def last_start_time(stackname):
     def _parse_datetime(value):
         return datetime.strptime(value, "%Y-%m-%dT%H:%M:%S.%fZ")
     return {node.id: _parse_datetime(node.launch_time) for node in nodes}
-
-def stop_if_next_hour_is_imminent(stackname, minimum_minutes=55):
-    maximum_minutes = 60
-    starting_times = last_start_time(stackname)
-    running_times = {node_id: int((datetime.utcnow() - launch_time).total_seconds()) % (maximum_minutes * 60) for (node_id, launch_time) in starting_times.items()}
-    LOG.info("Hourly fraction running times: %s", running_times)
-
-    minimum_running_time = minimum_minutes * 60
-    maximum_running_time = maximum_minutes * 60
-    LOG.info("Interval to select nodes to stop: %s,%s", minimum_running_time, maximum_running_time)
-
-    to_be_stopped = [node_id for (node_id, running_time) in running_times.items() if running_time >= minimum_running_time]
-    LOG.info("Selected for stopping: %s", to_be_stopped)
-    _stop(stackname, to_be_stopped)
 
 def stop_if_running_for(stackname, minimum_minutes=55):
     starting_times = last_start_time(stackname)

--- a/src/buildercore/lifecycle.py
+++ b/src/buildercore/lifecycle.py
@@ -5,7 +5,6 @@ The primary reason for doing this is to save on costs."""
 from datetime import datetime
 import logging
 import re
-import boto3
 from fabric.contrib import files
 import fabric.exceptions as fabric_exceptions
 from . import config
@@ -41,7 +40,7 @@ def start(stackname):
         _ec2_connection(stackname).start_instances(ec2_to_be_started)
     if rds_to_be_started:
         LOG.info("RDS nodes to be started: %s", rds_to_be_started)
-        [_rds_connection().start_db_instance(DBInstanceIdentifier=n) for n in rds_to_be_started]
+        [_rds_connection(stackname).start_db_instance(DBInstanceIdentifier=n) for n in rds_to_be_started]
 
     if ec2_to_be_started:
         _wait_ec2_all_in_state(stackname, 'running', ec2_to_be_started)
@@ -114,7 +113,7 @@ def _stop(stackname, ec2_to_be_stopped, rds_to_be_stopped):
     if ec2_to_be_stopped:
         _ec2_connection(stackname).stop_instances(ec2_to_be_stopped)
     if rds_to_be_stopped:
-        [_rds_connection().stop_db_instance(DBInstanceIdentifier=n) for n in rds_to_be_stopped]
+        [_rds_connection(stackname).stop_db_instance(DBInstanceIdentifier=n) for n in rds_to_be_stopped]
 
     if ec2_to_be_stopped:
         _wait_ec2_all_in_state(stackname, 'stopped', ec2_to_be_stopped)
@@ -275,4 +274,4 @@ def _ec2_connection(stackname):
     return connect_aws_with_stack(stackname, 'ec2')
 
 def _rds_connection(stackname):
-    return connect_aws_with_stack(stackname, 'rds', boto3=True)
+    return connect_aws_with_stack(stackname, 'rds', with_boto3=True)

--- a/src/buildercore/lifecycle.py
+++ b/src/buildercore/lifecycle.py
@@ -19,9 +19,14 @@ def start(stackname):
 
     # update local copy of context from s3
     download_from_s3(stackname, refresh=True)
+    context = load_context(stackname)
 
+    # TODO: do the same exclusion for EC2
     ec2_states = _ec2_nodes_states(stackname)
-    rds_states = _rds_nodes_states(stackname)
+    if context['project']['aws'].get('rds'):
+        rds_states = _rds_nodes_states(stackname)
+    else:
+        rds_states = {}
     LOG.info("Current states: EC2 %s, RDS %s", ec2_states, rds_states)
     _ensure_valid_ec2_states(ec2_states, {'stopped', 'pending', 'running', 'stopping'})
 
@@ -76,9 +81,13 @@ def stop(stackname, services=None):
     "Puts all EC2 nodes of stackname into the 'stopped' state. Idempotent"
     if not services:
         services = ['ec2', 'rds']
+    context = load_context(stackname)
 
     ec2_states = _ec2_nodes_states(stackname)
-    rds_states = _rds_nodes_states(stackname)
+    if context['project']['aws'].get('rds'):
+        rds_states = _rds_nodes_states(stackname)
+    else:
+        rds_states = {}
     LOG.info("Current states: EC2 %s, RDS %s", ec2_states, rds_states)
     _ensure_valid_ec2_states(ec2_states, {'running', 'stopping', 'stopped'})
 

--- a/src/buildercore/lifecycle.py
+++ b/src/buildercore/lifecycle.py
@@ -274,5 +274,5 @@ def _rds_nodes_states(stackname):
 def _ec2_connection(stackname):
     return connect_aws_with_stack(stackname, 'ec2')
 
-def _rds_connection():
-    return boto3.client('rds')
+def _rds_connection(stackname):
+    return connect_aws_with_stack(stackname, 'rds', boto3=True)

--- a/src/buildercore/lifecycle.py
+++ b/src/buildercore/lifecycle.py
@@ -99,9 +99,9 @@ def stop_if_running_for(stackname, minimum_minutes=55):
     minimum_running_time = minimum_minutes * 60
     LOG.info("Interval to select nodes to stop: %s,+oo", minimum_running_time)
 
-    to_be_stopped = [node_id for (node_id, running_time) in running_times.items() if running_time >= minimum_running_time]
-    LOG.info("Selected for stopping: %s", to_be_stopped)
-    _stop(stackname, to_be_stopped)
+    ec2_to_be_stopped = [node_id for (node_id, running_time) in running_times.items() if running_time >= minimum_running_time]
+    LOG.info("Selected for stopping: %s", ec2_to_be_stopped)
+    _stop(stackname, ec2_to_be_stopped, rds_to_be_stopped=[])
 
 def _stop(stackname, ec2_to_be_stopped, rds_to_be_stopped):
     if ec2_to_be_stopped:
@@ -140,7 +140,7 @@ def _wait_all_in_state(stackname, state, node_ids, source_of_states, node_descri
     # TODO: timeout argument
     call_while(
         some_node_is_still_not_compliant,
-        interval=2, 
+        interval=2,
         update_msg=("waiting for states of %s nodes to be %s" % (node_description, state)),
         done_msg="all nodes in state %s" % state
     )
@@ -261,7 +261,7 @@ def _ec2_nodes_states(stackname, node_ids=None):
     return {node.id: node.state for name, node in unified_nodes.items()}
 
 def _rds_nodes_states(stackname):
-    return {i['DBInstanceIdentifier']:i['DBInstanceStatus'] for i in find_rds_instances(stackname)}
+    return {i['DBInstanceIdentifier']: i['DBInstanceStatus'] for i in find_rds_instances(stackname)}
 
 
 def _ec2_connection(stackname):

--- a/src/buildercore/lifecycle.py
+++ b/src/buildercore/lifecycle.py
@@ -132,6 +132,10 @@ def _wait_daemons():
 
 def update_dns(stackname):
     context = load_context(stackname)
+    if not context['ec2']:
+        LOG.info("No EC2 nodes expected")
+        return
+
     nodes = find_ec2_instances(stackname, allow_empty=True)
     LOG.info("Nodes found for DNS update: %s", [node.id for node in nodes])
 

--- a/src/fabfile.py
+++ b/src/fabfile.py
@@ -21,5 +21,5 @@ import askmaster
 import buildvars
 import project
 from deploy import deploy, switch_revision_update_instance
-from lifecycle import start, stop, last_start_time, stop_if_running_for, update_dns
+from lifecycle import start, stop, stop_if_running_for, update_dns
 import masterless

--- a/src/fabfile.py
+++ b/src/fabfile.py
@@ -21,5 +21,5 @@ import askmaster
 import buildvars
 import project
 from deploy import deploy, switch_revision_update_instance
-from lifecycle import start, stop, last_start_time, stop_if_next_hour_is_imminent, stop_if_running_for, update_dns
+from lifecycle import start, stop, last_start_time, stop_if_running_for, update_dns
 import masterless

--- a/src/integration_tests/test_provisioning.py
+++ b/src/integration_tests/test_provisioning.py
@@ -1,6 +1,4 @@
 import os
-from datetime import datetime
-from subprocess import check_output
 from fabric.api import settings
 from tests import base
 from buildercore import bootstrap, cfngen, lifecycle
@@ -10,15 +8,10 @@ import cfn
 
 from fabfile import PROJECT_DIR
 
-def generate_environment_name():
-    """to avoid multiple people clashing while running their builds
-       and new builds clashing with older ones"""
-    return check_output('whoami').rstrip() + datetime.utcnow().strftime("%Y%m%d%H%M%S")
-
 class TestProvisioning(base.BaseCase):
     def setUp(self):
         self.stacknames = []
-        self.environment = generate_environment_name()
+        self.environment = self.generate_environment_name()
 
     def tearDown(self):
         for stackname in self.stacknames:
@@ -72,7 +65,7 @@ class TestProvisioning(base.BaseCase):
 class TestDeployment(base.BaseCase):
     def setUp(self):
         self.stacknames = []
-        self.environment = generate_environment_name()
+        self.environment = self.generate_environment_name()
 
     def tearDown(self):
         for stackname in self.stacknames:

--- a/src/lifecycle.py
+++ b/src/lifecycle.py
@@ -32,16 +32,6 @@ def last_start_time(stackname):
 @task
 @requires_aws_stack
 @timeit
-def stop_if_next_hour_is_imminent(stackname, minimum_minutes='55'):
-    # TODO: can we write a description of the @task somewhere?
-    """If a node has been running for a time between X:55:00 and X:59:59 hours, stops it to avoid incurring in a new charge for the next hour.
-
-    The assumption is that stacks where this command is used are not needed for long parts of the day/week, and that who needs them will call the start task first."""
-    return lifecycle.stop_if_next_hour_is_imminent(stackname, int(minimum_minutes))
-
-@task
-@requires_aws_stack
-@timeit
 def stop_if_running_for(stackname, minimum_minutes='30'):
     # TODO: can we write a description of the @task somewhere?
     """If a node has been running for a time greater than minimum_minutes, stop it.

--- a/src/lifecycle.py
+++ b/src/lifecycle.py
@@ -12,9 +12,12 @@ def start(stackname):
 @task
 @requires_aws_stack
 @timeit
-def stop(stackname):
+def stop(stackname, *services):
     "Stops the nodes of 'stackname' without losing their state. Idempotent"
-    lifecycle.stop(stackname)
+    if services == []:
+        services = ['ec2']
+
+    lifecycle.stop(stackname, services)
 
 @task
 @requires_aws_stack

--- a/src/lifecycle.py
+++ b/src/lifecycle.py
@@ -13,7 +13,9 @@ def start(stackname):
 @requires_aws_stack
 @timeit
 def stop(stackname, *services):
-    "Stops the nodes of 'stackname' without losing their state. Idempotent"
+    """Stops the nodes of 'stackname' without losing their state.
+    
+    Idempotent. Default to stopping only EC2 but additional services like 'rds' can be passed in"""
     if services == []:
         services = ['ec2']
 
@@ -30,8 +32,7 @@ def restart(stackname):
 @requires_aws_stack
 @timeit
 def stop_if_running_for(stackname, minimum_minutes='30'):
-    # TODO: can we write a description of the @task somewhere?
-    """If a node has been running for a time greater than minimum_minutes, stop it.
+    """If a EC2 node has been running for a time greater than minimum_minutes, stop it.
 
     The assumption is that stacks where this command is used are not needed for long parts of the day/week, and that who needs them will call the start task first."""
     return lifecycle.stop_if_running_for(stackname, int(minimum_minutes))
@@ -39,4 +40,7 @@ def stop_if_running_for(stackname, minimum_minutes='30'):
 @debugtask
 @requires_aws_stack
 def update_dns(stackname):
+    """Updates the public DNS entry of the EC2 nodes.
+
+    Private DNS entries typically do not need updates, and only EC2 nodes have public, mutable IP addresses during restarts"""
     lifecycle.update_dns(stackname)

--- a/src/lifecycle.py
+++ b/src/lifecycle.py
@@ -14,7 +14,7 @@ def start(stackname):
 @timeit
 def stop(stackname, *services):
     """Stops the nodes of 'stackname' without losing their state.
-    
+
     Idempotent. Default to stopping only EC2 but additional services like 'rds' can be passed in"""
     if services == []:
         services = ['ec2']

--- a/src/lifecycle.py
+++ b/src/lifecycle.py
@@ -1,6 +1,6 @@
 from fabric.api import task
 from buildercore import lifecycle
-from decorators import requires_aws_stack, timeit, echo_output, debugtask
+from decorators import requires_aws_stack, timeit, debugtask
 
 @task
 @requires_aws_stack
@@ -22,12 +22,6 @@ def stop(stackname):
 def restart(stackname):
     stop(stackname)
     start(stackname)
-
-@task
-@requires_aws_stack
-@echo_output
-def last_start_time(stackname):
-    return lifecycle.last_start_time(stackname)
 
 @task
 @requires_aws_stack

--- a/src/tests/base.py
+++ b/src/tests/base.py
@@ -1,5 +1,7 @@
+from datetime import datetime
 import os
 from os.path import join
+from subprocess import check_output
 from unittest import TestCase
 from buildercore import config, project
 
@@ -25,6 +27,11 @@ class BaseCase(TestCase):
         # clear any caches and reload the config module
         project.project_map.cache_clear()
         reload(config)
+
+    def generate_environment_name(self):
+        """to avoid multiple people clashing while running their builds
+           and new builds clashing with older ones"""
+        return check_output('whoami').rstrip() + datetime.utcnow().strftime("%Y%m%d%H%M%S")
 
     # pyline: disable=invalid-name
     def assertAllPairsEqual(self, fn, pair_lst):

--- a/src/tests/fixtures/projects/dummy-project.yaml
+++ b/src/tests/fixtures/projects/dummy-project.yaml
@@ -396,6 +396,13 @@ project-with-db-params:
                 key1: val1
                 key2: val2
 
+project-with-rds-only:
+    repo: ssh://git@github.com/elifesciences/dummy3
+    aws:
+        ec2: false
+        rds:
+            storage: 5
+
 project-with-elasticache-redis:
     domain: False
     intdomain: False

--- a/src/tests/test_buildercore_cfngen.py
+++ b/src/tests/test_buildercore_cfngen.py
@@ -6,10 +6,6 @@ import logging
 LOG = logging.getLogger(__name__)
 
 class TestBuildercoreCfngen(base.BaseCase):
-    def setUp(self):
-        super(TestBuildercoreCfngen, self).setUp()
-        self.test_region = 'us-east-1'
-
     def test_rendering(self):
         for pname in project.aws_projects().keys():
             LOG.info('rendering %s', pname)
@@ -35,10 +31,6 @@ class TestBuildercoreCfngen(base.BaseCase):
         self.switch_in_test_settings()
 
 class TestUpdates(base.BaseCase):
-    def setUp(self):
-        super(TestUpdates, self).setUp()
-        self.test_region = 'us-east-1'
-
     def test_empty_template_delta(self):
         context = self._base_context()
         (delta_plus, delta_edit, delta_minus) = cfngen.template_delta('dummy1', context)

--- a/src/tests/test_buildercore_cfngen.py
+++ b/src/tests/test_buildercore_cfngen.py
@@ -7,10 +7,8 @@ LOG = logging.getLogger(__name__)
 
 class TestBuildercoreCfngen(base.BaseCase):
     def setUp(self):
+        super(TestBuildercoreCfngen, self).setUp()
         self.test_region = 'us-east-1'
-
-    def tearDown(self):
-        pass
 
     def test_rendering(self):
         for pname in project.aws_projects().keys():
@@ -38,10 +36,8 @@ class TestBuildercoreCfngen(base.BaseCase):
 
 class TestUpdates(base.BaseCase):
     def setUp(self):
+        super(TestUpdates, self).setUp()
         self.test_region = 'us-east-1'
-
-    def tearDown(self):
-        pass
 
     def test_empty_template_delta(self):
         context = self._base_context()

--- a/src/tests/test_buildercore_lifecycle.py
+++ b/src/tests/test_buildercore_lifecycle.py
@@ -25,26 +25,13 @@ class TestBuildercoreLifecycle(base.BaseCase):
     @patch('buildercore.lifecycle.find_rds_instances')
     @patch('buildercore.lifecycle.find_ec2_instances')
     def test_start_idempotence(self, find_ec2_instances, find_rds_instances):
-        some = MagicMock()
-        some.id = 'i-456'
-        some.state = 'running'
-        some.tags = {'Name': 'dummy1--test--1'}
-        some.launch_time = '2000-01-01T00:00:00.000Z'
-
-        find_ec2_instances.return_value = [some]
+        find_ec2_instances.return_value = [self._ec2_instance('running')]
         lifecycle.start('dummy1--test')
 
     @patch('buildercore.lifecycle.find_ec2_instances')
     def test_ignores_terminated_stacks_that_have_been_replaced_by_a_new_instance(self, find_ec2_instances):
-        old = MagicMock()
-        old.id = 'i-123'
-        old.state = 'terminated'
-        old.tags = {'Name': 'dummy1--test--1'}
-
-        new = MagicMock()
-        new.id = 'i-456'
-        new.state = 'running'
-        new.tags = {'Name': 'dummy1--test--1'}
+        old = self._ec2_instance('terminated', 'i-123')
+        new = self._ec2_instance('running', 'i-456')
 
         find_ec2_instances.return_value = [old, new]
         self.assertEqual({'i-456': 'running'}, lifecycle._ec2_nodes_states('dummy1--test'))
@@ -52,20 +39,15 @@ class TestBuildercoreLifecycle(base.BaseCase):
     @patch('buildercore.lifecycle._stop')
     @patch('buildercore.lifecycle.find_ec2_instances')
     def test_stops_instances_when_running_for_too_many_minutes(self, find_ec2_instances, _stop):
-        some = MagicMock()
-        some.id = 'i-456'
-        some.state = 'running'
-        some.tags = {'Name': 'dummy1--test--1'}
-        some.launch_time = '2000-01-01T00:00:00.000Z'
 
-        find_ec2_instances.return_value = [some]
+        find_ec2_instances.return_value = [self._ec2_instance('running', launch_time='2000-01-01T00:00:00.000Z')]
         lifecycle.stop_if_running_for('dummy1--test', 30)
 
-    def _ec2_instance(self, state='running'):
+    def _ec2_instance(self, state='running', id='i-456', launch_time='2017-01-01T00:00:00.000Z'):
         instance = MagicMock()
-        instance.id = 'i-456'
+        instance.id = id
         instance.state = state
         instance.tags = {'Name': 'dummy1--test--1'}
-        instance.launch_time = '2000-01-01T00:00:00.000Z'
+        instance.launch_time = launch_time
         return instance
 

--- a/src/tests/test_buildercore_lifecycle.py
+++ b/src/tests/test_buildercore_lifecycle.py
@@ -1,6 +1,7 @@
+import json
 from mock import patch, MagicMock
 from . import base
-from buildercore import lifecycle
+from buildercore import cfngen, context_handler, lifecycle
 
 
 class TestBuildercoreLifecycle(base.BaseCase):
@@ -21,6 +22,19 @@ class TestBuildercoreLifecycle(base.BaseCase):
         c.start_instances = MagicMock()
         ec2_connection.return_value = c
         lifecycle.start('dummy1--test')
+
+    @patch('buildercore.lifecycle.find_rds_instances')
+    @patch('buildercore.lifecycle.find_ec2_instances')
+    def test_start_a_not_running_rds_instance(self, find_ec2_instances, find_rds_instances):
+        find_ec2_instances.return_value = []
+        find_rds_instances.side_effect = [
+            []
+        ]
+
+        context = cfngen.build_context('project-with-rds-only', stackname='project-with-rds-only--test')
+        context_handler.write_context_locally('project-with-rds-only--test', json.dumps(context))
+
+        lifecycle.start('project-with-rds-only--test')
 
     @patch('buildercore.lifecycle.find_rds_instances')
     @patch('buildercore.lifecycle.find_ec2_instances')

--- a/src/tests/test_buildercore_lifecycle.py
+++ b/src/tests/test_buildercore_lifecycle.py
@@ -5,6 +5,35 @@ from buildercore import lifecycle
 
 class TestBuildercoreLifecycle(base.BaseCase):
 
+    @patch('buildercore.lifecycle._some_node_is_not_ready')
+    @patch('buildercore.lifecycle._ec2_connection')
+    @patch('buildercore.lifecycle.find_rds_instances')
+    @patch('buildercore.lifecycle.find_ec2_instances')
+    def test_start_a_not_running_ec2_instance(self, find_ec2_instances, find_rds_instances, ec2_connection, some_node_is_not_ready):
+        find_ec2_instances.side_effect = [
+            [self._ec2_instance('stopped')],
+            [self._ec2_instance('running')],
+            [self._ec2_instance('running')] # update_dns additional call
+        ]
+        some_node_is_not_ready.return_value = False
+
+        c = MagicMock()
+        c.start_instances = MagicMock()
+        ec2_connection.return_value = c
+        lifecycle.start('dummy1--test')
+
+    @patch('buildercore.lifecycle.find_rds_instances')
+    @patch('buildercore.lifecycle.find_ec2_instances')
+    def test_start_idempotence(self, find_ec2_instances, find_rds_instances):
+        some = MagicMock()
+        some.id = 'i-456'
+        some.state = 'running'
+        some.tags = {'Name': 'dummy1--test--1'}
+        some.launch_time = '2000-01-01T00:00:00.000Z'
+
+        find_ec2_instances.return_value = [some]
+        lifecycle.start('dummy1--test')
+
     @patch('buildercore.lifecycle.find_ec2_instances')
     def test_ignores_terminated_stacks_that_have_been_replaced_by_a_new_instance(self, find_ec2_instances):
         old = MagicMock()
@@ -31,3 +60,12 @@ class TestBuildercoreLifecycle(base.BaseCase):
 
         find_ec2_instances.return_value = [some]
         lifecycle.stop_if_running_for('dummy1--test', 30)
+
+    def _ec2_instance(self, state='running'):
+        instance = MagicMock()
+        instance.id = 'i-456'
+        instance.state = state
+        instance.tags = {'Name': 'dummy1--test--1'}
+        instance.launch_time = '2000-01-01T00:00:00.000Z'
+        return instance
+

--- a/src/tests/test_buildercore_lifecycle.py
+++ b/src/tests/test_buildercore_lifecycle.py
@@ -18,7 +18,7 @@ class TestBuildercoreLifecycle(base.BaseCase):
         new.tags = {'Name': 'dummy1--test--1'}
 
         find_ec2_instances.return_value = [old, new]
-        self.assertEqual({'i-456': 'running'}, lifecycle._nodes_states('dummy1--test'))
+        self.assertEqual({'i-456': 'running'}, lifecycle._ec2_nodes_states('dummy1--test'))
 
     @patch('buildercore.lifecycle._stop')
     @patch('buildercore.lifecycle.find_ec2_instances')

--- a/src/tests/test_buildercore_lifecycle.py
+++ b/src/tests/test_buildercore_lifecycle.py
@@ -84,7 +84,7 @@ class TestBuildercoreLifecycle(base.BaseCase):
         find_ec2_instances.return_value = [self._ec2_instance('running', launch_time='2000-01-01T00:00:00.000Z')]
         lifecycle.stop_if_running_for('dummy1--test', 30)
 
-    def _generate_context(self, stackname): 
+    def _generate_context(self, stackname):
         (pname, instance_id) = parse_stackname(stackname)
         context = cfngen.build_context(pname, stackname=stackname)
         context_handler.write_context_locally(stackname, json.dumps(context))
@@ -99,7 +99,7 @@ class TestBuildercoreLifecycle(base.BaseCase):
 
     def _rds_instance(self, state='available', id='i-456'):
         instance = {
-            'DBInstanceIdentifier':id,
+            'DBInstanceIdentifier': id,
             'DBInstanceStatus': state,
         }
         return instance

--- a/src/tests/test_buildercore_lifecycle.py
+++ b/src/tests/test_buildercore_lifecycle.py
@@ -6,6 +6,10 @@ from buildercore import cfngen, context_handler, lifecycle
 
 
 class TestBuildercoreLifecycle(base.BaseCase):
+    @classmethod
+    def setUpClass(cls):
+        cls._generate_context('dummy1--test')
+        cls._generate_context('project-with-rds-only--test')
 
     @patch('buildercore.lifecycle._some_node_is_not_ready')
     @patch('buildercore.lifecycle._ec2_connection')
@@ -28,7 +32,6 @@ class TestBuildercoreLifecycle(base.BaseCase):
     @patch('buildercore.lifecycle.find_rds_instances')
     @patch('buildercore.lifecycle.find_ec2_instances')
     def test_start_a_not_running_rds_instance(self, find_ec2_instances, find_rds_instances, rds_connection):
-        self._generate_context('project-with-rds-only--test')
         find_ec2_instances.return_value = []
         find_rds_instances.side_effect = [
             [self._rds_instance('stopped')],
@@ -84,7 +87,8 @@ class TestBuildercoreLifecycle(base.BaseCase):
         find_ec2_instances.return_value = [self._ec2_instance('running', launch_time='2000-01-01T00:00:00.000Z')]
         lifecycle.stop_if_running_for('dummy1--test', 30)
 
-    def _generate_context(self, stackname):
+    @staticmethod
+    def _generate_context(stackname):
         (pname, instance_id) = parse_stackname(stackname)
         context = cfngen.build_context(pname, stackname=stackname)
         context_handler.write_context_locally(stackname, json.dumps(context))

--- a/src/tests/test_buildercore_project.py
+++ b/src/tests/test_buildercore_project.py
@@ -10,7 +10,7 @@ ALL_PROJECTS = [
     'just-some-sns', 'project-with-sqs', 'project-with-s3',
     'project-with-ext', 'project-with-cloudfront', 'project-with-cloudfront-minimal',
     'project-with-cloudfront-error-pages', 'project-with-cloudfront-origins', 'project-with-cluster', 'project-with-cluster-suppressed', 'project-with-cluster-overrides', 'project-with-stickiness', 'project-with-multiple-elb-listeners',
-    'project-with-cluster-integration-tests', 'project-with-db-params', 'project-with-elasticache-redis',
+    'project-with-cluster-integration-tests', 'project-with-db-params', 'project-with-rds-only', 'project-with-elasticache-redis',
 ]
 
 class TestProject(base.BaseCase):

--- a/src/tests/test_buildercore_s3.py
+++ b/src/tests/test_buildercore_s3.py
@@ -17,13 +17,13 @@ class SimpleCases(base.BaseCase):
         self.assertFalse(s3.exists(key))
 
     def test_writable(self):
-        key = "test/foo"
+        key = "test/foo-%s" % self.generate_environment_name()
         self.assertFalse(s3.exists(key))
         s3.write(key, "asdf")
         self.assertTrue(s3.exists(key))
 
     def test_overwrite(self):
-        key = "test/foo"
+        key = "test/foo-%s" % self.generate_environment_name()
         self.assertFalse(s3.exists(key))
         s3.write(key, "asdf")
         self.assertRaises(KeyError, s3.write, key, "fdsa")
@@ -32,7 +32,7 @@ class SimpleCases(base.BaseCase):
         # TODO: test content was actually overwritten
 
     def test_delete(self):
-        key = "test/foo"
+        key = "test/foo-%s" % self.generate_environment_name()
         s3.write(key, "asdf")
         self.assertTrue(s3.exists(key))
         s3.delete(key)
@@ -40,16 +40,16 @@ class SimpleCases(base.BaseCase):
 
     def test_list(self):
         keys = [
-            "test/foo",
-            "test/bar",
-            "test/baz"
+            "test/foo-%s" % self.generate_environment_name(),
+            "test/bar-%s" % self.generate_environment_name(),
+            "test/baz-%s" % self.generate_environment_name(),
         ]
         for key in keys:
             s3.write(key, 'asdf')
         self.assertEqual(sorted(keys), sorted(s3.simple_listing("test/")))
 
     def test_download(self):
-        key = "test/baz"
+        key = "test/foo-%s" % self.generate_environment_name()
         expected_contents = "test content"
         expected_output = '/tmp/builder/baz'
         s3.write(key, expected_contents)


### PR DESCRIPTION
Rough implementation of RDS start and stop primitives, including the polling to ensure they go into the specified states. RDS is slower to react, but it's somewhat simpler as there is no SSH polling that we can do to check if the instances are up; and we cannot read from the API the last starting time of the node.

Since RDS transitions are much slower than EC2, there is some more customization on involved services to support use cases:
- start everything (why would you start only a piece? A project would never work with just the database or just the EC2 up)
- stop only EC2 if they have been running for half an hour (frequently)
- stop only RDS or stop everything (at the end of the week)
Some obsolete scenario like `stop_if_next_hour_is_imminent` has been removed as AWS now bills in such a way that it makes no sense to stop instances in that pattern.

Unit testing of the `lifecycle` module is extended to cover basic start/stop scenarios without resorting to creating real EC2 or RDS resources (`integration_tests`), which would make the test suite very slow and brittle. Also the S3 testing needed to support concurrent runs to avoid builds clashing with a developer running the tests.

Will require some work to clean and productionize, but it's functionally complete.