### PR TITLE
crm project description now defaults to being rds-less

### DIFF
--- a/projects/elife.yaml
+++ b/projects/elife.yaml
@@ -1556,14 +1556,6 @@ crm:
             80: 80
             443: 443
 
-        # database is now too large for the instance and requires rds
-        rds:
-            engine: MySQL
-            version: '5.5'
-            storage: 30 # GB
-            type: db.t2.medium
-            params:
-                log_bin_trust_function_creators: 1
     aws-alt:
         standalone:
             # for now a copy of standalone1404
@@ -1575,6 +1567,31 @@ crm:
         ci:
             rds:
                 backup-retention: 2 # days
+                engine: MySQL
+                version: '5.5'
+                storage: 30 # GB
+                type: db.t2.medium
+                params:
+                    log_bin_trust_function_creators: 1
+
+        end2end:
+            rds:
+                engine: MySQL
+                version: '5.5'
+                storage: 30 # GB
+                type: db.t2.medium
+                params:
+                    log_bin_trust_function_creators: 1
+
+        prod:
+            rds:
+                engine: MySQL
+                version: '5.5'
+                storage: 30 # GB
+                type: db.t2.medium
+                params:
+                    log_bin_trust_function_creators: 1
+
     vagrant:
         box: ubuntu/trusty64 # Ubuntu 14.04, deprecated
         ram: 2048


### PR DESCRIPTION
this formula can now restore a tiny version of the database to use