### PR TITLE
ELPP-3520 Allow override of CNAME for Fastly

### DIFF
--- a/projects/elife.yaml
+++ b/projects/elife.yaml
@@ -127,6 +127,8 @@ defaults:
         fastly:
             # fastly defaults only used if a 'fastly' section present in project
             subdomains: []
+            dns:
+                cname: u2.shared.global.fastly.net
         subdomains: []
         elasticache:
             # elasticache defaults only used if an `rds` section present in project

--- a/src/buildercore/bootstrap.py
+++ b/src/buildercore/bootstrap.py
@@ -186,7 +186,7 @@ def _init_terraform(stackname):
 def setup_terraform(stackname, context):
     if not context.get('fastly'):
         return
-    ensure('FASTLY_API_KEY' in os.environ, "a FASTLY_API_KEY environment variable is required to provision Fastly resources", ConfigurationError)
+    ensure('FASTLY_API_KEY' in os.environ, "a FASTLY_API_KEY environment variable is required to provision Fastly resources. Get it at https://manage.fastly.com/account/personal/tokens", ConfigurationError)
 
     t = _init_terraform(stackname)
     t.apply(input=False, capture_output=False, raise_on_error=True)
@@ -286,7 +286,7 @@ def update_sqs_stack(stackname, **kwargs):
         setup_sqs(stackname, current_context_sqs, current_context['project']['aws']['region'])
 
 def update_terraform_stack(stackname, **kwargs):
-    ensure('FASTLY_API_KEY' in os.environ, "a FASTLY_API_KEY environment variable is required to provision Fastly resources", ConfigurationError)
+    ensure('FASTLY_API_KEY' in os.environ, "a FASTLY_API_KEY environment variable is required to provision Fastly resources. Get it at https://manage.fastly.com/account/personal/tokens", ConfigurationError)
     t = _init_terraform(stackname)
     t.apply(input=False, capture_output=False, raise_on_error=True)
 

--- a/src/buildercore/cfngen.py
+++ b/src/buildercore/cfngen.py
@@ -240,6 +240,7 @@ def build_context_fastly(context, parameterize):
             'subdomains': [build_subdomain(x) for x in context['project']['aws']['fastly']['subdomains']],
             # future use
             'subdomains-without-dns': [],
+            'dns': context['project']['aws']['fastly']['dns'],
         }
     else:
         context['fastly'] = False

--- a/src/buildercore/trop.py
+++ b/src/buildercore/trop.py
@@ -52,6 +52,7 @@ ELASTICACHE_PARAMETER_GROUP_TITLE = 'ElastiCacheParameterGroup'
 KEYPAIR = "KeyName"
 
 FASTLY_GLOBAL = 'nonssl.global.fastly.net.'
+FASTLY_SSL = 'u2.shared.global.fastly.net'
 
 def _read_script(script_filename):
     path = join(config.SCRIPTS_PATH, script_filename)
@@ -385,6 +386,9 @@ def external_dns_fastly(context):
     "a Fastly CDN requires additional CNAME DNS entries pointing at it"
     ensure(isinstance(context['domain'], str), "A 'domain' must be specified for CNAMEs to be built: %s" % context)
 
+    # may be used to point to TLS servers
+    cname = context['fastly']['dns'].get('cname', FASTLY_GLOBAL)
+
     def entry(hostname, i):
         if _is_domain_2nd_level(hostname):
             raise ConfigurationError("2nd-level domains aliases are not supported yet by builder. See https://docs.fastly.com/guides/basic-configuration/using-fastly-with-apex-domains")
@@ -395,7 +399,7 @@ def external_dns_fastly(context):
             Name=hostname,
             Type="CNAME",
             TTL="60",
-            ResourceRecords=[FASTLY_GLOBAL],
+            ResourceRecords=[cname],
         )
     return [entry(hostname, i) for i, hostname in enumerate(context['fastly']['subdomains'])]
 

--- a/src/tests/fixtures/projects/dummy-project.yaml
+++ b/src/tests/fixtures/projects/dummy-project.yaml
@@ -93,6 +93,8 @@ defaults:
         fastly:
             # fastly defaults only used if a 'fastly' section present in project
             subdomains: []
+            dns:
+                cname: something.fastly.net
         subdomains: []
         elasticache:
             # elasticache defaults only used if an `rds` section present in project


### PR DESCRIPTION
This custom CNAME is used to provide TLS through the shared certificate Fastly uses and to which *.elifesciences.org has been added. See configuration at https://manage.fastly.com/account/tls/domains