### PR TITLE
ELPP-3335 Elasticache multiple nodes

### DIFF
--- a/projects/elife.yaml
+++ b/projects/elife.yaml
@@ -403,6 +403,9 @@ journal:
             elasticache:
                 engine: redis
                 clusters: 2
+                overrides:
+                    2:
+                        type: cache.t2.micro
             elb:
                 stickiness:
                     type: cookie
@@ -432,6 +435,8 @@ journal:
         continuumtest:
             elasticache:
                 engine: redis
+                type: cache.t2.micro
+                clusters: 2
             cloudfront:
                 subdomains:
                     - "{instance}--cdn-journal"
@@ -454,6 +459,10 @@ journal:
             elasticache:
                 engine: redis
                 type: cache.t2.medium # 3.22 GB of memory, ~$50/mo
+                clusters: 2
+                overrides:
+                    2: 
+                        type: cache.t2.micro # 0.56 GB of memory, ~$12/mo
             elb:
                 stickiness:
                     type: cookie

--- a/projects/elife.yaml
+++ b/projects/elife.yaml
@@ -402,6 +402,7 @@ journal:
                 cluster-size: 2
             elasticache:
                 engine: redis
+                clusters: 2
             elb:
                 stickiness:
                     type: cookie

--- a/projects/elife.yaml
+++ b/projects/elife.yaml
@@ -135,7 +135,7 @@ defaults:
             version: "2.8.24" # closest to builder-base-formula redis.sls
             configuration:
                 maxmemory-policy: volatile-ttl
-
+            clusters: 1
     aws-alt:
         fresh:
             description: uses a plain Ubuntu basebox instead of an ami

--- a/src/buildercore/cfngen.py
+++ b/src/buildercore/cfngen.py
@@ -351,9 +351,9 @@ def generate_stack(pname, **more_context):
 
 
 # can't add ExtDNS: it changes dynamically when we start/stop instances and should not be touched after creation
-UPDATABLE_TITLE_PATTERNS = ['^CloudFront.*', '^ElasticLoadBalancer.*', '^EC2Instance.*', '.*Bucket$', '.*BucketPolicy', '^StackSecurityGroup$', '^ELBSecurityGroup$', '^CnameDNS.+$', '^AttachedDB$', '^AttachedDBSubnet$', '^ExtraStorage.+$', '^MountPoint.+$', '^IntDNS.*$', '^ElastiCache$', '^ElastiCacheParameterGroup$', '^ElastiCacheSecurityGroup$', '^ElastiCacheSubnetGroup$']
+UPDATABLE_TITLE_PATTERNS = ['^CloudFront.*', '^ElasticLoadBalancer.*', '^EC2Instance.*', '.*Bucket$', '.*BucketPolicy', '^StackSecurityGroup$', '^ELBSecurityGroup$', '^CnameDNS.+$', '^AttachedDB$', '^AttachedDBSubnet$', '^ExtraStorage.+$', '^MountPoint.+$', '^IntDNS.*$', '^ElastiCache.*$', '^ElastiCacheParameterGroup$', '^ElastiCacheSecurityGroup$', '^ElastiCacheSubnetGroup$']
 
-REMOVABLE_TITLE_PATTERNS = ['^CnameDNS\\d+$', '^ExtDNS$', '^ExtraStorage.+$', '^MountPoint.+$', '^.+Queue$', '^EC2Instance.+$', '^IntDNS.*$', '^ElastiCache$', '^ElastiCacheParameterGroup$', '^ElastiCacheSecurityGroup$', '^ElastiCacheSubnetGroup$', '^.+Topic$']
+REMOVABLE_TITLE_PATTERNS = ['^CnameDNS\\d+$', '^ExtDNS$', '^ExtraStorage.+$', '^MountPoint.+$', '^.+Queue$', '^EC2Instance.+$', '^IntDNS.*$', '^ElastiCache.*$', '^ElastiCacheParameterGroup$', '^ElastiCacheSecurityGroup$', '^ElastiCacheSubnetGroup$', '^.+Topic$']
 EC2_NOT_UPDATABLE_PROPERTIES = ['ImageId', 'Tags', 'UserData']
 
 class Delta(namedtuple('Delta', ['plus', 'edit', 'minus'])):
@@ -403,10 +403,11 @@ def template_delta(pname, context):
         title_in_new = dict(template[section][title])
         # ignore UserData changes, it's not useful to update them and cause
         # a needless reboot
-        if title_in_old['Type'] == 'AWS::EC2::Instance':
-            for property_name in EC2_NOT_UPDATABLE_PROPERTIES:
-                title_in_old['Properties'][property_name] = None
-                title_in_new['Properties'][property_name] = None
+        if 'Type' in title_in_old:
+            if title_in_old['Type'] == 'AWS::EC2::Instance':
+                for property_name in EC2_NOT_UPDATABLE_PROPERTIES:
+                    title_in_old['Properties'][property_name] = None
+                    title_in_new['Properties'][property_name] = None
         return title_in_old != title_in_new
 
     def legacy_title(title):

--- a/src/buildercore/cfngen.py
+++ b/src/buildercore/cfngen.py
@@ -46,7 +46,7 @@ def build_context(pname, **more_context): # pylint: disable=too-many-locals
         return default_value
 
     supported_projects = project.project_list()
-    assert pname in supported_projects, "Unknown project %r" % pname
+    assert pname in supported_projects, "Unknown project %r. Known projects: %s" % (pname, supported_projects)
 
     project_data = project.project_data(pname)
 

--- a/src/buildercore/cfngen.py
+++ b/src/buildercore/cfngen.py
@@ -37,7 +37,7 @@ def build_context(pname, **more_context): # pylint: disable=too-many-locals
     whatever renders the final template"""
 
     supported_projects = project.project_list()
-    ensure(pname in supported_projects,  Known projects: %s" % (pname, supported_projects))
+    ensure(pname in supported_projects, "Unknown project %r. Known projects: %s" % (pname, supported_projects))
 
     project_data = project.project_data(pname)
     if 'alt-config' in more_context:

--- a/src/buildercore/trop.py
+++ b/src/buildercore/trop.py
@@ -785,7 +785,11 @@ def render_elasticache(context, template):
     )
     template.add_resource(parameter_group)
 
+    suppressed = context['elasticache'].get('suppressed', [])
     for cluster in range(1, context['elasticache']['clusters']+1):
+        if cluster in suppressed:
+            continue
+
         cluster_title = ELASTICACHE_TITLE % cluster
         template.add_resource(elasticache.CacheCluster(
             cluster_title,

--- a/src/buildercore/trop.py
+++ b/src/buildercore/trop.py
@@ -271,7 +271,6 @@ def render_rds(context, template):
     map(template.add_output, outputs)
 
 def render_ext_volume(context, context_ext, template, node=1):
-    #context_ext = context['ext']
     vtype = context_ext.get('type', 'standard')
     # who cares what gp2 stands for? everyone knows what 'ssd' and 'standard' mean ...
     if vtype == 'ssd':

--- a/src/buildercore/trop.py
+++ b/src/buildercore/trop.py
@@ -790,7 +790,7 @@ def render_elasticache(context, template):
         if cluster in suppressed:
             continue
 
-        cluster_context = _overridden_component(context, 'elasticache', cluster, ['type', 'version', 'az'])
+        cluster_context = overridden_component(context, 'elasticache', cluster, ['type', 'version', 'az'])
 
         cluster_title = ELASTICACHE_TITLE % cluster
         template.add_resource(elasticache.CacheCluster(
@@ -832,7 +832,7 @@ def render(context):
             overrides = context['ec2'].get('overrides', {}).get(node, {})
             overridden_context = copy.deepcopy(context)
             overridden_context['ext'].update(overrides.get('ext', {}))
-            node_context = _overridden_component(context, 'ec2', node, ['ext'])
+            node_context = overridden_component(context, 'ec2', node, ['ext'])
             render_ext_volume(overridden_context, node_context.get('ext', {}), template, node)
 
     render_sns(context, template)
@@ -899,7 +899,7 @@ def _is_domain_2nd_level(hostname):
     "returns True if hostname is a 2nd level TLD, e.g. elifesciences.org or elifesciences.net"
     return hostname.count(".") == 1
 
-def _overridden_component(context, component, index, allowed):
+def overridden_component(context, component, index, allowed):
     "two-level merging of overrides into one of context's componenets"
     overrides = context[component].get('overrides', {}).get(index, {})
     for element in overrides:
@@ -911,4 +911,3 @@ def _overridden_component(context, component, index, allowed):
         else:
             overridden_context[component][key] = value
     return overridden_context[component]
-

--- a/src/buildercore/trop.py
+++ b/src/buildercore/trop.py
@@ -905,6 +905,7 @@ def overridden_component(context, component, index, allowed):
     for element in overrides:
         ensure(element in allowed, "`%s` override is not allowed for single elasticache clusters" % element)
     overridden_context = copy.deepcopy(context)
+    overridden_context[component].pop('overrides', None)
     for key, value in overrides.items():
         if isinstance(overridden_context[component][key], dict):
             overridden_context[component][key].update(value)

--- a/src/buildercore/trop.py
+++ b/src/buildercore/trop.py
@@ -790,10 +790,17 @@ def render_elasticache(context, template):
         if cluster in suppressed:
             continue
 
+        # TODO: extract so that it's common with ec2
+        # TODO: unit test
+        overrides = context['elasticache'].get('overrides', {}).get(cluster, {})
+        overridden_context = copy.deepcopy(context)
+        # TODO: extend to all properties
+        overridden_context['elasticache'].update(overrides)
+
         cluster_title = ELASTICACHE_TITLE % cluster
         template.add_resource(elasticache.CacheCluster(
             cluster_title,
-            CacheNodeType=context['elasticache']['type'],
+            CacheNodeType=overridden_context['elasticache']['type'],
             CacheParameterGroupName=Ref(parameter_group),
             CacheSubnetGroupName=Ref(subnet_group),
             Engine='redis',

--- a/src/tests/fixtures/projects/dummy-project.yaml
+++ b/src/tests/fixtures/projects/dummy-project.yaml
@@ -428,4 +428,5 @@ project-with-multiple-elasticaches:
             - 80
         elasticache:
             engine: redis
-            clusters: 2
+            clusters: 3
+            suppressed: [3]

--- a/src/tests/fixtures/projects/dummy-project.yaml
+++ b/src/tests/fixtures/projects/dummy-project.yaml
@@ -430,3 +430,6 @@ project-with-multiple-elasticaches:
             engine: redis
             clusters: 3
             suppressed: [3]
+            overrides:
+                2: 
+                    type: cache.t2.medium

--- a/src/tests/fixtures/projects/dummy-project.yaml
+++ b/src/tests/fixtures/projects/dummy-project.yaml
@@ -102,6 +102,7 @@ defaults:
             version: "2.8.24"
             configuration:
                 maxmemory-policy: volatile-ttl
+            clusters: 1
     aws-alt:
         fresh:
             description: uses a plain Ubuntu basebox instead of an ami
@@ -416,3 +417,15 @@ project-with-elasticache-redis:
             - 80
         elasticache:
             engine: redis
+
+project-with-multiple-elasticaches:
+    domain: False
+    intdomain: False
+    subdomain: www
+    aws:
+        ec2: false
+        ports:
+            - 80
+        elasticache:
+            engine: redis
+            clusters: 2

--- a/src/tests/test_buildercore_project.py
+++ b/src/tests/test_buildercore_project.py
@@ -10,7 +10,7 @@ ALL_PROJECTS = [
     'just-some-sns', 'project-with-sqs', 'project-with-s3',
     'project-with-ext', 'project-with-cloudfront', 'project-with-cloudfront-minimal',
     'project-with-cloudfront-error-pages', 'project-with-cloudfront-origins', 'project-with-cluster', 'project-with-cluster-suppressed', 'project-with-cluster-overrides', 'project-with-stickiness', 'project-with-multiple-elb-listeners',
-    'project-with-cluster-integration-tests', 'project-with-db-params', 'project-with-rds-only', 'project-with-elasticache-redis',
+    'project-with-cluster-integration-tests', 'project-with-db-params', 'project-with-rds-only', 'project-with-elasticache-redis', 'project-with-multiple-elasticaches',
 ]
 
 class TestProject(base.BaseCase):

--- a/src/tests/test_buildercore_trop.py
+++ b/src/tests/test_buildercore_trop.py
@@ -890,6 +890,8 @@ class TestBuildercoreTrop(base.BaseCase):
         # suppressed
         self.assertNotIn('ElastiCacheHost3', data['Outputs'].keys())
         self.assertNotIn('ElastiCachePort3', data['Outputs'].keys())
+        # overridden
+        self.assertEqual('cache.t2.medium', data['Resources']['ElastiCache2']['Properties']['CacheNodeType'])
 
     def _parse_json(self, dump):
         """Parses dump into a dictionary, using strings rather than unicode strings

--- a/src/tests/test_buildercore_trop.py
+++ b/src/tests/test_buildercore_trop.py
@@ -881,10 +881,15 @@ class TestBuildercoreTrop(base.BaseCase):
         data = self._parse_json(cfn_template)
         self.assertIn('ElastiCache1', data['Resources'].keys())
         self.assertIn('ElastiCache2', data['Resources'].keys())
+        # suppressed
+        self.assertNotIn('ElastiCache3', data['Resources'].keys())
         self.assertIn('ElastiCacheHost1', data['Outputs'].keys())
         self.assertIn('ElastiCachePort1', data['Outputs'].keys())
         self.assertIn('ElastiCacheHost2', data['Outputs'].keys())
         self.assertIn('ElastiCachePort2', data['Outputs'].keys())
+        # suppressed
+        self.assertNotIn('ElastiCacheHost3', data['Outputs'].keys())
+        self.assertNotIn('ElastiCachePort3', data['Outputs'].keys())
 
     def _parse_json(self, dump):
         """Parses dump into a dictionary, using strings rather than unicode strings

--- a/src/tests/test_buildercore_trop.py
+++ b/src/tests/test_buildercore_trop.py
@@ -893,6 +893,71 @@ class TestBuildercoreTrop(base.BaseCase):
         # overridden
         self.assertEqual('cache.t2.medium', data['Resources']['ElastiCache2']['Properties']['CacheNodeType'])
 
+    def test_overrides_scalar(self):
+        context = {
+            'elasticache': {
+                'type': 'cache.t2.small',
+                'engine': 'redis',
+                'overrides': {
+                    2: {
+                        'type': 'cache.t2.medium',
+                    }
+                }
+            }
+        }
+        self.assertEqual(
+            {
+                'engine': 'redis',
+                'type': 'cache.t2.small',
+            },
+            trop.overridden_component(context, 'elasticache', 1, ['type'])
+        )
+        self.assertEqual(
+            {
+                'engine': 'redis',
+                'type': 'cache.t2.medium',
+            },
+            trop.overridden_component(context, 'elasticache', 2, ['type'])
+        )
+
+    def test_overrides_dictionary(self):
+        context = {
+            'ec2': {
+                'cluster-size': 2,
+                'ext': {
+                    'size': 30,
+                    'device': '/dev/sdh',
+                },
+                'overrides': {
+                    2: {
+                        'ext': {
+                            'size': 100,
+                        }
+                    }
+                }
+            }
+        }
+        self.assertEqual(
+            {
+                'cluster-size': 2,
+                'ext': {
+                    'device': '/dev/sdh',
+                    'size': 30,
+                }
+            },
+            trop.overridden_component(context, 'ec2', 1, ['ext'])
+        )
+        self.assertEqual(
+            {
+                'cluster-size': 2,
+                'ext': {
+                    'device': '/dev/sdh',
+                    'size': 100,
+                }
+            },
+            trop.overridden_component(context, 'ec2', 2, ['ext'])
+        )
+
     def _parse_json(self, dump):
         """Parses dump into a dictionary, using strings rather than unicode strings
 

--- a/src/tests/test_buildercore_trop.py
+++ b/src/tests/test_buildercore_trop.py
@@ -801,10 +801,10 @@ class TestBuildercoreTrop(base.BaseCase):
         context = cfngen.build_context('project-with-elasticache-redis', **extra)
         cfn_template = trop.render(context)
         data = self._parse_json(cfn_template)
-        self.assertTrue('ElastiCache' in data['Resources'].keys())
-        self.assertTrue('ElastiCacheParameterGroup' in data['Resources'].keys())
-        self.assertTrue('ElastiCacheSecurityGroup' in data['Resources'].keys())
-        self.assertTrue('ElastiCacheSubnetGroup' in data['Resources'].keys())
+        self.assertIn('ElastiCache1', data['Resources'].keys())
+        self.assertIn('ElastiCacheParameterGroup', data['Resources'].keys())
+        self.assertIn('ElastiCacheSecurityGroup', data['Resources'].keys())
+        self.assertIn('ElastiCacheSubnetGroup', data['Resources'].keys())
         self.assertEquals(
             {
                 'CacheNodeType': 'cache.t2.small',
@@ -822,7 +822,7 @@ class TestBuildercoreTrop(base.BaseCase):
                 ],
                 'VpcSecurityGroupIds': [{'Ref': 'ElastiCacheSecurityGroup'}],
             },
-            data['Resources']['ElastiCache']['Properties']
+            data['Resources']['ElastiCache1']['Properties']
         )
         self.assertEquals(
             {
@@ -855,21 +855,36 @@ class TestBuildercoreTrop(base.BaseCase):
             },
             data['Resources']['ElastiCacheSubnetGroup']['Properties']
         )
-        self.assertTrue('ElastiCacheHost' in data['Outputs'])
+        self.assertIn('ElastiCacheHost1', data['Outputs'])
         self.assertEquals(
             {
                 'Description': 'The hostname on which the cache accepts connections',
-                'Value': {'Fn::GetAtt': ['ElastiCache', 'RedisEndpoint.Address']}
+                'Value': {'Fn::GetAtt': ['ElastiCache1', 'RedisEndpoint.Address']}
             },
-            data['Outputs']['ElastiCacheHost']
+            data['Outputs']['ElastiCacheHost1']
         )
+        self.assertIn('ElastiCachePort1', data['Outputs'])
         self.assertEquals(
             {
                 'Description': 'The port number on which the cache accepts connections',
-                'Value': {'Fn::GetAtt': ['ElastiCache', 'RedisEndpoint.Port']}
+                'Value': {'Fn::GetAtt': ['ElastiCache1', 'RedisEndpoint.Port']}
             },
-            data['Outputs']['ElastiCachePort']
+            data['Outputs']['ElastiCachePort1']
         )
+
+    def test_multiple_elasticache_clusters(self):
+        extra = {
+            'stackname': 'project-with-multiple-elasticaches--prod',
+        }
+        context = cfngen.build_context('project-with-multiple-elasticaches', **extra)
+        cfn_template = trop.render(context)
+        data = self._parse_json(cfn_template)
+        self.assertIn('ElastiCache1', data['Resources'].keys())
+        self.assertIn('ElastiCache2', data['Resources'].keys())
+        self.assertIn('ElastiCacheHost1', data['Outputs'].keys())
+        self.assertIn('ElastiCachePort1', data['Outputs'].keys())
+        self.assertIn('ElastiCacheHost2', data['Outputs'].keys())
+        self.assertIn('ElastiCachePort2', data['Outputs'].keys())
 
     def _parse_json(self, dump):
         """Parses dump into a dictionary, using strings rather than unicode strings


### PR DESCRIPTION
Apart from the multiple clusters which is configured through a number, `overrides` is useful to customized the size of one of those (which affects how much size it has for example); `suppress` is useful for migrations as there is currently a `ElastiCache` resource in `journal` templates we'll need to remove and substitute with `ElastiCache1` and `ElastiCache2`.