### PR TITLE
ELPP-3567 Python version flag

### DIFF
--- a/.activate-venv.sh
+++ b/.activate-venv.sh
@@ -13,16 +13,22 @@ else
     echo "* the no-delete-venv flag is set. preserving venv"
 fi
 
-python=/usr/bin/python3.5
-py=${python##*/} # ll: python3.5
-
-# build venv if one doesn't exist OR 
-# venv exists but the right python isn't installed
-if [ ! -e "venv/bin/$py" ]; then
-    echo "could not find venv/bin/$py, recreating venv"
-    rm -rf venv
+if [ ! -f .use-python-3.flag ]; then
+    virtualenv --python=`which python2` venv
+    echo "using python2"
+else
+    python=/usr/bin/python3.5
     $python -m venv venv
+    echo "using python 3"
 fi
+
+## build venv if one doesn't exist OR
+## venv exists but the right python isn't installed
+#if [ ! -e "venv/bin/$py" ]; then
+#    echo "could not find venv/bin/$py, recreating venv"
+#    rm -rf venv
+#    $python -m venv venv
+#fi
 
 source venv/bin/activate
 

--- a/src/buildercore/core.py
+++ b/src/buildercore/core.py
@@ -3,7 +3,11 @@ that is built upon by the more specialised parts of builder.
 
 suggestions for a better name than 'core' welcome."""
 
-import http.client
+try:
+    import http.client
+except ImportError:
+    import httplib
+
 import os, glob, json, re
 from os.path import join
 from . import utils, config, project, decorators # BE SUPER CAREFUL OF CIRCULAR DEPENDENCIES


### PR DESCRIPTION
Workaround to allow `.use-python-3.flag` to be used during installation to define which version of Python to use.