### PR TITLE
Feature: masterless instances with formulas configured at init

### DIFF
--- a/src/buildercore/bootstrap.py
+++ b/src/buildercore/bootstrap.py
@@ -521,7 +521,7 @@ def update_ec2_stack(stackname, concurrency=None, formula_revisions=None, **kwar
             run_script('init-formulas.sh', formula_list, prepo, **envvars)
 
             # second pass to optionally update formulas to specific revisions
-            for repo, formula, revision in (formula_revisions or []):
+            for repo, formula, revision in formula_revisions or []:
                 run_script('update-master-formula.sh', repo, formula, revision)
 
         if is_master:

--- a/src/buildercore/bootstrap.py
+++ b/src/buildercore/bootstrap.py
@@ -164,7 +164,7 @@ def setup_ec2(stackname, context_ec2):
     stack_all_ec2_nodes(stackname, _setup_ec2_node, username=BOOTSTRAP_USER)
 
 
-def update_sqs_stack(stackname):
+def update_sqs_stack(stackname, **kwargs):
     pdata = project_data_for_stackname(stackname)
     if not pdata['aws']['sqs']:
         return
@@ -307,7 +307,7 @@ def _sqs_notification_configuration(queue_arn, notification_specification):
 
     return queue_configuration
 
-def update_s3_stack(stackname):
+def update_s3_stack(stackname, **kwargs):
     pdata = project_data_for_stackname(stackname)
     if not pdata['aws']['s3']:
         return
@@ -398,29 +398,19 @@ def write_environment_info(stackname, overwrite=False):
 #
 
 @core.requires_active_stack
-def update_stack(stackname, service_list=None, concurrency=None):
+def update_stack(stackname, service_list=None, **kwargs):
     """updates the given stack. if a list of services are provided (s3, ec2, sqs, etc)
     then only those services will be updated"""
     service_update_fns = OrderedDict([
-        ('ec2', lambda stackname: update_ec2_stack(stackname, concurrency)),
+        ('ec2', update_ec2_stack),
         ('s3', update_s3_stack),
         ('sqs', update_sqs_stack)
     ])
-
     if not service_list:
         service_list = service_update_fns.keys()
     ensure(utils.iterable(service_list), "cannot iterate over given service list %r" % service_list)
 
-    [fn(stackname) for fn in subdict(service_update_fns, service_list).values()]
-
-@core.requires_stack_file
-def create_update(stackname, part_filter=None):
-    if not core.stack_is_active(stackname):
-        LOG.info('stack %s does not exist, creating', stackname)
-        create_stack(stackname)
-    LOG.info('updating stack %s', stackname)
-    update_stack(stackname, part_filter)
-    return stackname
+    [fn(stackname, **kwargs) for fn in subdict(service_update_fns, service_list).values()]
 
 def upload_master_builder_key(key):
     private_key = "/root/.ssh/id_rsa"
@@ -471,7 +461,7 @@ def upload_master_configuration(master_stack, master_configuration):
     with stack_conn(master_stack, username=BOOTSTRAP_USER):
         operations.put(local_path=master_configuration, remote_path='/etc/salt/master', use_sudo=True)
 
-def update_ec2_stack(stackname, concurrency):
+def update_ec2_stack(stackname, concurrency=None, formula_revisions=None, **kwargs):
     """installs/updates the ec2 instance attached to the specified stackname.
 
     Once AWS has finished creating an EC2 instance for us, we need to install
@@ -530,7 +520,12 @@ def update_ec2_stack(stackname, concurrency):
             # Vagrant's equivalent is 'init-vagrant-formulas.sh'
             run_script('init-formulas.sh', formula_list, prepo, **envvars)
 
+            # second pass to optionally update formulas to specific revisions
+            for repo, formula, revision in (formula_revisions or []):
+                run_script('update-master-formula.sh', repo, formula, revision)
+
         if is_master:
+            # it is possible to be a masterless master server
             builder_private_repo = pdata['private-repo']
             all_formulas = project.known_formulas()
             run_script('init-master.sh', stackname, builder_private_repo, ' '.join(all_formulas))

--- a/src/buildercore/bootstrap.py
+++ b/src/buildercore/bootstrap.py
@@ -510,7 +510,6 @@ def update_ec2_stack(stackname, concurrency=None, formula_revisions=None, **kwar
         if is_masterless:
             # order is important.
             formula_list = ' '.join(pdata.get('formula-dependencies', []) + [pdata['formula-repo']])
-            prepo = pdata['private-repo']
             # to init the builder-private formula, the masterless instance needs
             # the master-builder key
             upload_master_builder_key(master_builder_key)
@@ -518,7 +517,7 @@ def update_ec2_stack(stackname, concurrency=None, formula_revisions=None, **kwar
                 'BUILDER_TOPFILE': os.environ.get('BUILDER_TOPFILE', '')
             }
             # Vagrant's equivalent is 'init-vagrant-formulas.sh'
-            run_script('init-formulas.sh', formula_list, prepo, **envvars)
+            run_script('init-formulas.sh', formula_list, pdata['private-repo'], **envvars)
 
             # second pass to optionally update formulas to specific revisions
             for repo, formula, revision in formula_revisions or []:

--- a/src/decorators.py
+++ b/src/decorators.py
@@ -61,8 +61,6 @@ def requires_filtered_project(filterfn=None):
 
 
 # pylint: disable=invalid-name
-requires_branch_deployable_project = requires_filtered_project(lambda pname, project: project.get('repo'))
-# pylint: disable=invalid-name
 requires_project = requires_filtered_project(None)
 
 def requires_aws_project_stack(*plist):

--- a/src/deploy.py
+++ b/src/deploy.py
@@ -1,47 +1,14 @@
 """module concerns itself with tasks involving branch deployments of projects."""
 
 from fabric.api import task
-from decorators import requires_branch_deployable_project, echo_output, setdefault, requires_aws_stack, timeit
-import utils
-from buildercore import core, bootstrap, cfngen, project
+from decorators import requires_aws_stack
+from buildercore import bootstrap
 from buildercore.concurrency import concurrency_for
-import cfn
 import buildvars
 
 import logging
 
 LOG = logging.getLogger(__name__)
-
-def impose_ordering(branch_list):
-    branch_list, removed = utils.rmval(branch_list, 'master', 'develop')
-    branch_list.sort()
-    branch_list = removed + branch_list
-    return branch_list
-
-#
-#
-#
-
-@task
-@requires_branch_deployable_project
-@echo_output
-@timeit
-def deploy(pname, instance_id=None, alt_config=None):
-    pdata = project.project_data(pname)
-    stackname = cfn.generate_stack_from_input(pname, instance_id, alt_config=alt_config)
-
-    region = pdata['aws']['region']
-    active_stacks = core.active_stack_names(region)
-    if stackname in active_stacks:
-        LOG.info("stack %r exists, skipping creation", stackname)
-    else:
-        LOG.info("stack %r doesn't exist, creating", stackname)
-        more_context = cfngen.choose_config(stackname)
-        cfngen.generate_stack(pname, **more_context)
-
-    bootstrap.create_update(stackname)
-    setdefault('.active-stack', stackname)
-
 
 @task
 @requires_aws_stack

--- a/src/fabfile.py
+++ b/src/fabfile.py
@@ -20,6 +20,6 @@ import master
 import askmaster
 import buildvars
 import project
-from deploy import deploy, switch_revision_update_instance
+from deploy import switch_revision_update_instance
 from lifecycle import start, stop, stop_if_running_for, update_dns
 import masterless

--- a/src/masterless.py
+++ b/src/masterless.py
@@ -66,7 +66,7 @@ def parse_validate_repolist(pdata, *repolist):
         if not os.path.exists(path):
             LOG.warn("couldn't find formula %r locally, revision check skipped", path)
             continue
-        
+
         with lcd(path), settings(warn_only=True):
             ensure(local("git fetch --quiet").succeeded, "failed to fetch remote refs for %s" % path)
             ensure(local("git cat-file -e %s^{commit}" % revision).succeeded, "failed to find ref %r in %s" % (revision, name))

--- a/src/masterless.py
+++ b/src/masterless.py
@@ -3,7 +3,7 @@ from os.path import join
 from collections import OrderedDict
 from fabric.api import task, lcd, settings
 from fabric.operations import local
-from decorators import requires_project, requires_aws_stack
+from decorators import requires_project
 from buildercore import bootstrap, core, context_handler, project, config
 from buildercore.utils import ensure
 import logging
@@ -89,15 +89,6 @@ def launch(pname, instance_id=None, alt_config='standalone', *repolist):
 
     import cfn
     cfn.launch(pname, instance_id, alt_config, formula_revisions=repolist)
-
-
-@task
-@requires_aws_stack
-@requires_master_server_access
-@requires_masterless
-def update(stackname):
-    import cfn
-    return cfn.update(stackname)
 
 #
 #

--- a/src/masterless.py
+++ b/src/masterless.py
@@ -61,10 +61,10 @@ def parse_validate_repolist(pdata, *repolist):
         arglist.append((repo, known_formula_map[repo], rev))
 
     # test given revisions actually exist in formulas
-    for name, url, revision in arglist:
+    for name, _, revision in arglist:
         path = join(config.PROJECT_PATH, "cloned-projects", name)
         if not os.path.exists(path):
-            LOG.warn("couldn't find formula %r locally, revision check skipped" % path)
+            LOG.warn("couldn't find formula %r locally, revision check skipped", path)
             continue
         
         with lcd(path), settings(warn_only=True):

--- a/src/masterless.py
+++ b/src/masterless.py
@@ -2,7 +2,7 @@ import os
 from collections import OrderedDict
 from fabric.api import task
 from decorators import requires_project, requires_aws_stack
-from buildercore import bootstrap, core, context_handler
+from buildercore import bootstrap, core, context_handler, project
 from buildercore.utils import ensure
 import logging
 from functools import wraps
@@ -24,12 +24,57 @@ def requires_masterless(fn):
         return fn(stackname, *args, **kwargs)
     return wrapper
 
+
+#
+#
+#
+
+def parse_validate_repolist(pdata, *repolist):
+    "returns a list of triples"
+    known_formulas = pdata.get('formula-dependencies', [])
+    known_formulas.extend([
+        pdata['formula-repo'],
+        pdata['private-repo']
+    ])
+
+    known_formula_map = OrderedDict(zip(map(os.path.basename, known_formulas), known_formulas))
+
+    arglist = []
+    for user_string in repolist:
+        if '@' not in user_string:
+            print 'skipping %r, no revision component' % user_string
+            continue
+
+        repo, rev = user_string.split('@')
+
+        if not rev.strip():
+            print 'skipping %r, empty revision component' % user_string
+            continue
+
+        if repo not in known_formula_map:
+            print 'skipping %r, unknown formula. known formulas: %s' % (repo, ', '.join(known_formula_map.keys()))
+            continue
+
+        arglist.append((repo, known_formula_map[repo], rev))
+    return arglist
+
+#
+#
+
 @task
 @requires_project
 @requires_master_server_access
-def launch(pname, instance_id=None):
+def launch(pname, instance_id=None, alt_config='standalone', *repolist):
+    pdata = project.project_data(pname)
+    # ensure given alt config has masterless=True
+    ensure(pdata['aws-alt'], "project has no alternate configurations")
+    ensure(alt_config in pdata['aws-alt'], "unknown alt-config %r" % alt_config)
+    ensure(pdata['aws-alt'][alt_config]['ec2']['masterless'], "alternative configuration %r has masterless=False" % alt_config)
+    repolist = parse_validate_repolist(pdata, *repolist)
+
     import cfn
-    cfn.launch(pname, instance_id, 'standalone')
+    cfn.launch(pname, instance_id, alt_config, formula_revisions=repolist)
+
 
 @task
 @requires_aws_stack
@@ -49,42 +94,13 @@ def update(stackname):
 def set_versions(stackname, *repolist):
     "call with formula name and a revision, like: builder-private@ab87af78asdf2321431f31"
     ctx = context_handler.load_context(stackname)
-
-    pdata = ctx['project']
-    known_formulas = pdata.get('formula-dependencies', [])
-    known_formulas.extend([
-        pdata['formula-repo'],
-        pdata['private-repo']
-    ])
-
-    known_formula_map = OrderedDict(zip(map(os.path.basename, known_formulas), known_formulas))
+    repolist = parse_validate_repolist(ctx['project'], *repolist)
 
     if not repolist:
         return 'nothing to do'
 
-    arglist = []
-    for user_string in repolist:
-        if '@' not in user_string:
-            print 'skipping %r, no revision component' % user_string
-            continue
-
-        repo, rev = user_string.split('@')
-
-        if not rev.strip():
-            print 'skipping %r, empty revision component' % user_string
-            continue
-
-        if repo not in known_formula_map:
-            print 'skipping %r, unknown formula. known formulas: %s' % (repo, ', '.join(known_formula_map.keys()))
-            continue
-
-        arglist.append((repo, known_formula_map[repo], rev))
-
-    if not arglist:
-        return 'nothing to do'
-
     def updater():
-        for repo, formula, revision in arglist:
+        for repo, formula, revision in repolist:
             bootstrap.run_script('update-master-formula.sh', repo, formula, revision)
 
     core.stack_all_ec2_nodes(stackname, updater, concurrency='serial')


### PR DESCRIPTION
launch command looks like:

`./bldr masterless.launch:project,instanceid,alt-config,formula1-name@<rev-or-branch>,formula2-name@<rev-or-branch>`

for example, this works:

`./bldr masterless.launch:lax,bronin3,standalone,lax-formula@9e21f1b4e3e03fdd75984a665a3c4e2c29240d00,builder-base-formula@85ed66ae0be268aed24631691a0ad56d23fded40`