### PR TITLE
Remove minion key from master on destroy

### DIFF
--- a/src/buildercore/bootstrap.py
+++ b/src/buildercore/bootstrap.py
@@ -619,7 +619,7 @@ def remove_minion_key(stackname):
 def master_minion_keys(master_stackname, group_by_stackname=True):
     "returns a list of paths to minion keys on given master stack, optionally grouped by stackname"
     # all paths
-    master_stack_key_paths = core.list_dir(master_stackname, "/etc/salt/pki/master/minions/", use_sudo=True)
+    master_stack_key_paths = core.listfiles_remote(master_stackname, "/etc/salt/pki/master/minions/", use_sudo=True)
     if not group_by_stackname:
         return master_stack_key_paths
     # group by stackname. stackname is created by stripping node information off the end.

--- a/src/buildercore/bootstrap.py
+++ b/src/buildercore/bootstrap.py
@@ -626,7 +626,7 @@ def delete_stack(stackname):
                     return False
                 raise # not sure what happened, but we're not handling it here. die.
         utils.call_while(partial(is_deleting, stackname), timeout=3600, update_msg='Waiting for AWS to finish deleting stack ...')
-        # TODO: call remove_minion_key()? (from master server)
+        remove_minion_key(stackname)
         keypair.delete_keypair(stackname)
         delete_stack_file(stackname)
         delete_dns(stackname)

--- a/src/buildercore/core.py
+++ b/src/buildercore/core.py
@@ -13,7 +13,7 @@ from boto import sns
 from boto.exception import BotoServerError
 import boto3
 from contextlib import contextmanager
-from fabric.api import settings, execute, env, parallel, serial
+from fabric.api import settings, execute, env, parallel, serial, hide, run, sudo
 from fabric.exceptions import NetworkError
 from fabric.state import output
 import importlib
@@ -678,3 +678,15 @@ def project_data_for_stackname(stackname):
 def ami_name(stackname):
     # elife-api.2015-12-31
     return "%s.%s" % (project_name_from_stackname(stackname), utils.ymd())
+
+def list_dir(stackname, path=None, use_sudo=False):
+    """returns a list of files in a directory (dir_) as absolute paths"""
+    ensure(path, "path to remote directory required")
+    with stack_conn(stackname):
+        with hide('output'):
+            runfn = sudo if use_sudo else run
+            path = "%s/*" % path.rstrip("/")
+            output = runfn("for i in %s; do echo $i; done" % path)
+            if output == path: # some kind o
+                return []
+            return output.splitlines()

--- a/src/buildercore/core.py
+++ b/src/buildercore/core.py
@@ -687,6 +687,6 @@ def list_dir(stackname, path=None, use_sudo=False):
             runfn = sudo if use_sudo else run
             path = "%s/*" % path.rstrip("/")
             output = runfn("for i in %s; do echo $i; done" % path)
-            if output == path: # some kind o
+            if output == path: # some kind of bash artifact where it returns `/path/*` when no matches
                 return []
             return output.splitlines()

--- a/src/buildercore/core.py
+++ b/src/buildercore/core.py
@@ -679,8 +679,8 @@ def ami_name(stackname):
     # elife-api.2015-12-31
     return "%s.%s" % (project_name_from_stackname(stackname), utils.ymd())
 
-def list_dir(stackname, path=None, use_sudo=False):
-    """returns a list of files in a directory (dir_) as absolute paths"""
+def listfiles_remote(stackname, path=None, use_sudo=False):
+    """returns a list of files in a directory at `path` as absolute paths"""
     ensure(path, "path to remote directory required")
     with stack_conn(stackname):
         with hide('output'):

--- a/src/buildercore/utils.py
+++ b/src/buildercore/utils.py
@@ -65,6 +65,14 @@ def complement(pred):
 def splitfilter(func, data):
     return filter(func, data), filter(complement(func), data)
 
+def mkidx(fn, lst):
+    groups = {}
+    for v in lst:
+        key = fn(v)
+        grp = groups.get(key, [])
+        grp.append(v)
+        groups[key] = grp
+    return groups
 
 """
 # NOTE: works, unused.

--- a/src/cfn.py
+++ b/src/cfn.py
@@ -109,12 +109,14 @@ def update_template(stackname):
         bootstrap.update_stack(stackname, service_list=['s3'])
 
 
-@task
+# TODO: this task should probably live in `master.py`
+@debugtask # can't be and shouldn't be run by regular user of builder
 def update_master():
-    return bootstrap.update_stack(
-        core.find_master(aws.find_region()),
-        service_list=['ec2'] # master-server should be a self-contained EC2 instance
-    )
+    master_stackname = core.find_master(aws.find_region())
+    bootstrap.update_stack(master_stackname, service_list=[
+        'ec2' # master-server should be a self-contained EC2 instance
+    ])
+    bootstrap.remove_all_orphaned_keys(master_stackname)
 
 @requires_project
 def generate_stack_from_input(pname, instance_id=None, alt_config=None):


### PR DESCRIPTION
The intended behavior is that a stack can be recreated after `destroy`, without having to manually delete the key from the master-server's `/etc/salt/pki/...` folder.

However, needs to cater for:
- masterless instances (may just fail silently?)
- master servers themselves (can't destroy them?)