### PR TITLE
Smarter diff in EC2 updates

### DIFF
--- a/src/buildercore/cfngen.py
+++ b/src/buildercore/cfngen.py
@@ -408,8 +408,7 @@ def template_delta(pname, context):
         if 'Type' in title_in_old:
             if title_in_old['Type'] == 'AWS::EC2::Instance':
                 for property_name in EC2_NOT_UPDATABLE_PROPERTIES:
-                    title_in_old['Properties'][property_name] = None
-                    title_in_new['Properties'][property_name] = None
+                    title_in_new['Properties'][property_name] = title_in_old['Properties'][property_name]
         return title_in_old != title_in_new
 
     def legacy_title(title):


### PR DESCRIPTION
EC2 have some properties that we never want to update such as UserData. If we did so, we may cause the re-creation of the instance losing its state.

The previous comparison stripped these properties from the old and the new template, so that the resource wasn't detected as modified at all in most cases. This new comparison actually allows to modify some of the properties, as the non-updatable ones will be copied from the old template