### PR TITLE
ELPP-3338 Allow headers forwarding to be configured per-origin

### DIFF
--- a/projects/elife.yaml
+++ b/projects/elife.yaml
@@ -441,6 +441,9 @@ journal:
                             - Host
                             - CloudFront-Viewer-Country
                             - Referer
+                        cookies:
+                            - journal
+                            - AWSELB
                 #logging:
                 #    bucket: elife-cloudfront-logs
         continuumtest:
@@ -474,6 +477,8 @@ journal:
                             - Host
                             - CloudFront-Viewer-Country
                             - Referer
+                        cookies:
+                            - journal
         prod:
             description: prod environment for journal. ELB on top of multiple EC2 instances
             ec2:

--- a/projects/elife.yaml
+++ b/projects/elife.yaml
@@ -518,6 +518,20 @@ journal:
                         # ELB with no active instances
                         503: "/5xx.html"
                     protocol: http
+                origins:
+                    CloudFrontCDNOrigin:
+                        hostname: prod--journal.elifesciences.org
+                    LogInOrigin:
+                        hostname: prod--journal.elifesciences.org
+                        pattern: /log-in
+                        headers:
+                            - X-Requested-With
+                            - Host
+                            - CloudFront-Viewer-Country
+                            - Referer
+                        cookies:
+                            - journal
+                            - AWSELB
         cachetest:
             elasticache:
                 engine: redis

--- a/projects/elife.yaml
+++ b/projects/elife.yaml
@@ -463,6 +463,17 @@ journal:
                     codes:
                         503: "/5xx.html"
                     protocol: http
+                origins:
+                    CloudFrontCDNOrigin:
+                        hostname: continuumtest--journal.elifesciences.org
+                    LogInOrigin:
+                        hostname: continuumtest--journal.elifesciences.org
+                        pattern: /log-in
+                        headers:
+                            - X-Requested-With
+                            - Host
+                            - CloudFront-Viewer-Country
+                            - Referer
         prod:
             description: prod environment for journal. ELB on top of multiple EC2 instances
             ec2:

--- a/projects/elife.yaml
+++ b/projects/elife.yaml
@@ -430,6 +430,17 @@ journal:
                         # ELB with no active instances
                         503: "/5xx.html"
                     protocol: http
+                origins:
+                    CloudFrontCDNOrigin:
+                        hostname: end2end--journal.elifesciences.org
+                    LogInOrigin:
+                        hostname: end2end--journal.elifesciences.org
+                        pattern: /log-in
+                        headers:
+                            - X-Requested-With
+                            - Host
+                            - CloudFront-Viewer-Country
+                            - Referer
                 #logging:
                 #    bucket: elife-cloudfront-logs
         continuumtest:

--- a/src/buildercore/cfngen.py
+++ b/src/buildercore/cfngen.py
@@ -214,7 +214,11 @@ def build_context_cloudfront(context, parameterize):
             'errors': errors,
             'logging': context['project']['aws']['cloudfront'].get('logging', False),
             'origins': OrderedDict([
-                (o_id, {'hostname': parameterize(o['hostname']), 'pattern': o.get('pattern')})
+                (o_id, {
+                    'hostname': parameterize(o['hostname']),
+                    'pattern': o.get('pattern'),
+                    'headers': o.get('headers', []),
+                })
                 for o_id, o in context['project']['aws']['cloudfront']['origins'].items()
             ]),
         }

--- a/src/buildercore/cfngen.py
+++ b/src/buildercore/cfngen.py
@@ -218,6 +218,7 @@ def build_context_cloudfront(context, parameterize):
                     'hostname': parameterize(o['hostname']),
                     'pattern': o.get('pattern'),
                     'headers': o.get('headers', []),
+                    'cookies': o.get('cookies', []),
                 })
                 for o_id, o in context['project']['aws']['cloudfront']['origins'].items()
             ]),

--- a/src/tests/fixtures/projects/dummy-project.yaml
+++ b/src/tests/fixtures/projects/dummy-project.yaml
@@ -289,6 +289,8 @@ project-with-cloudfront-origins:
                 some-bucket:
                     hostname: "{instance}--some-bucket.s3.amazonaws.com"
                     pattern: articles/*
+                    headers:
+                        - Referer
 
 project-with-cluster:
     repo: ssh://git@github.com/elifesciences/dummy3

--- a/src/tests/fixtures/projects/dummy-project.yaml
+++ b/src/tests/fixtures/projects/dummy-project.yaml
@@ -291,6 +291,8 @@ project-with-cloudfront-origins:
                     pattern: articles/*
                     headers:
                         - Referer
+                    cookies:
+                        - session_id
 
 project-with-cluster:
     repo: ssh://git@github.com/elifesciences/dummy3

--- a/src/tests/test_buildercore_trop.py
+++ b/src/tests/test_buildercore_trop.py
@@ -763,6 +763,10 @@ class TestBuildercoreTrop(base.BaseCase):
         )
         self.assertEquals(
             {
+                'Cookies': {
+                    'Forward': 'whitelist',
+                    'WhitelistedNames': ['session_id'],
+                },
                 'Headers': ['Referer'],
                 'QueryString': 'false',
             },
@@ -792,6 +796,9 @@ class TestBuildercoreTrop(base.BaseCase):
             [{
                 'DefaultTTL': 300,
                 'ForwardedValues': {
+                    'Cookies': {
+                        'Forward': 'none',
+                    },
                     'Headers': [],
                     # yes this is a string containing the word 'false'...
                     'QueryString': 'false',

--- a/src/tests/test_buildercore_trop.py
+++ b/src/tests/test_buildercore_trop.py
@@ -616,6 +616,7 @@ class TestBuildercoreTrop(base.BaseCase):
                 'Properties': {
                     'DistributionConfig': {
                         'Aliases': ['prod--cdn-of-www.example.org', 'example.org', 'future.example.org'],
+                        'CacheBehaviors': [],
                         'DefaultCacheBehavior': {
                             'AllowedMethods': ['DELETE', 'GET', 'HEAD', 'OPTIONS', 'PATCH', 'POST', 'PUT'],
                             'CachedMethods': ['GET', 'HEAD'],
@@ -791,6 +792,7 @@ class TestBuildercoreTrop(base.BaseCase):
             [{
                 'DefaultTTL': 300,
                 'ForwardedValues': {
+                    'Headers': [],
                     # yes this is a string containing the word 'false'...
                     'QueryString': 'false',
                 },

--- a/src/tests/test_buildercore_trop.py
+++ b/src/tests/test_buildercore_trop.py
@@ -760,6 +760,13 @@ class TestBuildercoreTrop(base.BaseCase):
             'articles/*',
             distribution_config['CacheBehaviors'][0]['PathPattern'],
         )
+        self.assertEquals(
+            {
+                'Headers': ['Referer'],
+                'QueryString': 'false',
+            },
+            distribution_config['CacheBehaviors'][0]['ForwardedValues'],
+        )
 
     def test_cdn_template_error_pages(self):
         extra = {


### PR DESCRIPTION
Turns out we already had some support for multiple origins:

- one additional origin is required for error pages
- some CDNs merge contents from multiple buckets 

What was missing was being able to customize the `CacheBehavior` of each origin. In this we case, we add the capability to customize which headers are forwarded so that some paths (like `/log-in) can benefit from more info about the user; they sacrifice cacheability as they are not cacheable anyway.