### PR TITLE
CloudFront logs

### DIFF
--- a/projects/elife.yaml
+++ b/projects/elife.yaml
@@ -118,6 +118,7 @@ defaults:
             headers: []
             errors: null
             default-ttl: 0 # seconds
+            logging: false
         subdomains: []
         elasticache:
             # elasticache defaults only used if an `rds` section present in project

--- a/projects/elife.yaml
+++ b/projects/elife.yaml
@@ -407,6 +407,8 @@ journal:
                         # ELB with no active instances
                         503: "/5xx.html"
                     protocol: http
+                logging:
+                    bucket: elife-cloudfront-logs
         continuumtest:
             elasticache:
                 engine: redis

--- a/src/buildercore/cfngen.py
+++ b/src/buildercore/cfngen.py
@@ -206,6 +206,7 @@ def build_context_cloudfront(context, parameterize):
             'headers': context['project']['aws']['cloudfront']['headers'],
             'default-ttl': context['project']['aws']['cloudfront']['default-ttl'],
             'errors': errors,
+            'logging': context['project']['aws']['cloudfront'].get('logging', False),
             'origins': OrderedDict([
                 (o_id, {'hostname': parameterize(o['hostname']), 'pattern': o.get('pattern')})
                 for o_id, o in context['project']['aws']['cloudfront']['origins'].items()

--- a/src/buildercore/trop.py
+++ b/src/buildercore/trop.py
@@ -712,6 +712,12 @@ def render_cloudfront(context, template, origin_hostname):
             ) for code, page in context['cloudfront']['errors']['codes'].items()
         ]
 
+    if context['cloudfront']['logging']:
+        props['Logging'] = cloudfront.Logging(
+            Bucket=context['cloudfront']['logging']['bucket'],
+            Prefix="%s/" % context['stackname']
+        )
+
     if context['cloudfront']['origins']:
         props['CacheBehaviors'] = [
             _cache_behavior(o_id, o['pattern'])

--- a/src/buildercore/trop.py
+++ b/src/buildercore/trop.py
@@ -714,7 +714,7 @@ def render_cloudfront(context, template, origin_hostname):
 
     if context['cloudfront']['logging']:
         props['Logging'] = cloudfront.Logging(
-            Bucket=context['cloudfront']['logging']['bucket'],
+            Bucket="%s.s3.amazonaws.com" % context['cloudfront']['logging']['bucket'],
             Prefix="%s/" % context['stackname']
         )
 

--- a/src/tests/fixtures/projects/dummy-project.yaml
+++ b/src/tests/fixtures/projects/dummy-project.yaml
@@ -87,6 +87,7 @@ defaults:
             headers: []
             errors: null
             default-ttl: 300 # seconds
+            logging: false
         subdomains: []
         elasticache:
             # elasticache defaults only used if an `rds` section present in project

--- a/src/tests/fixtures/projects/dummy-project.yaml
+++ b/src/tests/fixtures/projects/dummy-project.yaml
@@ -239,6 +239,8 @@ project-with-cloudfront:
             headers:
                 - Accept
             default-ttl: 5
+            logging:
+                bucket: acme-logs
 
 project-with-cloudfront-minimal:
     repo: ssh://git@github.com/elifesciences/dummy3

--- a/src/tests/test_buildercore_cfngen.py
+++ b/src/tests/test_buildercore_cfngen.py
@@ -52,6 +52,7 @@ class TestUpdates(base.BaseCase):
             "headers": [],
             "errors": None,
             "default-ttl": 300,
+            "logging": False,
         }
         (delta_plus, delta_edit, delta_minus) = cfngen.template_delta('dummy1', context)
         self.assertEqual(delta_plus['Resources'].keys(), ['CloudFrontCDN', 'CloudFrontCDNDNS1', 'ExtDNS'])

--- a/src/tests/test_buildercore_trop.py
+++ b/src/tests/test_buildercore_trop.py
@@ -572,6 +572,9 @@ class TestBuildercoreTrop(base.BaseCase):
                 'compress': True,
                 'cookies': ['session_id'],
                 'headers': ['Accept'],
+                'logging': {
+                    'bucket': 'acme-logs',
+                },
                 'origins': {},
                 'subdomains': ['prod--cdn-of-www.example.org', 'example.org'],
                 'subdomains-without-dns': ['future.example.org'],
@@ -609,6 +612,10 @@ class TestBuildercoreTrop(base.BaseCase):
                         # yes this is a string containing the word 'true'...
                         'Enabled': 'true',
                         'HttpVersion': 'http2',
+                        'Logging': {
+                            'Bucket': 'acme-logs',
+                            'Prefix': 'project-with-cloudfront--prod/',
+                        },
                         'Origins': [
                             {
                                 'DomainName': 'prod--www.example.org',

--- a/src/tests/test_buildercore_trop.py
+++ b/src/tests/test_buildercore_trop.py
@@ -613,7 +613,7 @@ class TestBuildercoreTrop(base.BaseCase):
                         'Enabled': 'true',
                         'HttpVersion': 'http2',
                         'Logging': {
-                            'Bucket': 'acme-logs',
+                            'Bucket': 'acme-logs.s3.amazonaws.com',
                             'Prefix': 'project-with-cloudfront--prod/',
                         },
                         'Origins': [


### PR DESCRIPTION
CloudFront can fill a bucket with lots of zip files that you have to aggregate to see the traffic coming to the CDN. This can be useful for statistics, but in general to identify real user agents and real ip addresses in case you want to know the source of some traffic.

Spawned from a search incident this afternoon in which we know there is someone crawling our search pages, but we can't know where the traffic comes from.