### PR TITLE
journal-cms--ci should have an /ext volume

### DIFF
--- a/projects/elife.yaml
+++ b/projects/elife.yaml
@@ -648,9 +648,9 @@ journal-cms:
             ec2:
                 ami: ami-92002785 # Ubuntu 14.04, deprecated
                 masterless: true
-        restore-test:
+        ci:
             ext:
-                size: 30 # GB
+                size: 5 # GB
         end2end:
             description: production-like environment. backed by RDS
             rds:


### PR DESCRIPTION
It is currently at 95% of occupied space on /