### PR TITLE
ELPP-3360 bot hostname and ports for access in end2end tests

### DIFF
--- a/projects/elife.yaml
+++ b/projects/elife.yaml
@@ -626,6 +626,10 @@ elife-bot:
                 "{instance}-elife-bot-sessions":
                     deletion-policy: delete
         end2end:
+            ports:
+                - 22
+                - 8020 # exposing FTP contents
+                - 8021 # exposing FTP contents, HTTPS
             description: speeding up end2end tests
             #    end2end-elife-production-final:
             #        sqs-notifications:

--- a/projects/elife.yaml
+++ b/projects/elife.yaml
@@ -589,7 +589,6 @@ elife-metrics:
 elife-bot:
     repo: https://github.com/elifesciences/elife-bot
     formula-repo: https://github.com/elifesciences/elife-bot-formula
-    domain: false
     subdomain: bot
     aws:
         ec2:

--- a/src/buildercore/cfngen.py
+++ b/src/buildercore/cfngen.py
@@ -391,6 +391,8 @@ def template_delta(pname, context):
             template['Resources']['MountPoint']['Properties']['InstanceId']['Ref'] = 'EC2Instance'
         if 'IntDNS' in template['Resources']:
             template['Resources']['IntDNS']['Properties']['ResourceRecords'][0]['Fn::GetAtt'][0] = 'EC2Instance'
+        if 'ExtDNS' in template['Resources']:
+            template['Resources']['ExtDNS']['Properties']['ResourceRecords'][0]['Fn::GetAtt'][0] = 'EC2Instance'
     # end backward compatibility code
 
     def _title_has_been_updated(title, section):


### PR DESCRIPTION
- Add a public domain name to bot instances
- Add ports to expose the fake FTP server content