### PR TITLE
Enable S3 storage for contexts by default

### DIFF
--- a/example.settings.yml
+++ b/example.settings.yml
@@ -3,7 +3,7 @@
 
 ## feature: enable/disable writing of ec2 build context to s3
 ## this helps when starting/stopping instances and updating dns records
-write-context-to-s3: False
+write-context-to-s3: True
 
 ## feature: enable/disable writing of ec2 keypairs to s3
 write-keypairs-to-s3: True


### PR DESCRIPTION
@seanwiseman had this turned off and it was producing strange errors about missing contexts as they couldn't be downloaded.