### PR TITLE
ELPP-3213 Persistent retries on connection timeouts

### DIFF
--- a/src/buildercore/core.py
+++ b/src/buildercore/core.py
@@ -257,20 +257,21 @@ def stack_all_ec2_nodes(stackname, workfn, username=config.DEPLOY_USER, concurre
     ensure(None not in public_ips.values(), "Public ips are not valid: %s", public_ips, exception_class=NoPublicIps)
 
     def single_node_work():
-        try:
-            return workfn(**work_kwargs)
-        except NetworkError as err:
-            if str(err.message).startswith('Timed out trying to connect'):
-                LOG.info("Timeout while executing task on a %s node (%s), retrying once on this node", stackname, err.message)
+        for attempt in range(0, 6):
+            try:
                 return workfn(**work_kwargs)
-            else:
-                raise err
-        except config.FabricException as err:
-            LOG.error(str(err).replace("\n", "    "))
-            # not useful to specify more, this will be printed out
-            # but we are already logging it (and printing it on stderr)
-            # which is better
-            raise SystemExit("")
+            except NetworkError as err:
+                if str(err.message).startswith('Timed out trying to connect'):
+                    LOG.info("Timeout while executing task on a %s node (%s) during attempt %s, retrying on this node", stackname, err.message, attempt)
+                    continue
+                else:
+                    raise err
+            except config.FabricException as err:
+                LOG.error(str(err).replace("\n", "    "))
+                # not useful to specify more, this will be printed out
+                # but we are already logging it (and printing it on stderr)
+                # which is better
+                raise SystemExit("")
 
     # something less stateful like a context manager?
     output['aborts'] = False


### PR DESCRIPTION
Going from 2 attempts (maximum 20 seconds) to 6 attempts (maximum 60 seconds). On bootstrapping a node, we sometimes see its connectivity go down:

```
Dec 13 15:20:16 ci--ppp-dash.elifesciences.org newrelic-infra:
time="2017-12-13T15:20:16Z" level=error msg="couldn't post deltas? <nil>" error="Unable to submit state changes for entity [i-dfa24946]: Post https://infra-api.newrelic.com/inventory/deltas: net/http: request canceled while waiting for connection (Client.Timeout exceeded while awaiting headers)"
```

even after it was previously reachable:

```
2017-12-13 15:19:35,074 - INFO - 54.236.236.248 - buildercore.utils - Waiting for /var/lib/cloud/instance/boot-finished to be detected on i-dfa24946...
2017-12-13 15:19:38,556 - INFO - 54.236.236.248 - buildercore.utils - Waiting for /var/lib/cloud/instance/boot-finished to be detected on i-dfa24946...
2017-12-13 15:19:41,625 - INFO - 54.236.236.248 - buildercore.utils - done.
```

If that happens, we observe this:

```
2017-12-13 15:19:48,380 - INFO - MainProcess - cfn - Connecting to: elife-dashboard--ci
2017-12-13 15:19:48,520 - INFO - MainProcess - buildercore.core - Executing on ec2 nodes ({u'i-dfa24946': u'54.236.236.248'}), concurrency serial
2017-12-13 15:19:58,839 - INFO - MainProcess - buildercore.core - Timeout while executing task on a elife-dashboard--ci node (Timed out trying to connect to 54.236.236.248 (tried 1 time)), retrying once on this node
2017-12-13 15:20:08,898 - ERROR - MainProcess - cfn - Timed out trying to connect to 54.236.236.248 (tried 1 time)
```
and a whole build fails. `If at first you don't succeed, Try, try, try again`.