### PR TITLE
PI-654 Force alt-config in update_template

### DIFF
--- a/src/buildercore/cfngen.py
+++ b/src/buildercore/cfngen.py
@@ -44,17 +44,12 @@ def build_context(pname, **more_context): # pylint: disable=too-many-locals
     # regenerating templates (like random passwords)
     existing_context = more_context.pop('existing_context', {})
 
-    # order is important. prefer the alt-config in more_context (explicit) over
-    # any existing context (implicit)
-    alt_config = utils.firstnn([
-        more_context.get('alt-config'),
-        existing_context.get('alt-config')
-    ])
+    # order is important. always use the alt-config in more_context (explicit) also when regenerating
+    alt_config = more_context.get('alt-config')
 
     project_data = project.project_data(pname)
-    if alt_config:
+    if alt_config and project_data.get('aws-alt', {}).get(alt_config):
         project_data = project.set_project_alt(project_data, 'aws', alt_config)
-        more_context['alt-config'] = alt_config
 
     defaults = {
         'project_name': pname,
@@ -511,8 +506,9 @@ def regenerate_stack(stackname, current_template, **more_context):
    # as it is, it requires a dependency between cfngen and bootstrap (removed) that shouldn't really exist
     current_context = context_handler.load_context(stackname)
     write_template(stackname, json.dumps(current_template))
-    pname = core.project_name_from_stackname(stackname)
+    (pname, instance_id) = core.parse_stackname(stackname)
     more_context['stackname'] = stackname # TODO: purge this crap
+    more_context['alt-config'] = instance_id
     context = build_context(pname, existing_context=current_context, **more_context)
     delta = template_delta(context)
     return context, delta, current_context

--- a/src/tests/test_buildercore_cfngen.py
+++ b/src/tests/test_buildercore_cfngen.py
@@ -32,6 +32,27 @@ class TestBuildercoreCfngen(base.BaseCase):
         # todo: does this need to live in a try: ... finally: ... ?
         self.switch_in_test_settings()
 
+class TestBuildContext(base.BaseCase):
+    def test_existing_alt_config(self):
+        stackname = 'dummy2--test'
+        more_context = {
+            'stackname': stackname,
+            'alt-config': 'alt-config1',
+        }
+        context = cfngen.build_context('dummy2', **more_context)
+        self.assertEqual(context['alt-config'], 'alt-config1')
+        self.assertEqual(context['ec2']['ami'], 'ami-22222')
+
+    def test_not_existing_alt_config(self):
+        stackname = 'dummy2--test'
+        more_context = {
+            'stackname': stackname,
+            'alt-config': 'my-custom-adhoc-instance',
+        }
+        context = cfngen.build_context('dummy2', **more_context)
+        self.assertEqual(context['alt-config'], 'my-custom-adhoc-instance')
+        self.assertEqual(context['ec2']['ami'], 'ami-111111')
+
 class TestUpdates(base.BaseCase):
     def test_empty_template_delta(self):
         context = self._base_context()


### PR DESCRIPTION
`elife-bot--prod` had a empty `alt-config` key in its existing context. In general it's possible to add a `aws-alt:` configuration after a stack has already been created without it, so as part of the regeneration we should reevaluate whether `alt-config` is telling us to use a particular custom configuration.