### PR TITLE
Allow SNS topic removal

### DIFF
--- a/src/buildercore/cfngen.py
+++ b/src/buildercore/cfngen.py
@@ -348,7 +348,7 @@ def regenerate_stack(pname, **more_context):
 # can't add ExtDNS: it changes dynamically when we start/stop instances and should not be touched after creation
 UPDATABLE_TITLE_PATTERNS = ['^CloudFront.*', '^ElasticLoadBalancer.*', '^EC2Instance.*', '.*Bucket$', '.*BucketPolicy', '^StackSecurityGroup$', '^ELBSecurityGroup$', '^CnameDNS.+$', '^AttachedDB$', '^AttachedDBSubnet$', '^ExtraStorage.+$', '^MountPoint.+$', '^IntDNS$', '^ElastiCache$', '^ElastiCacheParameterGroup$', '^ElastiCacheSecurityGroup$', '^ElastiCacheSubnetGroup$']
 
-REMOVABLE_TITLE_PATTERNS = ['^CnameDNS\\d+$', '^ExtDNS$', '^ExtraStorage.+$', '^MountPoint.+$', '^.+Queue$', '^EC2Instance.+$', '^IntDNS$', '^ElastiCache$', '^ElastiCacheParameterGroup$', '^ElastiCacheSecurityGroup$', '^ElastiCacheSubnetGroup$']
+REMOVABLE_TITLE_PATTERNS = ['^CnameDNS\\d+$', '^ExtDNS$', '^ExtraStorage.+$', '^MountPoint.+$', '^.+Queue$', '^EC2Instance.+$', '^IntDNS$', '^ElastiCache$', '^ElastiCacheParameterGroup$', '^ElastiCacheSecurityGroup$', '^ElastiCacheSubnetGroup$', '^.+Topic$']
 EC2_NOT_UPDATABLE_PROPERTIES = ['ImageId', 'Tags', 'UserData']
 
 class Delta(namedtuple('Delta', ['plus', 'edit', 'minus'])):

--- a/src/cfn.py
+++ b/src/cfn.py
@@ -206,7 +206,9 @@ def _are_there_existing_servers(context):
         return True
 
     if isinstance(context['ec2'], bool):
-        LOG.error("bad buildvars in %s: context.ec2 is a boolean?", context['full_hostname'], extra={'context': str(context)})
+        if context['ec2'] is False:
+            return False
+        LOG.error("bad buildvars in %s: context.ec2 is True?", context['full_hostname'], extra={'context': str(context)})
         return context['ec2']
 
     num_suppressed = len(context['ec2'].get('suppressed', []))

--- a/src/cfn.py
+++ b/src/cfn.py
@@ -206,9 +206,8 @@ def _are_there_existing_servers(context):
         return True
 
     if isinstance(context['ec2'], bool):
-        if context['ec2'] is False:
-            return False
-        LOG.error("bad buildvars in %s: context.ec2 is True?", context['full_hostname'], extra={'context': str(context)})
+        # no ec2 instances or an instance whose buildvars haven't been updated.
+        # either way, the value here can be used as-is
         return context['ec2']
 
     num_suppressed = len(context['ec2'].get('suppressed', []))

--- a/src/cfn.py
+++ b/src/cfn.py
@@ -207,7 +207,7 @@ def _are_there_existing_servers(context):
 
     if isinstance(context['ec2'], bool):
         LOG.error("bad buildvars in %s: context.ec2 is a boolean?", context['full_hostname'], extra={'context': str(context)})
-        return True
+        return context['ec2']
 
     num_suppressed = len(context['ec2'].get('suppressed', []))
     cluster_size = context['ec2'].get('cluster-size', 1)


### PR DESCRIPTION
As per our whitelist model, we add SNS topics to the list of resources that can be removed from a template.

`bus` has no ec2 instance and exposes a little bug in
`_are_there_existing_servers`: if `ec2` is `False`, there are no servers to
start.

These topics were left around when we renamed from `labs-experiment` to `labs-post`, and will be removed:
```
[17:04:56][giorgio@Newton:~/code/builder]$ bldr update_template:bus--end2end
2017-11-13 17:05:29,396 - INFO - MainProcess - cfn - Create: {'Outputs': {}, 'Resources': {}}
2017-11-13 17:05:29,397 - INFO - MainProcess - cfn - Update: {'Outputs': {}, 'Resources': {}}
2017-11-13 17:05:29,398 - INFO - MainProcess - cfn - Delete: {'Outputs': {},
 'Resources': {u'BusLabsExperimentsEnd2endTopic': {u'Properties': {u'TopicName': u'bus-labs-experiments--end2end'},
                                                   u'Type': u'AWS::SNS::Topic'}}}
Confirming changes to the stack template? This will rewrite the context and the CloudFormation template
```
```
[17:07:12][giorgio@Newton:~/code/builder]$ bldr update_template:bus--prod
2017-11-13 17:07:15,946 - INFO - MainProcess - cfn - Create: {'Outputs': {}, 'Resources': {}}
2017-11-13 17:07:15,947 - INFO - MainProcess - cfn - Update: {'Outputs': {}, 'Resources': {}}
2017-11-13 17:07:15,947 - INFO - MainProcess - cfn - Delete: {'Outputs': {},
 'Resources': {u'BusLabsExperimentsProdTopic': {u'Properties': {u'TopicName': u'bus-labs-experiments--prod'},
                                                u'Type': u'AWS::SNS::Topic'}}}
Confirming changes to the stack template? This will rewrite the context and the CloudFormation template
```