### PR TITLE
ELPP-3233 Consistent tagging

### DIFF
--- a/src/buildercore/trop.py
+++ b/src/buildercore/trop.py
@@ -117,14 +117,15 @@ def rds_security(context):
 #
 
 
-def _generic_tags(context):
-    return {
+def _generic_tags(context, name=True):
+    tags = {
         'Project': context['project_name'], # journal
         'Environment': context['instance_id'], # stack instance id
         # the name AWS Console uses to label an instance
-        'Name': context['stackname'], # ll: journal-prod
         'Cluster': context['stackname'], # ll: journal--prod
     }
+    tags['Name'] = context['stackname'] # ll: journal-prod
+    return tags
 
 def instance_tags(context, node=None):
     # NOTE: RDS and Elasticache instances also call this function
@@ -450,7 +451,8 @@ def render_sqs(context, template):
 def render_s3(context, template):
     for bucket_name in context['s3']:
         props = {
-            'DeletionPolicy': context['s3'][bucket_name]['deletion-policy'].capitalize()
+            'DeletionPolicy': context['s3'][bucket_name]['deletion-policy'].capitalize(),
+            'Tags': s3.Tags(**_generic_tags(context, name=False)),
         }
         bucket_title = _sanitize_title(bucket_name) + "Bucket"
         if context['s3'][bucket_name]['cors']:

--- a/src/buildercore/trop.py
+++ b/src/buildercore/trop.py
@@ -280,6 +280,7 @@ def render_ext_volume(context, template, node=1):
         "Size": str(context_ext['size']),
         "AvailabilityZone": GetAtt(EC2_TITLE_NODE % node, "AvailabilityZone"),
         "VolumeType": vtype,
+        "Tags": instance_tags(context, node),
     }
     ec2v = ec2.Volume(EXT_TITLE % node, **args)
 

--- a/src/buildercore/trop.py
+++ b/src/buildercore/trop.py
@@ -123,7 +123,8 @@ def _generic_tags(context):
         'Project': context['project_name'], # journal
         'Environment': context['instance_id'], # stack instance id
         # the name AWS Console uses to label an instance
-        'Name': context['stackname'] # ll: journal-prod
+        'Name': context['stackname'], # ll: journal-prod
+        'Cluster': context['stackname'], # ll: journal--prod
     }
 
 def instance_tags(context, node=None):
@@ -133,7 +134,6 @@ def instance_tags(context, node=None):
         # this instance is part of a cluster
         tags.update({
             'Name': '%s--%d' % (context['stackname'], node), # ll: journal--prod--1
-            'Cluster': context['stackname'], # ll: journal--prod
             'Node': node, # ll: 1
         })
     return [ec2.Tag(key, str(value)) for key, value in tags.items()]

--- a/src/buildercore/trop.py
+++ b/src/buildercore/trop.py
@@ -142,7 +142,6 @@ def elb_tags(context):
     tags = _generic_tags(context)
     tags.update({
         'Name': '%s--elb' % context['stackname'], # ll: journal--prod--elb
-        'Cluster': context['stackname'], # ll: journal--prod
     })
     return [ec2.Tag(key, value) for key, value in tags.items()]
 

--- a/src/buildercore/trop.py
+++ b/src/buildercore/trop.py
@@ -119,7 +119,6 @@ def rds_security(context):
 
 def _generic_tags(context):
     return {
-        'Owner': context['author'],
         'Project': context['project_name'], # journal
         'Environment': context['instance_id'], # stack instance id
         # the name AWS Console uses to label an instance
@@ -233,7 +232,7 @@ def render_rds(context, template):
     # rds parameter group. None or a Ref
     param_group_ref = rdsdbparams(context, template)
 
-    tags = [t for t in instance_tags(context) if t.Key != 'Owner']
+    tags = [t for t in instance_tags(context)]
     # db instance
     data = {
         'DBName': lu('rds_dbname'), # dbname generated from instance id.

--- a/src/tests/test_buildercore_trop.py
+++ b/src/tests/test_buildercore_trop.py
@@ -444,6 +444,12 @@ class TestBuildercoreTrop(base.BaseCase):
                 'DeletionPolicy': 'Delete',
                 'Properties': {
                     'BucketName': 'widgets-prod',
+                    'Tags': [
+                        {'Key': 'Cluster', 'Value': 'project-with-s3--prod'},
+                        {'Key': 'Environment', 'Value': 'prod'},
+                        {'Key': 'Name', 'Value': 'project-with-s3--prod'},
+                        {'Key': 'Project', 'Value': 'project-with-s3'},
+                    ],
                 }
             },
             data['Resources']['WidgetsProdBucket']
@@ -454,6 +460,12 @@ class TestBuildercoreTrop(base.BaseCase):
                 'DeletionPolicy': 'Retain',
                 'Properties': {
                     'BucketName': 'widgets-archive-prod',
+                    'Tags': [
+                        {'Key': 'Cluster', 'Value': 'project-with-s3--prod'},
+                        {'Key': 'Environment', 'Value': 'prod'},
+                        {'Key': 'Name', 'Value': 'project-with-s3--prod'},
+                        {'Key': 'Project', 'Value': 'project-with-s3'},
+                    ],
                 },
             },
             data['Resources']['WidgetsArchiveProdBucket']
@@ -475,7 +487,13 @@ class TestBuildercoreTrop(base.BaseCase):
                     },
                     'WebsiteConfiguration': {
                         'IndexDocument': 'index.html',
-                    }
+                    },
+                    'Tags': [
+                        {'Key': 'Cluster', 'Value': 'project-with-s3--prod'},
+                        {'Key': 'Environment', 'Value': 'prod'},
+                        {'Key': 'Name', 'Value': 'project-with-s3--prod'},
+                        {'Key': 'Project', 'Value': 'project-with-s3'},
+                    ],
                 },
             },
             data['Resources']['WidgetsStaticHostingProdBucket']
@@ -510,6 +528,12 @@ class TestBuildercoreTrop(base.BaseCase):
                 'Properties': {
                     'AccessControl': 'PublicRead',
                     'BucketName': 'widgets-just-access-prod',
+                    'Tags': [
+                        {'Key': 'Cluster', 'Value': 'project-with-s3--prod'},
+                        {'Key': 'Environment', 'Value': 'prod'},
+                        {'Key': 'Name', 'Value': 'project-with-s3--prod'},
+                        {'Key': 'Project', 'Value': 'project-with-s3'},
+                    ],
                 },
             },
             data['Resources']['WidgetsJustAccessProdBucket']

--- a/src/tests/test_buildercore_trop.py
+++ b/src/tests/test_buildercore_trop.py
@@ -106,6 +106,14 @@ class TestBuildercoreTrop(base.BaseCase):
                 'AvailabilityZone': {'Fn::GetAtt': ['EC2Instance1', 'AvailabilityZone']},
                 'VolumeType': 'standard',
                 'Size': '200',
+                'Tags': [
+                    {'Key': 'Project', 'Value': 'project-with-ext'},
+                    {'Key': 'Environment', 'Value': 'prod'},
+                    {'Key': 'Name', 'Value': 'project-with-ext--prod--1'},
+                    {'Key': 'Cluster', 'Value': 'project-with-ext--prod'},
+                    {'Key': 'Owner', 'Value': 'my_user'},
+                    {'Key': 'Node', 'Value': '1'},
+                ],
             },
             data['Resources']['ExtraStorage1']['Properties']
         )

--- a/src/tests/test_buildercore_trop.py
+++ b/src/tests/test_buildercore_trop.py
@@ -27,8 +27,8 @@ class TestBuildercoreTrop(base.BaseCase):
             data['Resources']['AttachedDB']['Properties']['Tags'],
             [
                 {'Key': 'Project', 'Value': 'dummy3'},
-                {'Key': 'Name', 'Value': 'dummy3--test'},
                 {'Key': 'Environment', 'Value': 'test'},
+                {'Key': 'Name', 'Value': 'dummy3--test'},
                 {'Key': 'Cluster', 'Value': 'dummy3--test'},
             ]
         )
@@ -111,7 +111,6 @@ class TestBuildercoreTrop(base.BaseCase):
                     {'Key': 'Environment', 'Value': 'prod'},
                     {'Key': 'Name', 'Value': 'project-with-ext--prod--1'},
                     {'Key': 'Cluster', 'Value': 'project-with-ext--prod'},
-                    {'Key': 'Owner', 'Value': 'my_user'},
                     {'Key': 'Node', 'Value': '1'},
                 ],
             },
@@ -774,7 +773,6 @@ class TestBuildercoreTrop(base.BaseCase):
                     {'Key': 'Cluster', 'Value': 'project-with-elasticache-redis--prod'},
                     {'Key': 'Environment', 'Value': 'prod'},
                     {'Key': 'Name', 'Value': 'project-with-elasticache-redis--prod'},
-                    {'Key': 'Owner', 'Value': 'my_user'},
                     {'Key': 'Project', 'Value': 'project-with-elasticache-redis'},
                 ],
                 'VpcSecurityGroupIds': [{'Ref': 'ElastiCacheSecurityGroup'}],

--- a/src/tests/test_buildercore_trop.py
+++ b/src/tests/test_buildercore_trop.py
@@ -29,6 +29,7 @@ class TestBuildercoreTrop(base.BaseCase):
                 {'Key': 'Project', 'Value': 'dummy3'},
                 {'Key': 'Name', 'Value': 'dummy3--test'},
                 {'Key': 'Environment', 'Value': 'test'},
+                {'Key': 'Cluster', 'Value': 'dummy3--test'},
             ]
         )
 
@@ -762,6 +763,7 @@ class TestBuildercoreTrop(base.BaseCase):
                 'PreferredAvailabilityZone': 'us-east-1a',
                 'NumCacheNodes': 1,
                 'Tags': [
+                    {'Key': 'Cluster', 'Value': 'project-with-elasticache-redis--prod'},
                     {'Key': 'Environment', 'Value': 'prod'},
                     {'Key': 'Name', 'Value': 'project-with-elasticache-redis--prod'},
                     {'Key': 'Owner', 'Value': 'my_user'},


### PR DESCRIPTION
Useful to have the same tags all over, so that they can be used without confusion from the AWS billing console.

- Tag `Cluster` for RDS and ElastiCache
- Tags for EBS volumes
- Tags for S3 buckets
- Tags for ELB already in place
- Dropping `Owner` tag (like for RDS before) because it leads to updates being performed just when two different people work on the same stack