### PR TITLE
Backoff in CloudFormation validation calls

### DIFF
--- a/py2-requirements.txt
+++ b/py2-requirements.txt
@@ -1,4 +1,5 @@
 autopep8==1.3.1
+backoff==1.5.0
 boto==2.46.1
 botocore==1.5.95
 boto3==1.4.4

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,5 @@
 autopep8==1.3.4
+backoff==1.5.0
 boto==2.48.0
 boto3==1.6.8
 botocore==1.9.8

--- a/src/buildercore/cloudformation.py
+++ b/src/buildercore/cloudformation.py
@@ -1,8 +1,22 @@
-from . import trop
+import logging
+import backoff
+import boto
+from . import core, trop
 from .utils import ensure
+
+LOG = logging.getLogger(__name__)
 
 def render_template(context):
     pname = context['project_name']
     msg = 'could not render a CloudFormation template for %r' % pname
     ensure('aws' in context['project'], msg, ValueError)
     return trop.render(context)
+
+def _log_backoff(event):
+    LOG.warn("Backing off in validating project %s", event['args'][0])
+
+@backoff.on_exception(backoff.expo, boto.connection.BotoServerError, on_backoff=_log_backoff, max_time=30)
+def validate_template(pname, rendered_template):
+    "remote cloudformation template checks."
+    conn = core.connect_aws_with_pname(pname, 'cfn')
+    return conn.validate_template(rendered_template)

--- a/src/cfn.py
+++ b/src/cfn.py
@@ -1,7 +1,9 @@
 from distutils.util import strtobool as _strtobool  # pylint: disable=import-error,no-name-in-module
 import json
 from pprint import pformat
+import backoff
 from fabric.api import task, local, run, sudo, put, get, abort, settings
+import fabric.exceptions
 import fabric.state
 from fabric.contrib import files
 import aws, utils, buildvars
@@ -313,11 +315,15 @@ def download_file(stackname, path, destination='.', node=None, allow_missing="Fa
     Boolean arguments are expressed as strings as this is the idiomatic way of passing them from the command line.
     """
     allow_missing, use_bootstrap_user = lmap(strtobool, [allow_missing, use_bootstrap_user])
-    with stack_conn(stackname, username=BOOTSTRAP_USER if use_bootstrap_user else DEPLOY_USER, node=node):
-        if allow_missing and not files.exists(path):
-            return # skip download
-        get(path, destination, use_sudo=True)
 
+    @backoff.on_exception(backoff.expo, fabric.exceptions.NetworkError, max_time=60)
+    def _download(path, destination):
+        with stack_conn(stackname, username=BOOTSTRAP_USER if use_bootstrap_user else DEPLOY_USER, node=node):
+            if allow_missing and not files.exists(path):
+                return # skip download
+            get(path, destination, use_sudo=True)
+
+    _download(path, destination)
 
 @task
 @requires_aws_stack

--- a/src/integration_tests/test_validation.py
+++ b/src/integration_tests/test_validation.py
@@ -1,19 +1,18 @@
-from time import sleep
 from tests import base
 from buildercore import cfngen, project
 import logging
 LOG = logging.getLogger(__name__)
 
-# not integration tests per se, but very lengthy and depend on
-# talking to AWS.
+logging.disable(logging.NOTSET) # re-enables logging during integration testing
 
-class TestBuildercoreCfngen(base.BaseCase):
+# Depends on talking to AWS.
+
+class TestValidation(base.BaseCase):
 
     def test_validation(self):
         "dummy projects and their alternative configurations pass validation"
         for pname in project.aws_projects().keys():
             cfngen.validate_project(pname)
-            sleep(0.25)
 
     def test_validation_elife_projects(self):
         "elife projects (and their alternative configurations) that come with the builder pass validation"
@@ -25,7 +24,6 @@ class TestBuildercoreCfngen(base.BaseCase):
         for pname in project.aws_projects().keys():
             with self.subTest(pname):
                 cfngen.validate_project(pname)
-                sleep(0.5)
 
         # todo: does this need to live in a try: ... finally: ... ?
         self.switch_in_test_settings()


### PR DESCRIPTION
This integration test often fails with a `BotoServerError` showing a `400 Bad Request` with `Code` `Throttling`. Rather than blindly waiting on every call, we can backoff our calls only when they fail.