### PR TITLE
ELPP-3301 Check that all instances are in service before disconnecting some from ELB

### DIFF
--- a/src/integration_tests/test_provisioning.py
+++ b/src/integration_tests/test_provisioning.py
@@ -81,5 +81,10 @@ class TestDeployment(base.BaseCase):
             cfngen.generate_stack(project, stackname=stackname)
             bootstrap.create_stack(stackname)
 
+            # try to wait for both of them to be InService,
+            # health check is based on TCP:22
+            output = cfn.cmd(stackname, 'ls -l /', username=BOOTSTRAP_USER, concurrency='parallel')
+            print output
+
             output = cfn.cmd(stackname, 'ls -l /', username=BOOTSTRAP_USER, concurrency='blue-green')
             print output

--- a/src/integration_tests/test_provisioning.py
+++ b/src/integration_tests/test_provisioning.py
@@ -61,28 +61,3 @@ class TestProvisioning(base.BaseCase):
 
             cfn.download_file(stackname, "/bin/pwd", "subfolder/pwd", use_bootstrap_user="true")
             self.assertTrue(os.path.isfile("./subfolder/pwd"))
-
-class TestDeployment(base.BaseCase):
-    def setUp(self):
-        self.stacknames = []
-        self.environment = self.generate_environment_name()
-
-    def tearDown(self):
-        for stackname in self.stacknames:
-            cfn.ensure_destroyed(stackname)
-
-    def test_blue_green_operations(self):
-        with settings(abort_on_prompts=True):
-            project = 'project-with-cluster-integration-tests'
-            stackname = '%s--%s' % (project, self.environment)
-
-            cfn.ensure_destroyed(stackname)
-            self.stacknames.append(stackname)
-            cfngen.generate_stack(project, stackname=stackname)
-            bootstrap.create_stack(stackname)
-
-            import time
-            time.sleep(30)
-
-            output = cfn.cmd(stackname, 'ls -l /', username=BOOTSTRAP_USER, concurrency='blue-green')
-            print output

--- a/src/integration_tests/test_provisioning.py
+++ b/src/integration_tests/test_provisioning.py
@@ -81,10 +81,8 @@ class TestDeployment(base.BaseCase):
             cfngen.generate_stack(project, stackname=stackname)
             bootstrap.create_stack(stackname)
 
-            # try to wait for both of them to be InService,
-            # health check is based on TCP:22
-            output = cfn.cmd(stackname, 'ls -l /', username=BOOTSTRAP_USER, concurrency='parallel')
-            print output
+            import time
+            time.sleep(30)
 
             output = cfn.cmd(stackname, 'ls -l /', username=BOOTSTRAP_USER, concurrency='blue-green')
             print output


### PR DESCRIPTION
In case a deploy is attempted while one of the instance is not healthy:
```
    ...
    raise SomeOutOfServiceInstances(service_status_by_id)
buildercore.bluegreen.SomeOutOfServiceInstances: {'i-0a902e0941b0f6c00': 'InService', 'i-09ec22c3eaf95a51a': 'OutOfService'}
```