### PR TITLE
[wip] adds rds deletion policy.

### DIFF
--- a/projects/elife.yaml
+++ b/projects/elife.yaml
@@ -79,6 +79,7 @@ defaults:
                 # it tells us which subnets we can provision RDS within
                 - subnet-8eea67d7 # elife-dbsubnet-1
                 - subnet-dbc471f0 # elife-dbsubnet-2
+            deletion-policy: Snapshot
 
         # TODO: this will be moved inside aws.ec2
         ext:
@@ -274,6 +275,7 @@ lax:
         standalone1404:
             rds:
                 storage: 5
+                deletion-policy: Delete
         end2end:
             description: production-like
             ec2:
@@ -1234,6 +1236,7 @@ observer:
             rds:
                 storage: 10
                 backup-retention: 2 # days
+                deletion-policy: Delete
         end2end:
             description: production-like environment. RDS backed
             rds:
@@ -1572,9 +1575,12 @@ crm:
             ec2:
                 ami: ami-92002785 # Ubuntu 14.04, deprecated
                 masterless: true
+            rds:
+                deletion-policy: Delete
         ci:
             rds:
                 backup-retention: 2 # days
+                deletion-policy: Delete
     vagrant:
         box: ubuntu/trusty64 # Ubuntu 14.04, deprecated
         ram: 2048

--- a/src/buildercore/bluegreen.py
+++ b/src/buildercore/bluegreen.py
@@ -41,7 +41,7 @@ class BlueGreenConcurrency(object):
         ensure(len(names) >= 1, "No load balancers found")
         tags = self.conn.describe_tags(LoadBalancerNames=names)['TagDescriptions']
         balancers = [lb['LoadBalancerName'] for lb in tags if {'Key': 'Cluster', 'Value': stackname} in lb['Tags']]
-        ensure(len(balancers) == 1, "Expected to find exactly 1 load balancer, but found %s", balancers)
+        ensure(len(balancers) == 1, "Expected to find exactly 1 load balancer, but found %s" % balancers)
         return balancers[0]
 
     def divide_by_color(self, nodes_params):

--- a/src/buildercore/bootstrap.py
+++ b/src/buildercore/bootstrap.py
@@ -137,7 +137,8 @@ def _wait_until_in_progress(stackname):
     )
     final_stack = core.describe_stack(stackname)
     events = [(e.resource_status, e.resource_status_reason) for e in final_stack.describe_events()]
-    ensure(final_stack.stack_status in ['CREATE_COMPLETE'], "Failed to create stack: %s.\nEvents: %s", final_stack.stack_status, pformat(events))
+    ensure(final_stack.stack_status in ['CREATE_COMPLETE'],
+           "Failed to create stack: %s.\nEvents: %s" % (final_stack.stack_status, pformat(events)))
 
 def setup_ec2(stackname, context_ec2):
     if not context_ec2:

--- a/src/buildercore/cfngen.py
+++ b/src/buildercore/cfngen.py
@@ -35,21 +35,11 @@ LOG = logging.getLogger(__name__)
 def build_context(pname, **more_context): # pylint: disable=too-many-locals
     """wrangles parameters into a dictionary (context) that can be given to
     whatever renders the final template"""
-    existing_context = more_context.get('existing_context', {})
-    if 'existing_context' in more_context:
-        del more_context['existing_context']
-
-    def from_existing_context(field, default_value):
-        password = existing_context.get(field)
-        if password:
-            return password
-        return default_value
 
     supported_projects = project.project_list()
-    assert pname in supported_projects, "Unknown project %r" % pname
+    ensure(pname in supported_projects, "Unknown project %r" % pname)
 
     project_data = project.project_data(pname)
-
     if 'alt-config' in more_context:
         project_data = project.set_project_alt(project_data, 'aws', more_context['alt-config'])
 
@@ -58,7 +48,7 @@ def build_context(pname, **more_context): # pylint: disable=too-many-locals
         'project': project_data,
 
         'author': os.environ.get("LOGNAME") or os.getlogin(),
-        'date_rendered': utils.ymd(),
+        'date_rendered': utils.ymd(), # TODO: if this value is used at all, more precision might be nice
 
         # a stackname looks like: <pname>--<instance_id>[--<cluster-id>]
         'stackname': None, # must be provided by whatever is calling this
@@ -67,10 +57,13 @@ def build_context(pname, **more_context): # pylint: disable=too-many-locals
 
         'branch': project_data.get('default-branch'),
         'revision': None, # may be used in future to checkout a specific revision of project
+
+        # TODO: shift these rds_ values under an 'rds' key
         'rds_dbname': None, # generated from the instance_id when present
         'rds_username': None, # could possibly live in the project data, but really no need.
         'rds_password': None,
         'rds_instance_id': None,
+
         'ec2': False,
         's3': {},
         'elb': False,
@@ -81,52 +74,36 @@ def build_context(pname, **more_context): # pylint: disable=too-many-locals
         'elasticache': False,
     }
 
+    # this is the context data from the currently existing template (if any)
+    # by re-using current values we can avoid making unnecessary changes when
+    # regenerating templates (like random passwords)
+    existing_context = more_context.pop('existing_context', {})
+
     context = copy.deepcopy(defaults)
     context.update(more_context)
 
-    assert context['stackname'] is not None, "a stackname wasn't provided."
+    # proceed with wrangling
+
+    ensure(context['stackname'], "a stackname wasn't provided.")
     stackname = context['stackname']
 
     # stackname data
-    bit_keys = ['project_name', 'instance_id', 'cluster_id']
-    bits = dict(zip(bit_keys, core.parse_stackname(stackname, all_bits=True)))
-    assert bits['project_name'] == pname, \
-        "the project name derived from the `stackname` doesn't match the given project name"
+    bits = core.parse_stackname(stackname, all_bits=True, idx=True)
+    ensure(bits['project_name'] == pname,
+           "the project name %r derived from the given `stackname` %r doesn't match" % (bits['project_name'], pname))
     context.update(bits)
+
+    # is this a production instance? if yes, then we'll do things like tweak the dns records ...
+    context['is_prod_instance'] = core.is_prod_stack(stackname)
 
     # hostname data
     context.update(core.hostname_struct(stackname))
 
-    # post-processing
-    if 'rds' in context['project']['aws']:
-        default_rds_dbname = slugify(stackname, separator="")
-
-        # used to give mysql a range of valid ip addresses to connect from
-        subnet_cidr = netaddr.IPNetwork(context['project']['aws']['subnet-cidr'])
-        net = subnet_cidr.network
-        mask = subnet_cidr.netmask
-        networkmask = "%s/%s" % (net, mask) # ll: 10.0.2.0/255.255.255.0
-
-        generated_password = utils.random_alphanumeric(length=32)
-        rds_password = from_existing_context('rds_password', generated_password)
-        context.update({
-            'netmask': networkmask,
-            'rds_username': 'root',
-            'rds_password': rds_password,
-            # alpha-numeric only
-            # TODO: investigate possibility of ambiguous RDS naming here
-            'rds_dbname': context.get('rds_dbname') or default_rds_dbname, # *must* use 'or' here
-            'rds_instance_id': slugify(stackname), # *completely* different to database name
-            'rds_params': context['project']['aws']['rds'].get('params', [])
-        })
+    # rds
+    context.update(build_context_rds(context, existing_context))
 
     if 'ext' in context['project']['aws']:
         context['ext'] = context['project']['aws']['ext']
-
-    # is this a production instance? if yes, then we'll do things like tweak the dns records ...
-    context.update({
-        'is_prod_instance': core.is_prod_stack(stackname),
-    })
 
     context['ec2'] = context['project']['aws'].get('ec2', True)
     if isinstance(context['ec2'], dict):
@@ -144,10 +121,7 @@ def build_context(pname, **more_context): # pylint: disable=too-many-locals
     for queue_template_name in context['project']['aws']['sqs']:
         queue_name = _parameterize(queue_template_name)
         queue_configuration = context['project']['aws']['sqs'][queue_template_name]
-        subscriptions = []
-        if 'subscriptions' in queue_configuration:
-            for topic_template_name in queue_configuration['subscriptions']:
-                subscriptions.append(_parameterize(topic_template_name))
+        subscriptions = map(_parameterize, queue_configuration.get('subscriptions', []))
         context['sqs'][queue_name] = subscriptions
 
     # future: build what is necessary for buildercore.bootstrap.setup_s3()
@@ -169,6 +143,43 @@ def build_context(pname, **more_context): # pylint: disable=too-many-locals
     build_context_elasticache(context)
 
     return context
+
+
+def build_context_rds(context, existing_context):
+    if 'rds' not in context['project']['aws']:
+        return {}
+    stackname = context['stackname']
+
+    # deletion policy
+    # enforce here rather than allow to be specified in project config
+    deletion_policy = 'Delete'
+    if context['is_prod_instance'] or context['instance_id'] in ['continuumtest', 'end2end']:
+        deletion_policy = 'Snapshot'
+
+    # used to give mysql a range of valid ip addresses to connect from
+    subnet_cidr = netaddr.IPNetwork(context['project']['aws']['subnet-cidr'])
+    net = subnet_cidr.network
+    mask = subnet_cidr.netmask
+    networkmask = "%s/%s" % (net, mask) # ll: 10.0.2.0/255.255.255.0
+
+    # pull password from existing context, if it exists
+    generated_password = utils.random_alphanumeric(length=32)
+    rds_password = existing_context.get('rds_password', generated_password)
+
+    return {
+        'netmask': networkmask,
+        'rds_username': 'root',
+        'rds_password': rds_password,
+        # alpha-numeric only
+        # TODO: investigate possibility of ambiguous RDS naming here
+        'rds_dbname': context.get('rds_dbname') or slugify(stackname, separator=""), # *must* use 'or' here
+        'rds_instance_id': slugify(stackname), # *completely* different to database name
+        'rds_params': context['project']['aws']['rds'].get('params', []),
+
+        'rds': {
+            'deletion-policy': deletion_policy
+        }
+    }
 
 
 def build_context_elb(context):
@@ -251,26 +262,30 @@ def choose_config(stackname):
 
 def render_template(context, template_type='aws'):
     pname = context['project_name']
-    if template_type not in context['project']:
-        raise ValueError("could not render an %r template for %r: no %r context found" %
-                         (template_type, pname, template_type))
+    msg = "could not render an %r template for %r: no %r context found" % (template_type, pname, template_type)
+    ensure(template_type in context['project'], msg, ValueError)
     if template_type == 'aws':
         return trop.render(context)
+    # are we saving this space for different template types in future?
 
 def write_template(stackname, contents):
+    "writes a json version of the python cloudformation template to the stacks directory"
     output_fname = os.path.join(STACK_DIR, stackname + ".json")
     open(output_fname, 'w').write(contents)
     return output_fname
 
 def read_template(stackname):
+    "returns the contents of a cloudformation template as a python data structure"
     output_fname = os.path.join(STACK_DIR, stackname + ".json")
     return json.load(open(output_fname, 'r'))
 
 def validate_aws_template(pname, rendered_template):
+    "remote cloudformation template checks."
     conn = core.connect_aws_with_pname(pname, 'cfn')
     return conn.validate_template(rendered_template)
 
 def more_validation(json_template_str):
+    "local cloudformation template checks. complements the validation AWS does"
     try:
         data = json.loads(json_template_str)
         # case: when "DBInstanceIdentifier" == "lax--temp2"
@@ -278,7 +293,7 @@ def more_validation(json_template_str):
         # must contain only ASCII letters, digits, and hyphens; and must not end with a hyphen or contain two consecutive hyphens.
         dbid = utils.lookup(data, 'Resources.AttachedDB.Properties.DBInstanceIdentifier', False)
         if dbid:
-            assert '--' not in dbid, "database instance identifier contains a double hyphen: %r" % dbid
+            ensure('--' not in dbid, "database instance identifier contains a double hyphen: %r" % dbid)
 
         return True
     except BaseException:
@@ -286,6 +301,8 @@ def more_validation(json_template_str):
         raise
 
 def validate_project(pname, **extra):
+    """validates all of project's possible cloudformation templates.
+    only called during testing"""
     import time, boto
     LOG.info('validating %s', pname)
     template = quick_render(pname)
@@ -312,19 +329,16 @@ def validate_project(pname, **extra):
     return True
 
 #
-#
+# create new template
 #
 
 def quick_render(project_name, **more_context):
-    "generates a representative Cloudformation template for given project with dummy values"
+    """generates a representative Cloudformation template for given project with dummy values
+    only called during testing"""
     # set a dummy instance id if one hasn't been set.
     more_context['stackname'] = more_context.get('stackname', core.mk_stackname(project_name, 'dummy'))
     context = build_context(project_name, **more_context)
     return render_template(context)
-
-#
-#
-#
 
 def generate_stack(pname, **more_context):
     """given a project name and any context overrides, generates a Cloudformation
@@ -336,13 +350,9 @@ def generate_stack(pname, **more_context):
     context_handler.write_context(stackname, context)
     return context, out_fname
 
-def regenerate_stack(pname, **more_context):
-    current_template = bootstrap.current_template(more_context['stackname'])
-    current_context = context_handler.load_context(more_context['stackname'])
-    write_template(more_context['stackname'], json.dumps(current_template))
-    context = build_context(pname, existing_context=current_context, **more_context)
-    delta = template_delta(pname, context)
-    return context, delta, current_context
+#
+# update existing template
+#
 
 
 # can't add ExtDNS: it changes dynamically when we start/stop instances and should not be touched after creation
@@ -457,16 +467,24 @@ def merge_delta(stackname, delta):
 
 def apply_delta(template, delta):
     for component in delta.plus:
-        ensure(component in ["Resources", "Outputs"], "Template component %s not recognized", component)
+        ensure(component in ["Resources", "Outputs"], "Template component %s not recognized" % component)
         data = template.get(component, {})
         data.update(delta.plus[component])
         template[component] = data
     for component in delta.edit:
-        ensure(component in ["Resources", "Outputs"], "Template component %s not recognized", component)
+        ensure(component in ["Resources", "Outputs"], "Template component %s not recognized" % component)
         data = template.get(component, {})
         data.update(delta.edit[component])
         template[component] = data
     for component in delta.minus:
-        ensure(component in ["Resources", "Outputs"], "Template component %s not recognized", component)
+        ensure(component in ["Resources", "Outputs"], "Template component %s not recognized" % component)
         for title in delta.minus[component]:
             del template[component][title]
+
+def regenerate_stack(pname, **more_context):
+    current_template = bootstrap.current_template(more_context['stackname'])
+    current_context = context_handler.load_context(more_context['stackname'])
+    write_template(more_context['stackname'], json.dumps(current_template))
+    context = build_context(pname, existing_context=current_context, **more_context)
+    delta = template_delta(pname, context)
+    return context, delta, current_context

--- a/src/buildercore/cfngen.py
+++ b/src/buildercore/cfngen.py
@@ -93,9 +93,6 @@ def build_context(pname, **more_context): # pylint: disable=too-many-locals
            "the project name %r derived from the given `stackname` %r doesn't match" % (bits['project_name'], pname))
     context.update(bits)
 
-    # is this a production instance? if yes, then we'll do things like tweak the dns records ...
-    context['is_prod_instance'] = core.is_prod_stack(stackname)
-
     # hostname data
     context.update(core.hostname_struct(stackname))
 
@@ -151,10 +148,7 @@ def build_context_rds(context, existing_context):
     stackname = context['stackname']
 
     # deletion policy
-    # enforce here rather than allow to be specified in project config
-    deletion_policy = 'Delete'
-    if context['is_prod_instance'] or context['instance_id'] in ['continuumtest', 'end2end']:
-        deletion_policy = 'Snapshot'
+    deletion_policy = utils.lookup(context, 'project.aws.rds.deletion-policy', 'Snapshot')
 
     # used to give mysql a range of valid ip addresses to connect from
     subnet_cidr = netaddr.IPNetwork(context['project']['aws']['subnet-cidr'])

--- a/src/buildercore/cfngen.py
+++ b/src/buildercore/cfngen.py
@@ -58,11 +58,12 @@ def build_context(pname, **more_context): # pylint: disable=too-many-locals
         'branch': project_data.get('default-branch'),
         'revision': None, # may be used in future to checkout a specific revision of project
 
-        # TODO: shift these rds_ values under an 'rds' key
+        # TODO: shift these rds_ values under the 'rds' key
         'rds_dbname': None, # generated from the instance_id when present
         'rds_username': None, # could possibly live in the project data, but really no need.
         'rds_password': None,
         'rds_instance_id': None,
+        'rds': {},
 
         'ec2': False,
         's3': {},

--- a/src/buildercore/core.py
+++ b/src/buildercore/core.py
@@ -368,9 +368,6 @@ def project_name_from_stackname(stackname):
 def is_master_server_stack(stackname):
     return 'master-server--' in str(stackname)
 
-def is_prod_stack(stackname):
-    return parse_stackname(stackname, idx=True)['instance_id'] in ['master', 'prod']
-
 #
 # stack file wrangling
 # stack 'files' are the things on the file system in the `.cfn/stacks/` dir.

--- a/src/buildercore/lifecycle.py
+++ b/src/buildercore/lifecycle.py
@@ -163,7 +163,7 @@ def _wait_all_in_state(stackname, state, node_ids, source_of_states, node_descri
 def _ensure_valid_ec2_states(states, valid_states):
     ensure(
         set(states.values()).issubset(valid_states),
-        "The states of EC2 nodes are not supported, manual recovery is needed: %s", states
+        "The states of EC2 nodes are not supported, manual recovery is needed: %s" % states
     )
 
 def _wait_daemons():

--- a/src/buildercore/trop.py
+++ b/src/buildercore/trop.py
@@ -234,7 +234,7 @@ def render_rds(context, template):
     # rds parameter group. None or a Ref
     param_group_ref = rdsdbparams(context, template)
 
-    tags = [t for t in instance_tags(context)]
+    tags = instance_tags(context)
     # db instance
     data = {
         'DBName': lu('rds_dbname'), # dbname generated from instance id.
@@ -252,7 +252,7 @@ def render_rds(context, template):
         'MasterUsername': lu('rds_username'), # pillar data is now UNavailable
         'MasterUserPassword': lu('rds_password'),
         'BackupRetentionPeriod': lu('project.aws.rds.backup-retention'),
-        'DeletionPolicy': 'Snapshot',
+        'DeletionPolicy': lu('rds.deletion-policy'),
         "Tags": tags,
         "AllowMajorVersionUpgrade": False, # default? not specified.
         "AutoMinorVersionUpgrade": True, # default

--- a/src/buildercore/utils.py
+++ b/src/buildercore/utils.py
@@ -266,7 +266,7 @@ def mkdir_p(path):
     ensure(os.access(path, os.W_OK | os.X_OK), "directory isn't writable: %s" % path)
     return path
 
-def json_dumps(obj, dangerous=False):
+def json_dumps(obj, dangerous=False, **kwargs):
     """drop-in for json.dumps that handles datetime objects.
 
     dangerous=True will replace unserializable values with the string '[unserializable]'.
@@ -278,7 +278,7 @@ def json_dumps(obj, dangerous=False):
             return '[unserializable]'
         else:
             raise TypeError('Object of type %s with value of %s is not JSON serializable' % (type(obj), repr(obj)))
-    return json.dumps(obj, default=json_handler)
+    return json.dumps(obj, default=json_handler, **kwargs)
 
 def lookup(data, path, default=0xDEADBEEF):
     if not isinstance(data, dict):

--- a/src/buildercore/utils.py
+++ b/src/buildercore/utils.py
@@ -254,20 +254,11 @@ def ymd(dt=None, fmt="%Y-%m-%d"):
         dt = datetime.now() # TODO: replace this with a utcnow()
     return dt.strftime(fmt)
 
-def ensure(assertion, msg, *args, **kwargs):
+def ensure(assertion, msg, exception_class=AssertionError):
     """intended as a convenient replacement for `assert` statements that
     get compiled away with -O flags"""
-
-    exception_class = AssertionError
-    if 'exception_class' in kwargs:
-        exception_class = kwargs['exception_class']
-        del kwargs['exception_class']
-
-    if len(kwargs):
-        raise ValueError("No other keyword arguments than exception_class are accepted: %s", kwargs)
-
     if not assertion:
-        raise exception_class(msg % args)
+        raise exception_class(msg)
 
 def mkdir_p(path):
     os.system("mkdir -p %s" % path)

--- a/src/buildvars.py
+++ b/src/buildvars.py
@@ -52,14 +52,10 @@ def _retrieve_build_vars():
         LOG.debug('build vars: %s', buildvars)
 
         # buildvars exist
-        ensure(
-            isinstance(buildvars, dict),
-            'build vars not found (%s). use `./bldr buildvars.fix` to attempt to fix this.',
-            buildvars
-        )
+        ensure(isinstance(buildvars, dict), 'build vars not found (%s). use `./bldr buildvars.fix` to attempt to fix this.' % buildvars)
 
         # nothing important is missing
-        missing_keys = core_utils.missingkeys(buildvars, ['stackname', 'instance_id', 'branch', 'revision', 'is_prod_instance'])
+        missing_keys = core_utils.missingkeys(buildvars, ['stackname', 'instance_id', 'branch', 'revision'])
         ensure(
             len(missing_keys) == 0,
             'build vars are not valid: missing keys %s. use `./bldr buildvars.fix` to attempt to fix this.' % missing_keys

--- a/src/cfn.py
+++ b/src/cfn.py
@@ -102,9 +102,7 @@ def update_master():
 @requires_project
 def generate_stack_from_input(pname, instance_id=None, alt_config=None):
     """creates a new CloudFormation file for the given project."""
-    if not instance_id:
-        default_instance_id = core_utils.ymd()
-        instance_id = utils.uin("instance id", default_instance_id)
+    instance_id = instance_id or utils.uin("instance id", core_utils.ymd())
     stackname = core.mk_stackname(pname, instance_id)
     more_context = {'stackname': stackname}
 
@@ -120,6 +118,7 @@ def generate_stack_from_input(pname, instance_id=None, alt_config=None):
             except KeyError:
                 return None
         if instance_id in pdata['aws-alt'].keys():
+            LOG.info("instance-id found in known alternative configurations. using configuration %r", instance_id)
             more_context['alt-config'] = instance_id
         else:
             default = 'skip this step'

--- a/src/cfn.py
+++ b/src/cfn.py
@@ -15,7 +15,7 @@ import logging
 LOG = logging.getLogger(__name__)
 
 def strtobool(x):
-    return x if isinstance(x, bool) else bool(strtobool(x))
+    return x if isinstance(x, bool) else bool(_strtobool(x))
 
 # these aliases are deprecated
 @task(alias='aws_delete_stack')

--- a/src/fabfile.py
+++ b/src/fabfile.py
@@ -23,3 +23,4 @@ import project
 from deploy import switch_revision_update_instance
 from lifecycle import start, stop, stop_if_running_for, update_dns
 import masterless
+import fixtures

--- a/src/fixtures.py
+++ b/src/fixtures.py
@@ -27,7 +27,7 @@ def regen(output_format='json'):
     formatters = {
         'json': partial(core_utils.json_dumps, indent=4),
         'yaml': core_utils.yaml_dumps,
-        
+
         'default': lambda v: pformat(core_utils.remove_ordereddict(v))
     }
     formatter = formatters.get(output_format if output_format in formatters else 'default')

--- a/src/fixtures.py
+++ b/src/fixtures.py
@@ -1,0 +1,42 @@
+from pprint import pformat
+from functools import partial
+from os.path import join
+from decorators import debugtask
+from buildercore import project, utils as core_utils, config
+
+def _hackgibson():
+    fixtures_dir = join(config.SRC_PATH, 'tests', 'fixtures')
+    config.SETTINGS_FILE = join(fixtures_dir, 'dummy-settings.yaml')
+    project.project_map.cache_clear()
+    config.app.cache_clear()
+    return fixtures_dir
+
+@debugtask
+def lst():
+    _hackgibson()
+    for org, plist in project.org_project_map().items():
+        print org
+        for project_name in plist:
+            print '  ', project_name
+        print
+
+@debugtask
+def regen(output_format='json'):
+    "given a project name, returns the fully realized project description data."
+    fixtures_dir = _hackgibson()
+    formatters = {
+        'json': partial(core_utils.json_dumps, indent=4),
+        'yaml': core_utils.yaml_dumps,
+        
+        'default': lambda v: pformat(core_utils.remove_ordereddict(v))
+    }
+    formatter = formatters.get(output_format if output_format in formatters else 'default')
+
+    for org, plist in project.org_project_map().items():
+        print org
+        for pname in plist:
+            fix = formatter(project.project_data(pname))
+            output_path = join(fixtures_dir, "%s-project.%s" % (pname, output_format))
+            with open(output_path, 'w') as fh:
+                fh.write(fix)
+            print '- wrote', output_path

--- a/src/tests/fixtures/dummy1-project.json
+++ b/src/tests/fixtures/dummy1-project.json
@@ -13,26 +13,26 @@
     ], 
     "aws": {
         "ec2": {
-            "cluster-size": 1,
-            "dns-internal": false,
-            "overrides": {},
-            "suppressed": [],
+            "cluster-size": 1, 
+            "dns-internal": false, 
+            "suppressed": [], 
+            "overrides": {}, 
             "ami": "ami-9eaa1cf6"
-        },
+        }, 
         "type": "t2.micro", 
         "region": "us-east-1", 
-        "sns": [],
-        "sqs": [],
-        "s3": [],
         "vpc-id": "vpc-78a2071d", 
         "subnet-id": "subnet-1d4eb46a", 
         "subnet-cidr": "10.0.2.0/24", 
         "redundant-subnet-id": "subnet-7a31dd46", 
         "redundant-subnet-cidr": "10.0.2.0/24", 
+        "sns": [], 
+        "sqs": [], 
+        "s3": [], 
+        "subdomains": [], 
         "ports": [
             22
-        ],
-        "subdomains": []
+        ]
     }, 
     "vagrant": {
         "box": "ubuntu/trusty64", 

--- a/src/tests/fixtures/dummy2-project.json
+++ b/src/tests/fixtures/dummy2-project.json
@@ -13,17 +13,14 @@
     ], 
     "aws": {
         "ec2": {
-            "cluster-size": 1,
-            "dns-internal": false,
-            "overrides": {},
-            "suppressed": [],
+            "cluster-size": 1, 
+            "dns-internal": false, 
+            "suppressed": [], 
+            "overrides": {}, 
             "ami": "ami-111111"
-        },
+        }, 
         "type": "t2.small", 
         "region": "us-east-1", 
-        "sns": [],
-        "sqs": [],
-        "s3": [],
         "vpc-id": "vpc-78a2071d", 
         "subnet-id": "subnet-1d4eb46a", 
         "subnet-cidr": "10.0.2.0/24", 
@@ -43,6 +40,12 @@
                 "subnet-bar"
             ]
         }, 
+        "sns": [], 
+        "sqs": [], 
+        "s3": [], 
+        "subdomains": [
+            "official"
+        ], 
         "ports": [
             22, 
             {
@@ -51,23 +54,19 @@
                     "cidr-ip": "0.0.0.0/0"
                 }
             }
-        ],
-        "subdomains": ["official"]
+        ]
     }, 
     "aws-alt": {
         "fresh": {
             "ec2": {
-                "cluster-size": 1,
-                "dns-internal": false,
-                "overrides": {},
-                "suppressed": [],
+                "cluster-size": 1, 
+                "dns-internal": false, 
+                "suppressed": [], 
+                "overrides": {}, 
                 "ami": "ami-9eaa1cf6"
-            },
+            }, 
             "type": "t2.small", 
             "region": "us-east-1", 
-            "sns": [],
-            "sqs": [],
-            "s3": [],
             "vpc-id": "vpc-78a2071d", 
             "subnet-id": "subnet-1d4eb46a", 
             "subnet-cidr": "10.0.2.0/24", 
@@ -87,6 +86,12 @@
                     "subnet-bar"
                 ]
             }, 
+            "sns": [], 
+            "sqs": [], 
+            "s3": [], 
+            "subdomains": [
+                "official"
+            ], 
             "ports": [
                 22, 
                 {
@@ -96,22 +101,18 @@
                     }
                 }
             ], 
-            "description": "uses a plain Ubuntu basebox instead of an ami",
-            "subdomains": ["official"]
+            "description": "uses a plain Ubuntu basebox instead of an ami"
         }, 
         "alt-config1": {
             "ec2": {
-                "cluster-size": 1,
-                "dns-internal": false,
-                "overrides": {},
-                "suppressed": [],
+                "cluster-size": 1, 
+                "dns-internal": false, 
+                "suppressed": [], 
+                "overrides": {}, 
                 "ami": "ami-22222"
-            },
+            }, 
             "type": "t2.small", 
             "region": "us-east-1", 
-            "sns": [],
-            "sqs": [],
-            "s3": [],
             "vpc-id": "vpc-78a2071d", 
             "subnet-id": "subnet-1d4eb46a", 
             "subnet-cidr": "10.0.2.0/24", 
@@ -131,6 +132,12 @@
                     "subnet-bar"
                 ]
             }, 
+            "sns": [], 
+            "sqs": [], 
+            "s3": [], 
+            "subdomains": [
+                "official"
+            ], 
             "ports": [
                 22, 
                 {
@@ -139,8 +146,7 @@
                         "cidr-ip": "0.0.0.0/0"
                     }
                 }
-            ],
-            "subdomains": ["official"]
+            ]
         }
     }, 
     "vagrant": {

--- a/src/tests/fixtures/dummy3-project.json
+++ b/src/tests/fixtures/dummy3-project.json
@@ -13,65 +13,62 @@
     ], 
     "aws": {
         "ec2": {
-            "cluster-size": 1,
-            "dns-internal": false,
-            "overrides": {},
-            "suppressed": [],
+            "cluster-size": 1, 
+            "dns-internal": false, 
+            "suppressed": [], 
+            "overrides": {}, 
             "ami": "ami-111111"
-        },
+        }, 
         "type": "t2.small", 
         "region": "us-east-1", 
-        "sns": [],
-        "sqs": [],
-        "s3": [],
         "vpc-id": "vpc-78a2071d", 
         "subnet-id": "subnet-1d4eb46a", 
         "subnet-cidr": "10.0.2.0/24", 
         "redundant-subnet-id": "subnet-7a31dd46", 
         "redundant-subnet-cidr": "10.0.2.0/24", 
+        "sns": [], 
+        "sqs": [], 
+        "s3": [], 
+        "subdomains": [], 
         "ports": [
             22
-        ],
-        "subdomains": []
+        ]
     }, 
     "aws-alt": {
         "fresh": {
             "ec2": {
-                "cluster-size": 1,
-                "dns-internal": false,
-                "overrides": {},
-                "suppressed": [],
+                "cluster-size": 1, 
+                "dns-internal": false, 
+                "suppressed": [], 
+                "overrides": {}, 
                 "ami": "ami-9eaa1cf6"
-            },
+            }, 
             "type": "t2.small", 
             "region": "us-east-1", 
-            "sns": [],
-            "sqs": [],
-            "s3": [],
             "vpc-id": "vpc-78a2071d", 
             "subnet-id": "subnet-1d4eb46a", 
             "subnet-cidr": "10.0.2.0/24", 
             "redundant-subnet-id": "subnet-7a31dd46", 
             "redundant-subnet-cidr": "10.0.2.0/24", 
+            "sns": [], 
+            "sqs": [], 
+            "s3": [], 
+            "subdomains": [], 
             "ports": [
                 22
             ], 
-            "description": "uses a plain Ubuntu basebox instead of an ami",
-            "subdomains": []
+            "description": "uses a plain Ubuntu basebox instead of an ami"
         }, 
         "alt-config1": {
             "ec2": {
-                "cluster-size": 1,
-                "dns-internal": false,
-                "overrides": {},
-                "suppressed": [],
+                "cluster-size": 1, 
+                "dns-internal": false, 
+                "suppressed": [], 
+                "overrides": {}, 
                 "ami": "ami-111111"
-            },
+            }, 
             "type": "t2.small", 
             "region": "us-east-1", 
-            "sns": [],
-            "sqs": [],
-            "s3": [],
             "vpc-id": "vpc-78a2071d", 
             "subnet-id": "subnet-1d4eb46a", 
             "subnet-cidr": "10.0.2.0/24", 
@@ -95,10 +92,51 @@
                 "size": 200, 
                 "device": "/dev/sdh"
             }, 
+            "sns": [], 
+            "sqs": [], 
+            "s3": [], 
+            "subdomains": [], 
             "ports": [
                 80
-            ],
-            "subdomains": []
+            ]
+        }, 
+        "alt-config2": {
+            "ec2": {
+                "cluster-size": 1, 
+                "dns-internal": false, 
+                "suppressed": [], 
+                "overrides": {}, 
+                "ami": "ami-111111"
+            }, 
+            "type": "t2.small", 
+            "region": "us-east-1", 
+            "vpc-id": "vpc-78a2071d", 
+            "subnet-id": "subnet-1d4eb46a", 
+            "subnet-cidr": "10.0.2.0/24", 
+            "redundant-subnet-id": "subnet-7a31dd46", 
+            "redundant-subnet-cidr": "10.0.2.0/24", 
+            "rds": {
+                "name": "<defined at generation>", 
+                "multi-az": false, 
+                "engine": "postgres", 
+                "version": "9.4", 
+                "type": "db.t2.small", 
+                "storage": 5, 
+                "backup-retention": 28, 
+                "params": [], 
+                "subnets": [
+                    "subnet-foo", 
+                    "subnet-bar"
+                ], 
+                "deletion-policy": "Delete"
+            }, 
+            "sns": [], 
+            "sqs": [], 
+            "s3": [], 
+            "subdomains": [], 
+            "ports": [
+                22
+            ]
         }
     }, 
     "meta": {

--- a/src/tests/fixtures/projects/dummy-project.yaml
+++ b/src/tests/fixtures/projects/dummy-project.yaml
@@ -176,7 +176,7 @@ dummy3:
         ports:
             - 22
     aws-alt:
-        # uses an rds backend
+        # uses an rds backend, snapshot on delete
         alt-config1:
             ports:
                 - 80
@@ -184,6 +184,10 @@ dummy3:
                 storage: 15
             ext:
                 size: 200
+        # uses an rds backend, no snapshot on delete
+        alt-config2:
+            rds:
+                deletion-policy: Delete
 
 just-some-sns:
     repo: ssh://git@github.com/elifesciences/dummy3

--- a/src/tests/test_buildercore_core.py
+++ b/src/tests/test_buildercore_core.py
@@ -99,11 +99,6 @@ class SimpleCases(base.BaseCase):
         self.assertFalse(core.is_master_server_stack('master-some-project--end2end'))
         self.assertFalse(core.is_master_server_stack('lax--end2end'))
 
-    def test_is_prod_stack(self):
-        self.assertTrue(core.is_prod_stack('lax--prod'))
-        self.assertFalse(core.is_prod_stack('lax--end2end'))
-        self.assertFalse(core.is_prod_stack('lax--ci'))
-
     def test_bad_pname_from_stackname(self):
         expected_error = [
             # project names by themselves. a stackname must be projectname + instance_id

--- a/src/tests/test_buildercore_core.py
+++ b/src/tests/test_buildercore_core.py
@@ -1,3 +1,4 @@
+from functools import partial
 import json
 from os.path import join
 from . import base
@@ -66,11 +67,32 @@ class SimpleCases(base.BaseCase):
         self.assertAllPairsEqual(core.project_name_from_stackname, expected)
 
     def test_parse_stackname(self):
+        # basic
         expected = [
             ('lax--prod', ['lax', 'prod']),
+            ('lax--prod--1', ['lax', 'prod--1']), # is this really what we're expecting?
             ('journal-cms--end2end', ['journal-cms', 'end2end']),
+            ('journal-cms--end2end--2', ['journal-cms', 'end2end--2']), # again, really?
         ]
         self.assertAllPairsEqual(core.parse_stackname, expected)
+
+        # extended
+        expected = [
+            ('lax--prod', ['lax', 'prod']),
+            ('lax--prod--1', ['lax', 'prod', '1']),
+            ('journal-cms--end2end', ['journal-cms', 'end2end']),
+            ('journal-cms--end2end--2', ['journal-cms', 'end2end', '2']),
+        ]
+        self.assertAllPairsEqual(partial(core.parse_stackname, all_bits=True), expected)
+
+        # as dict
+        expected = [
+            ('lax--prod', {"project_name": 'lax', "instance_id": 'prod'}),
+            ('lax--prod--1', {"project_name": 'lax', "instance_id": 'prod', "cluster_id": '1'}),
+            ('journal-cms--end2end', {"project_name": 'journal-cms', "instance_id": 'end2end'}),
+            ('journal-cms--end2end--2', {"project_name": 'journal-cms', "instance_id": 'end2end', "cluster_id": '2'}),
+        ]
+        self.assertAllPairsEqual(partial(core.parse_stackname, all_bits=True, idx=True), expected)
 
     def test_master_server_stackname(self):
         self.assertTrue(core.is_master_server_stack('master-server--temp'))

--- a/src/tests/test_buildercore_utils.py
+++ b/src/tests/test_buildercore_utils.py
@@ -99,11 +99,8 @@ class TestBuildercoreUtils(base.BaseCase):
 
     def test_ensure(self):
         utils.ensure(True, "True should allow ensure() to continue")
-        self.assertRaises(AssertionError, lambda: utils.ensure(False, "Error message"))
-        self.assertRaises(AssertionError, lambda: utils.ensure(False, "Error message: %s", "argument"))
+        self.assertRaises(AssertionError, utils.ensure, False, "Error message")
 
         class CustomException(Exception):
             pass
-        self.assertRaises(CustomException, lambda: utils.ensure(False, "Error message", exception_class=CustomException))
-        self.assertRaises(CustomException, lambda: utils.ensure(False, "Error message: %s", "argument", exception_class=CustomException))
-        self.assertRaises(ValueError, lambda: utils.ensure(False, "Error message", random_argument=CustomException))
+        self.assertRaises(CustomException, utils.ensure, False, "Error message", CustomException)


### PR DESCRIPTION
I made the behaviour of 'buildercore.utils.ensure' sane again. The optional third parameter is now consistent with other projects also using ensure.
Tidied up 'buildercore.cfngen.build_context' a bit. It's still fat but we're getting there.

depends on:
* https://github.com/elifesciences/builder-base-formula/pull/99
