### PR TITLE
[wip] some tweaks to commands that have been hanging around for a bit

### DIFF
--- a/src/askmaster.py
+++ b/src/askmaster.py
@@ -55,8 +55,8 @@ def installed_linux():
 
 @task
 def patched():
-    #output = str(installed_linux()).splitlines()
-    output = open('src/foo.txt', 'r').readlines()
+    output = str(installed_linux()).splitlines()
+    #output = open('src/foo.txt', 'r').readlines()
 
     def rowfn(row):
         # parses output of dpkg -l
@@ -73,7 +73,7 @@ def patched():
 
     fully_patched = [
         '3.13.0-139-generic', '3.13.0-139.188',
-        '4.4.0-1047-aws', '4.4.0.1048.50'
+        '4.4.0-1048-aws', '4.4.0.1048.50'
     ]
 
     csvrows = [('instance', 'instance-id', 'running', 'installed', 'running latest', 'needs update', 'needs reboot')]

--- a/src/askmaster.py
+++ b/src/askmaster.py
@@ -9,6 +9,7 @@ from buildercore.core import stack_conn
 import aws
 from buildercore.decorators import osissue
 
+@task
 def salt_master_cmd(cmd, module='cmd.run', minions=r'\*'):
     "runs the given command on all aws instances. given command must escape double quotes"
     with stack_conn(core.find_master(aws.find_region())):
@@ -45,4 +46,4 @@ def fail2ban_running():
 
 @task
 def installed_linux():
-    return salt_master_cmd("'dpkg -l | grep -i linux-image'")
+    return salt_master_cmd("'dpkg -l | grep -i linux-image && uname -r'")

--- a/src/buildercore/config.py
+++ b/src/buildercore/config.py
@@ -27,11 +27,15 @@ class FabricException(Exception):
 env.abort_exception = FabricException
 
 
+ENVS = [
+    'ci', 'end2end', 'prod', 'continuumtest',
+    'demo', 'continuumtestpreview', 'preview'
+]
+
 # dirs are relative
 # paths are absolute
 # a file is an absolute path to a file
 # filenames are names of files without any other context
-
 
 # these users should probably be specified in the project/org config file
 # as 'defaults'. deploy user especially

--- a/src/buildercore/utils.py
+++ b/src/buildercore/utils.py
@@ -11,6 +11,9 @@ from more_itertools import unique_everseen
 import logging
 LOG = logging.getLogger(__name__)
 
+def identity(x):
+    return x
+
 def shallow_flatten(lst):
     "flattens a single level of nesting [[1] [2] [3]] => [1 2 3]"
     return [item for sublist in lst for item in sublist]

--- a/src/continuum.py
+++ b/src/continuum.py
@@ -1,0 +1,37 @@
+import os
+import cfn
+from fabric.api import run, task
+from fabric.context_managers import cd
+from decorators import requires_aws_project_stack, echo_output
+from buildercore import core
+
+@task
+@requires_aws_project_stack('lax')
+def lax_backfill(stackname):
+    with core.stack_conn(stackname):
+        # TODO: run this in a screen session but also figure out how to ctrl-c it
+        with cd('/opt/bot-lax-adaptor/'):
+            run('./backfill.sh')
+
+@task
+@requires_aws_project_stack('observer')
+def observer_backfill(stackname):
+    with core.stack_conn(stackname), cd('/srv/observer/'):
+        run('./manage.sh load_from_api')
+
+@task
+@echo_output
+def adhoc_instances():
+    def unrecognised(stackname):
+        iid = stackname.split('--')[-1]
+        return iid not in ['ci', 'end2end', 'prod', 'continuumtest']
+    import aws
+    region = aws.find_region()
+    return filter(unrecognised, core.active_stack_names(region))
+
+@task
+def daily_update_logs(*stacknames):
+    path = "/var/log/daily-system-update.log"
+    for stackname in stacknames:
+        destpath = "%s--%s" % (stackname, os.path.basename(path))
+        cfn.download_file(stackname, path, destpath)

--- a/src/continuum.py
+++ b/src/continuum.py
@@ -3,7 +3,7 @@ import cfn
 from fabric.api import run, task
 from fabric.context_managers import cd
 from decorators import requires_aws_project_stack, echo_output
-from buildercore import core
+from buildercore import core, config
 
 @task
 @requires_aws_project_stack('lax')
@@ -24,7 +24,7 @@ def observer_backfill(stackname):
 def adhoc_instances():
     def unrecognised(stackname):
         iid = stackname.split('--')[-1]
-        return iid not in ['ci', 'end2end', 'prod', 'continuumtest']
+        return iid not in config.ENVS
     import aws
     region = aws.find_region()
     return filter(unrecognised, core.active_stack_names(region))

--- a/src/fabfile.py
+++ b/src/fabfile.py
@@ -24,3 +24,4 @@ from deploy import switch_revision_update_instance
 from lifecycle import start, stop, stop_if_running_for, update_dns
 import masterless
 import fixtures
+import continuum


### PR DESCRIPTION
pretty rough PR. it tweaks some of the commands in the askmaster module and introduces `continuum.py` commands, a module I thought I added ages and ages ago but apparently didn't. it has a handy command in there for identifying adhoc instances.

before/if this is merged I want to fix the problem with not being able to download a file from a multi-node stack. I keep 'fixing' it and then reverting it because the changes go a little deep.