### PR TITLE
Do not source update.sh unintentionally

### DIFF
--- a/bldr
+++ b/bldr
@@ -4,7 +4,7 @@ DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 cd $DIR
 
 if [ ! -d venv ]; then
-    source update.sh
+    ./update.sh
 fi
 
 source ./venv/bin/activate


### PR DESCRIPTION
If you run `./bldr ssh:elife-dashboard--prod` (or any other command), the arguments get passed to `update.sh` and down to `.prerequisites.py`. The arguments to `bldr` should not be passed there, as they are incompatible.

```
$ rm -r venv/
$ ./bldr ssh:elife-dashboard--prod
usage: .prerequisites.py [-h] [--exclude EXCLUSIONS [EXCLUSIONS ...]]
.prerequisites.py: error: unrecognized arguments:
ssh:elife-dashboard--prod
```