### PR TITLE
ELPP-3481 Add exeter-adapter project

### DIFF
--- a/projects/elife.yaml
+++ b/projects/elife.yaml
@@ -1725,6 +1725,8 @@ exeter-adapter:
     intdomain: False
     aws:
         ec2: false
+        sqs:
+            exeter-adapter--{instance}: {}
     aws-alt:
         continuumtest:
             sqs:

--- a/projects/elife.yaml
+++ b/projects/elife.yaml
@@ -1719,14 +1719,21 @@ task-adept:
         s3:
             "{instance}-elife-task-adept":
 
-sample-sqs:
-    description: testing SQS subscriptions
-    domain: null
-    intdomain: null
+exeter-adapter:
+    description: Exeter history API integration
+    domain: false
+    intdomain: False
     aws:
         ec2: false
-        sqs:
-            sample-sqs--{instance}:
-                subscriptions:
-                    - bus-articles--{instance}
-                    - bus-press-packages--{instance}
+    aws-alt:
+        continuumtest:
+            sqs:
+                exeter-adapter--{instance}:
+                    subscriptions:
+                        - elife-bot-event-property--continuumtest
+        prod:
+            sqs:
+                exeter-adapter--{instance}:
+                    subscriptions:
+                        - elife-bot-event-property--prod
+

--- a/projects/elife.yaml
+++ b/projects/elife.yaml
@@ -1728,6 +1728,18 @@ exeter-adapter:
         sqs:
             exeter-adapter--{instance}: {}
     aws-alt:
+        fresh:
+            ec2: false
+        1604:
+            ec2: false
+        1404:
+            ec2: false
+        standalone1604:
+            ec2: false
+        standalone1404:
+            ec2: false
+        standalone:
+            ec2: false
         continuumtest:
             sqs:
                 exeter-adapter--{instance}:

--- a/src/tests/test_buildercore_bootstrap.py
+++ b/src/tests/test_buildercore_bootstrap.py
@@ -91,3 +91,21 @@ pillar_roots:
                 ],
             }
         )
+
+    def test_remove_all_topics_from_sqs_policy(self):
+        original = {
+            'Version': '2008-10-17',
+            'Statement': [
+                {
+                    # ...
+                    'Condition': {
+                        'StringLike': {
+                            'aws:SourceArn': 'arn:aws:sns:us-east-1:512686554592:bus-articles--end2end',
+                        },
+                    },
+                },
+            ],
+        }
+
+        cleaned = bootstrap.remove_topics_from_sqs_policy(original, ['arn:aws:sns:us-east-1:512686554592:bus-articles--end2end'])
+        self.assertIsNone(cleaned)


### PR DESCRIPTION
This project will be expanded with something reading from the queue, but now we just want to collect data.

Solves also a bug on `unsub_sqs` called on a queue not subscribed to anything. The `Policy` attribute cannot be empty, so it needs to be removed by setting an empty string when there are no topics to subscribe to.

Incidentally, even if a queue subscribed to topics, it will still run `unsub_sqs` at its creation when it's not subscribed to anything yet, running into the problem.