### PR TITLE
ELPP-3448 Pin master server in build vars

### DIFF
--- a/projects/elife.yaml
+++ b/projects/elife.yaml
@@ -45,6 +45,8 @@ defaults:
             # ami: ami-92002785   # elife 'basebox.2016-11-03'
             # use a master server or go ronin?
             masterless: false
+            # optional: pin a master server for all new instances of a project
+            master_ip: 10.0.2.198
         region: us-east-1
         vpc-id: vpc-78a2071d  # vpc-id + subnet-id are peculiar to AWS account + region
         subnet-id: subnet-1d4eb46a # elife-public-subnet, us-east-1d

--- a/src/buildercore/bootstrap.py
+++ b/src/buildercore/bootstrap.py
@@ -551,10 +551,10 @@ def update_ec2_stack(stackname, concurrency=None, formula_revisions=None, **kwar
 
         salt_version = pdata['salt']
         install_master_flag = str(is_master or is_masterless).lower() # ll: 'true'
-        master_ip = master(region, 'private_ip_address')
 
         build_vars = bvars.read_from_current_host()
         minion_id = build_vars.get('nodename', stackname)
+        master_ip = build_vars.get('ec2').get('master_ip', master(region, 'private_ip_address'))
         run_script('bootstrap.sh', salt_version, minion_id, install_master_flag, master_ip)
 
         if is_masterless:

--- a/src/buildercore/cfngen.py
+++ b/src/buildercore/cfngen.py
@@ -113,6 +113,8 @@ def build_context(pname, **more_context): # pylint: disable=too-many-locals
     context['ec2'] = context['project']['aws'].get('ec2', True)
     if isinstance(context['ec2'], dict):
         context['ec2']['type'] = context['project']['aws']['type']
+        if context['ec2'].get('masterless') and context['ec2'].get('master_ip'):
+            del context['ec2']['master_ip']
 
     build_context_elb(context)
 

--- a/src/tests/fixtures/dummy1-project.json
+++ b/src/tests/fixtures/dummy1-project.json
@@ -17,7 +17,8 @@
             "dns-internal": false, 
             "suppressed": [], 
             "overrides": {}, 
-            "ami": "ami-9eaa1cf6"
+            "ami": "ami-9eaa1cf6",
+            "master_ip": "10.0.2.42"
         }, 
         "type": "t2.micro", 
         "region": "us-east-1", 

--- a/src/tests/fixtures/dummy2-project.json
+++ b/src/tests/fixtures/dummy2-project.json
@@ -17,7 +17,8 @@
             "dns-internal": false, 
             "suppressed": [], 
             "overrides": {}, 
-            "ami": "ami-111111"
+            "ami": "ami-111111",
+            "master_ip": "10.0.2.42"
         }, 
         "type": "t2.small", 
         "region": "us-east-1", 
@@ -63,7 +64,8 @@
                 "dns-internal": false, 
                 "suppressed": [], 
                 "overrides": {}, 
-                "ami": "ami-9eaa1cf6"
+                "ami": "ami-9eaa1cf6",
+                "master_ip": "10.0.2.42"
             }, 
             "type": "t2.small", 
             "region": "us-east-1", 
@@ -109,7 +111,8 @@
                 "dns-internal": false, 
                 "suppressed": [], 
                 "overrides": {}, 
-                "ami": "ami-22222"
+                "ami": "ami-22222",
+                "master_ip": "10.0.2.42"
             }, 
             "type": "t2.small", 
             "region": "us-east-1", 

--- a/src/tests/fixtures/dummy3-project.json
+++ b/src/tests/fixtures/dummy3-project.json
@@ -17,7 +17,8 @@
             "dns-internal": false, 
             "suppressed": [], 
             "overrides": {}, 
-            "ami": "ami-111111"
+            "ami": "ami-111111",
+            "master_ip": "10.0.2.42"
         }, 
         "type": "t2.small", 
         "region": "us-east-1", 
@@ -41,7 +42,8 @@
                 "dns-internal": false, 
                 "suppressed": [], 
                 "overrides": {}, 
-                "ami": "ami-9eaa1cf6"
+                "ami": "ami-9eaa1cf6",
+                "master_ip": "10.0.2.42"
             }, 
             "type": "t2.small", 
             "region": "us-east-1", 
@@ -65,7 +67,8 @@
                 "dns-internal": false, 
                 "suppressed": [], 
                 "overrides": {}, 
-                "ami": "ami-111111"
+                "ami": "ami-111111",
+                "master_ip": "10.0.2.42"
             }, 
             "type": "t2.small", 
             "region": "us-east-1", 
@@ -106,7 +109,8 @@
                 "dns-internal": false, 
                 "suppressed": [], 
                 "overrides": {}, 
-                "ami": "ami-111111"
+                "ami": "ami-111111",
+                "master_ip": "10.0.2.42"
             }, 
             "type": "t2.small", 
             "region": "us-east-1", 

--- a/src/tests/fixtures/projects/dummy-project.yaml
+++ b/src/tests/fixtures/projects/dummy-project.yaml
@@ -30,6 +30,7 @@ defaults:
             overrides: {}
             # find more here: http://cloud-images.ubuntu.com/releases/
             ami: ami-9eaa1cf6  # Ubuntu 14.04
+            master_ip: 10.0.2.42
         type: t2.small
         region: us-east-1
         vpc-id: vpc-78a2071d  # vpc-id + subnet-id are peculiar to AWS account + region


### PR DESCRIPTION
`update_template` (soon to be renamed in `update_infrastructure`) pins the new master ip, which then is preferred to the one passed from builder.

`update` or other deploys don't change the build vars instead.