### PR TITLE
ELPP-3180 Implemented IntDNS$n entries for EC2

### DIFF
--- a/projects/elife.yaml
+++ b/projects/elife.yaml
@@ -28,6 +28,9 @@ defaults:
         ec2:
             # how many EC2 instance per stack instance
             cluster-size: 1
+            # whether the EC2 nodes should get a per-node internal DNS entry such as env--project--1.elife.internal
+            # only makes sense if cluster-size > 1
+            dns-internal: False
             # override 'ext' (only supported key)
             # for some EC2 instances
             overrides: {}
@@ -1007,8 +1010,15 @@ search:
     aws:
         type: t2.medium # 4 GB of RAM: once we know more about which software
                         # will be installed, we can choose the right machine
+        #elb: 
+        #    protocol: 
+        #        - http
+        #    healthcheck:
+        #        path: /
         ec2:
             ami: ami-92002785 # Ubuntu 14.04, deprecated
+            #cluster-size: 2
+            #dns-internal: True
         ports:
             - 22
             - 80:

--- a/projects/elife.yaml
+++ b/projects/elife.yaml
@@ -1043,8 +1043,6 @@ search:
             elb: 
                 protocol: 
                     - http
-                healthcheck:
-                    path: /
         standalone:
             # for now a copy of standalone1404
             # required by masterless module

--- a/projects/elife.yaml
+++ b/projects/elife.yaml
@@ -1033,10 +1033,25 @@ search:
                 - 22
                 - 80:
                     cidr-ip: 10.0.0.0/16 # ELB only
-                #- 4730: # Gearman
-                #    cidr-ip: 10.0.0.0/16 # ELB only
-                #- 9200: # ElasticSearch
-                #    cidr-ip: 10.0.0.0/16 # ELB only
+                - 4730: # Gearman
+                    cidr-ip: 10.0.0.0/16 # follower nodes
+                - 9200: # ElasticSearch
+                    cidr-ip: 10.0.0.0/16 # follower nodes
+            ec2:
+                cluster-size: 2
+                dns-internal: True
+            elb: 
+                protocol: 
+                    - http
+        prod:
+            ports:
+                - 22
+                - 80:
+                    cidr-ip: 10.0.0.0/16 # ELB only
+                - 4730: # Gearman
+                    cidr-ip: 10.0.0.0/16 # follower nodes
+                - 9200: # ElasticSearch
+                    cidr-ip: 10.0.0.0/16 # follower nodes
             ec2:
                 cluster-size: 1
                 dns-internal: True

--- a/projects/elife.yaml
+++ b/projects/elife.yaml
@@ -1038,7 +1038,7 @@ search:
                 - 9200: # ElasticSearch
                     cidr-ip: 10.0.0.0/16 # follower nodes
             ec2:
-                cluster-size: 2
+                cluster-size: 1
                 dns-internal: True
             elb: 
                 protocol: 

--- a/projects/elife.yaml
+++ b/projects/elife.yaml
@@ -1010,15 +1010,8 @@ search:
     aws:
         type: t2.medium # 4 GB of RAM: once we know more about which software
                         # will be installed, we can choose the right machine
-        #elb: 
-        #    protocol: 
-        #        - http
-        #    healthcheck:
-        #        path: /
         ec2:
             ami: ami-92002785 # Ubuntu 14.04, deprecated
-            #cluster-size: 2
-            #dns-internal: True
         ports:
             - 22
             - 80:
@@ -1035,6 +1028,23 @@ search:
                     - bus-blog-articles--{instance}
                     - bus-labs-posts--{instance}
     aws-alt:
+        end2end:
+            ports:
+                - 22
+                - 80:
+                    cidr-ip: 10.0.0.0/16 # ELB only
+                #- 4730: # Gearman
+                #    cidr-ip: 10.0.0.0/16 # ELB only
+                #- 9200: # ElasticSearch
+                #    cidr-ip: 10.0.0.0/16 # ELB only
+            ec2:
+                cluster-size: 1
+                dns-internal: True
+            elb: 
+                protocol: 
+                    - http
+                healthcheck:
+                    path: /
         standalone:
             # for now a copy of standalone1404
             # required by masterless module

--- a/src/buildercore/cfngen.py
+++ b/src/buildercore/cfngen.py
@@ -407,12 +407,8 @@ def template_delta(pname, context):
     def legacy_title(title):
         # some titles like EC2Instance1 were originally EC2Instance
         # however, no reason not to let EC2Instance2 be created?
-        if title == 'EC2Instance1':
-            return 'EC2Instance'
-        if title == 'ExtraStorage1':
-            return 'ExtraStorage'
-        if title == 'MountPoint1':
-            return 'MountPoint'
+        if title in ['EC2Instance1', 'ExtraStorage1', 'MountPoint1']:
+            return title.strip('1')
 
     delta_plus_resources = {
         title: r for (title, r) in template['Resources'].items()

--- a/src/buildercore/cfngen.py
+++ b/src/buildercore/cfngen.py
@@ -346,9 +346,9 @@ def regenerate_stack(pname, **more_context):
 
 
 # can't add ExtDNS: it changes dynamically when we start/stop instances and should not be touched after creation
-UPDATABLE_TITLE_PATTERNS = ['^CloudFront.*', '^ElasticLoadBalancer.*', '^EC2Instance.*', '.*Bucket$', '.*BucketPolicy', '^StackSecurityGroup$', '^ELBSecurityGroup$', '^CnameDNS.+$', '^AttachedDB$', '^AttachedDBSubnet$', '^ExtraStorage.+$', '^MountPoint.+$', '^IntDNS$', '^ElastiCache$', '^ElastiCacheParameterGroup$', '^ElastiCacheSecurityGroup$', '^ElastiCacheSubnetGroup$']
+UPDATABLE_TITLE_PATTERNS = ['^CloudFront.*', '^ElasticLoadBalancer.*', '^EC2Instance.*', '.*Bucket$', '.*BucketPolicy', '^StackSecurityGroup$', '^ELBSecurityGroup$', '^CnameDNS.+$', '^AttachedDB$', '^AttachedDBSubnet$', '^ExtraStorage.+$', '^MountPoint.+$', '^IntDNS.*$', '^ElastiCache$', '^ElastiCacheParameterGroup$', '^ElastiCacheSecurityGroup$', '^ElastiCacheSubnetGroup$']
 
-REMOVABLE_TITLE_PATTERNS = ['^CnameDNS\\d+$', '^ExtDNS$', '^ExtraStorage.+$', '^MountPoint.+$', '^.+Queue$', '^EC2Instance.+$', '^IntDNS$', '^ElastiCache$', '^ElastiCacheParameterGroup$', '^ElastiCacheSecurityGroup$', '^ElastiCacheSubnetGroup$']
+REMOVABLE_TITLE_PATTERNS = ['^CnameDNS\\d+$', '^ExtDNS$', '^ExtraStorage.+$', '^MountPoint.+$', '^.+Queue$', '^EC2Instance.+$', '^IntDNS.*$', '^ElastiCache$', '^ElastiCacheParameterGroup$', '^ElastiCacheSecurityGroup$', '^ElastiCacheSubnetGroup$']
 EC2_NOT_UPDATABLE_PROPERTIES = ['ImageId', 'Tags', 'UserData']
 
 class Delta(namedtuple('Delta', ['plus', 'edit', 'minus'])):
@@ -359,7 +359,7 @@ class Delta(namedtuple('Delta', ['plus', 'edit', 'minus'])):
 def template_delta(pname, context):
     """given an already existing template, regenerates it and produces a delta containing only the new resources.
 
-    Most of the existing resources are treated as immutable and not put in the delta. Some that support updates like CloudFront are instead included"""
+    Some the existing resources are treated as immutable and not put in the delta. Most that support non-destructive updates like CloudFront are instead included"""
     old_template = read_template(context['stackname'])
     template = json.loads(render_template(context))
 
@@ -407,7 +407,12 @@ def template_delta(pname, context):
     def legacy_title(title):
         # some titles like EC2Instance1 were originally EC2Instance
         # however, no reason not to let EC2Instance2 be created?
-        return title.strip("1")
+        if title == 'EC2Instance1':
+            return 'EC2Instance'
+        if title == 'ExtraStorage1':
+            return 'ExtraStorage'
+        if title == 'MountPoint1':
+            return 'MountPoint'
 
     delta_plus_resources = {
         title: r for (title, r) in template['Resources'].items()

--- a/src/buildercore/config.py
+++ b/src/buildercore/config.py
@@ -111,6 +111,9 @@ PACKER_BOX_KEY = "boxes"
 PACKER_BOX_S3_PATH = "s3://%s" % join(PACKER_BOX_BUCKET, PACKER_BOX_KEY)
 PACKER_BOX_S3_HTTP_PATH = join("https://s3.amazonaws.com", PACKER_BOX_BUCKET, PACKER_BOX_KEY)
 
+# these sections *shouldn't* be merged if they *don't* exist in the project
+AWS_EXCLUDING = ['rds', 'ext', 'elb', 'cloudfront', 'elasticache']
+
 #
 # settings
 # believe it or not but buildercore.config is NOT the place to be putting settings

--- a/src/buildercore/core.py
+++ b/src/buildercore/core.py
@@ -627,6 +627,7 @@ def hostname_struct(stackname):
     if intdomain:
         updates['int_project_hostname'] = subdomain + "." + intdomain
         updates['int_full_hostname'] = hostname + "." + intdomain
+        updates['int_node_hostname'] = hostname + "--%s." + intdomain
 
     struct.update(updates)
     return struct

--- a/src/buildercore/project/files.py
+++ b/src/buildercore/project/files.py
@@ -5,6 +5,7 @@ from collections import OrderedDict
 # from . import core # DONT import core. this module should be relatively independent
 from buildercore import utils
 from buildercore.decorators import testme
+from buildercore.config import AWS_EXCLUDING
 from kids.cache import cache as cached
 
 import logging
@@ -73,14 +74,12 @@ def project_data(pname, project_file, snippets=0xDEADBEEF):
     utils.deepmerge(global_defaults, default_overrides)
 
     # exceptions.
-    # these values *shouldn't* be merged if they *don't* exist in the project
-    aws_excluding = ['rds', 'ext', 'elb', 'cloudfront', 'elasticache']
     excluding = [
         'aws',
         'vagrant',
         'vagrant-alt',
         'aws-alt',
-        {'aws': aws_excluding},
+        {'aws': AWS_EXCLUDING},
     ]
     project_data = copy.deepcopy(global_defaults)
     utils.deepmerge(project_data, project_list[pname], excluding)
@@ -101,7 +100,7 @@ def project_data(pname, project_file, snippets=0xDEADBEEF):
         # merge this over top of original aws defaults
         orig_defaults = copy.deepcopy(global_defaults['aws'])
 
-        utils.deepmerge(orig_defaults, project_aws, aws_excluding)
+        utils.deepmerge(orig_defaults, project_aws, AWS_EXCLUDING)
         project_data['aws-alt'][altname] = orig_defaults
 
     for altname, altdata in project_data.get('vagrant-alt', {}).items():

--- a/src/buildercore/trop.py
+++ b/src/buildercore/trop.py
@@ -845,8 +845,7 @@ def render(context):
     return template.to_json()
 
 def add_outputs(context, template):
-    if context['full_hostname']:
-        ensure(R53_EXT_TITLE in template.resources.keys(), "You want an external DNS entry but there is no resource configuring it: %s" % context)
+    if R53_EXT_TITLE in template.resources.keys():
         template.add_output(mkoutput("DomainName", "Domain name of the newly created stack instance", Ref(R53_EXT_TITLE)))
 
     if R53_INT_TITLE in template.resources.keys():

--- a/src/tests/fixtures/dummy1-project.json
+++ b/src/tests/fixtures/dummy1-project.json
@@ -14,6 +14,7 @@
     "aws": {
         "ec2": {
             "cluster-size": 1,
+            "dns-internal": false,
             "overrides": {},
             "suppressed": [],
             "ami": "ami-9eaa1cf6"

--- a/src/tests/fixtures/dummy2-project.json
+++ b/src/tests/fixtures/dummy2-project.json
@@ -14,6 +14,7 @@
     "aws": {
         "ec2": {
             "cluster-size": 1,
+            "dns-internal": false,
             "overrides": {},
             "suppressed": [],
             "ami": "ami-111111"
@@ -57,6 +58,7 @@
         "fresh": {
             "ec2": {
                 "cluster-size": 1,
+                "dns-internal": false,
                 "overrides": {},
                 "suppressed": [],
                 "ami": "ami-9eaa1cf6"
@@ -100,6 +102,7 @@
         "alt-config1": {
             "ec2": {
                 "cluster-size": 1,
+                "dns-internal": false,
                 "overrides": {},
                 "suppressed": [],
                 "ami": "ami-22222"

--- a/src/tests/fixtures/dummy3-project.json
+++ b/src/tests/fixtures/dummy3-project.json
@@ -14,6 +14,7 @@
     "aws": {
         "ec2": {
             "cluster-size": 1,
+            "dns-internal": false,
             "overrides": {},
             "suppressed": [],
             "ami": "ami-111111"
@@ -37,6 +38,7 @@
         "fresh": {
             "ec2": {
                 "cluster-size": 1,
+                "dns-internal": false,
                 "overrides": {},
                 "suppressed": [],
                 "ami": "ami-9eaa1cf6"
@@ -60,6 +62,7 @@
         "alt-config1": {
             "ec2": {
                 "cluster-size": 1,
+                "dns-internal": false,
                 "overrides": {},
                 "suppressed": [],
                 "ami": "ami-111111"

--- a/src/tests/fixtures/projects/dummy-project.yaml
+++ b/src/tests/fixtures/projects/dummy-project.yaml
@@ -23,6 +23,7 @@ defaults:
     aws:
         ec2:
             cluster-size: 1
+            dns-internal: False
             # nodes to temporarily delete, for later recreation
             # https://martinfowler.com/bliki/PhoenixServer.html
             suppressed: []
@@ -287,13 +288,12 @@ project-with-cloudfront-origins:
 project-with-cluster:
     repo: ssh://git@github.com/elifesciences/dummy3
     subdomain: project-with-cluster
-    # no internal domain, while the public 'domain' is true by default
-    intdomain: false
     aws:
         ports:
             - 80
         ec2:
             cluster-size: 2
+            dns-internal: True
         elb: 
             protocol: http
         subdomains:

--- a/src/tests/fixtures/projects/dummy-project2.yaml
+++ b/src/tests/fixtures/projects/dummy-project2.yaml
@@ -22,6 +22,7 @@ defaults:
     aws:
         ec2:
             cluster-size: 1
+            dns-internal: False
             # find more here: http://cloud-images.ubuntu.com/releases/
             ami: ami-9eaa1cf6  # Ubuntu 14.04
         type: t2.small

--- a/src/tests/test_buildercore_core.py
+++ b/src/tests/test_buildercore_core.py
@@ -35,6 +35,7 @@ class SimpleCases(base.BaseCase):
             'int_project_hostname': 'dummy2.example.internal',
             'full_hostname': 'ci--dummy2.example.org',
             'int_full_hostname': 'ci--dummy2.example.internal',
+            'int_node_hostname': 'ci--dummy2--%s.example.internal',
         }
         stackname = 'dummy2--ci'
         self.assertEqual(core.hostname_struct(stackname), expected)

--- a/src/tests/test_buildercore_trop.py
+++ b/src/tests/test_buildercore_trop.py
@@ -251,6 +251,20 @@ class TestBuildercoreTrop(base.BaseCase):
             resources['CnameDNS2']['Properties']
         )
 
+        self.assertIn('IntDNS1', resources.keys())
+        self.assertEqual(
+            {
+                'ResourceRecords': [{'Fn::GetAtt': ['EC2Instance1', 'PrivateIp']}],
+                'HostedZoneName': 'example.internal.',
+                'Name': 'prod--project-with-cluster--1.example.internal',
+                'TTL': '60',
+                'Type': 'A',
+                'Comment': 'Internal DNS record for EC2 node 1',
+            },
+            resources['IntDNS1']['Properties']
+        )
+        self.assertIn('IntDNS2', resources.keys())
+
     def test_clustered_template_suppressing_some_nodes(self):
         extra = {
             'stackname': 'project-with-cluster-suppressed--prod',


### PR DESCRIPTION
Useful for clusters of nodes that want to talk to each other. For example, nodes that are follower can connect to `end2end--search--1.elife.internal`, the leader node of the cluster.