### PR TITLE
ELPP-3520 Switch api-gateway CDN traffic to Fastly

### DIFF
--- a/projects/elife.yaml
+++ b/projects/elife.yaml
@@ -338,9 +338,6 @@ api-gateway:
             - 443
             # - 8000: # don't expose this to public. Kong uses this to proxy requests
             # - 8001: # don't ever expose to public. Kong uses this for API admin
-            fastly:
-                subdomains:
-                    - "{instance}--cdn-gateway"
     aws-alt:
         standalone:
             # for now a copy of standalone1404
@@ -349,9 +346,18 @@ api-gateway:
             ec2:
                 ami: ami-92002785 # Ubuntu 14.04, deprecated
                 masterless: true
+        end2end:
+            fastly:
+                subdomains:
+                    - "{instance}--cdn-gateway"
+        continuumtest:
+            fastly:
+                subdomains:
+                    - "{instance}--cdn-gateway"
         prod:
             fastly:
                 subdomains:
+                    - "{instance}--cdn-gateway"
                     - api
             cloudfront:
                 subdomains: []

--- a/projects/elife.yaml
+++ b/projects/elife.yaml
@@ -338,9 +338,9 @@ api-gateway:
             - 443
             # - 8000: # don't expose this to public. Kong uses this to proxy requests
             # - 8001: # don't ever expose to public. Kong uses this for API admin
-        fastly:
-            subdomains:
-                - "{instance}--fastly-gateway"
+            fastly:
+                subdomains:
+                    - "{instance}--cdn-gateway"
     aws-alt:
         standalone:
             # for now a copy of standalone1404
@@ -349,21 +349,13 @@ api-gateway:
             ec2:
                 ami: ami-92002785 # Ubuntu 14.04, deprecated
                 masterless: true
-        end2end:
-            cloudfront:
-                subdomains: 
-                    - "{instance}--cdn-gateway"
-                headers:
-                    - Accept
-        continuumtest:
-            cloudfront:
-                subdomains: 
-                    - "{instance}--cdn-gateway"
-                headers:
-                    - Accept
         prod:
+            fastly:
+                subdomains:
+                    - api
             cloudfront:
-                subdomains: 
+                subdomains: []
+                subdomains-without-dns: 
                     - "{instance}--cdn-gateway"
                     - api
                 headers:

--- a/src/buildercore/cfngen.py
+++ b/src/buildercore/cfngen.py
@@ -384,7 +384,7 @@ def generate_stack(pname, **more_context):
 # can't add ExtDNS: it changes dynamically when we start/stop instances and should not be touched after creation
 UPDATABLE_TITLE_PATTERNS = ['^CloudFront.*', '^ElasticLoadBalancer.*', '^EC2Instance.*', '.*Bucket$', '.*BucketPolicy', '^StackSecurityGroup$', '^ELBSecurityGroup$', '^CnameDNS.+$', 'FastlyDNS\\d+$', '^AttachedDB$', '^AttachedDBSubnet$', '^ExtraStorage.+$', '^MountPoint.+$', '^IntDNS.*$', '^ElastiCache.*$']
 
-REMOVABLE_TITLE_PATTERNS = ['^CnameDNS\\d+$', 'FastlyDNS\\d+$', '^ExtDNS$', '^ExtraStorage.+$', '^MountPoint.+$', '^.+Queue$', '^EC2Instance.+$', '^IntDNS.*$', '^ElastiCache.*$', '^.+Topic$']
+REMOVABLE_TITLE_PATTERNS = ['^CloudFront.*', '^CnameDNS\\d+$', 'FastlyDNS\\d+$', '^ExtDNS$', '^ExtraStorage.+$', '^MountPoint.+$', '^.+Queue$', '^EC2Instance.+$', '^IntDNS.*$', '^ElastiCache.*$', '^.+Topic$']
 EC2_NOT_UPDATABLE_PROPERTIES = ['ImageId', 'Tags', 'UserData']
 
 # CloudFormation is nicely chopped up into:

--- a/src/buildercore/terraform.py
+++ b/src/buildercore/terraform.py
@@ -27,10 +27,8 @@ def render(context):
                         'name': context['stackname'],
                         'port': 443,
                         'use_ssl': True,
-                        'ssl_check_cert': False # bad option
-                        # it's for minimal fuss. Before we start customizing this, a lot of the risk to be tackled
-                        # is integrating everything together with a good lifecycle for adding, modifying and removing
-                        # CDNs that point to CloudFormation-managed resources.
+                        'ssl_cert_hostname': context['full_hostname'],
+                        'ssl_check_cert': True,
                     },
                     'force_destroy': True
                 }

--- a/src/buildercore/terraform.py
+++ b/src/buildercore/terraform.py
@@ -13,17 +13,15 @@ def render(context):
     if not context['fastly']:
         return '{}'
 
-    ensure(len(context['fastly']['subdomains']) == 1, "Only 1 subdomain for Fastly CDNs is supported")
-
     tf_file = {
         'resource': {
             RESOURCE_TYPE_FASTLY: {
                 # must be unique but only in a certain context like this, use some constants
                 RESOURCE_NAME_FASTLY: {
                     'name': context['stackname'],
-                    'domain': {
-                        'name': context['fastly']['subdomains'][0],
-                    },
+                    'domain': [
+                        {'name': subdomain} for subdomain in context['fastly']['subdomains']
+                    ],
                     'backend': {
                         'address': context['full_hostname'],
                         'name': context['stackname'],

--- a/src/tests/fixtures/projects/dummy-project.yaml
+++ b/src/tests/fixtures/projects/dummy-project.yaml
@@ -311,6 +311,17 @@ project-with-fastly-minimal:
             subdomains:
                 - "{instance}--cdn-of-www"
 
+project-with-fastly-complex:
+    repo: ssh://git@github.com/elifesciences/dummy3
+    subdomain: www
+    aws:
+        ports:
+            - 80
+        fastly:
+            subdomains:
+                - "{instance}--cdn1-of-www"
+                - "{instance}--cdn2-of-www"
+
 project-with-cluster:
     repo: ssh://git@github.com/elifesciences/dummy3
     subdomain: project-with-cluster

--- a/src/tests/test_buildercore_project.py
+++ b/src/tests/test_buildercore_project.py
@@ -9,7 +9,7 @@ ALL_PROJECTS = [
     'dummy1', 'dummy2', 'dummy3',
     'just-some-sns', 'project-with-sqs', 'project-with-s3',
     'project-with-ext', 'project-with-cloudfront', 'project-with-cloudfront-minimal',
-    'project-with-cloudfront-error-pages', 'project-with-cloudfront-origins', 'project-with-fastly-minimal',
+    'project-with-cloudfront-error-pages', 'project-with-cloudfront-origins', 'project-with-fastly-minimal', 'project-with-fastly-complex',
     'project-with-cluster', 'project-with-cluster-suppressed', 'project-with-cluster-overrides', 'project-with-stickiness', 'project-with-multiple-elb-listeners',
     'project-with-cluster-integration-tests', 'project-with-db-params', 'project-with-rds-only', 'project-with-elasticache-redis', 'project-with-multiple-elasticaches', 'project-with-fully-overridden-elasticaches',
 ]

--- a/src/tests/test_buildercore_terraform.py
+++ b/src/tests/test_buildercore_terraform.py
@@ -72,7 +72,8 @@ class TestBuildercoreTerraform(base.BaseCase):
                                 'name': 'project-with-fastly-complex--prod',
                                 'port': 443,
                                 'use_ssl': True,
-                                'ssl_check_cert': False
+                                'ssl_cert_hostname': 'prod--www.example.org',
+                                'ssl_check_cert': True
                             },
                             'force_destroy': True
                         }

--- a/src/tests/test_buildercore_terraform.py
+++ b/src/tests/test_buildercore_terraform.py
@@ -34,7 +34,8 @@ class TestBuildercoreTerraform(base.BaseCase):
                                 'name': 'project-with-fastly-minimal--prod',
                                 'port': 443,
                                 'use_ssl': True,
-                                'ssl_check_cert': False
+                                'ssl_cert_hostname': 'prod--www.example.org',
+                                'ssl_check_cert': True,
                             },
                             'force_destroy': True
                         }

--- a/src/tests/test_buildercore_terraform.py
+++ b/src/tests/test_buildercore_terraform.py
@@ -26,12 +26,49 @@ class TestBuildercoreTerraform(base.BaseCase):
                         # must be unique but only in a certain context like this, use some constants
                         'fastly-cdn': {
                             'name': 'project-with-fastly-minimal--prod',
-                            'domain': {
+                            'domain': [{
                                 'name': 'prod--cdn-of-www.example.org'
-                            },
+                            }],
                             'backend': {
                                 'address': 'prod--www.example.org',
                                 'name': 'project-with-fastly-minimal--prod',
+                                'port': 443,
+                                'use_ssl': True,
+                                'ssl_check_cert': False
+                            },
+                            'force_destroy': True
+                        }
+                    }
+                },
+            },
+            data
+        )
+
+    def test_fastly_template_complex(self):
+        extra = {
+            'stackname': 'project-with-fastly-complex--prod',
+        }
+        context = cfngen.build_context('project-with-fastly-complex', **extra)
+        terraform_template = terraform.render(context)
+        data = json.loads(terraform_template)
+        self.assertEqual(
+            {
+                'resource': {
+                    'fastly_service_v1': {
+                        # must be unique but only in a certain context like this, use some constants
+                        'fastly-cdn': {
+                            'name': 'project-with-fastly-complex--prod',
+                            'domain': [
+                                {
+                                    'name': 'prod--cdn1-of-www.example.org'
+                                },
+                                {
+                                    'name': 'prod--cdn2-of-www.example.org'
+                                },
+                            ],
+                            'backend': {
+                                'address': 'prod--www.example.org',
+                                'name': 'project-with-fastly-complex--prod',
                                 'port': 443,
                                 'use_ssl': True,
                                 'ssl_check_cert': False


### PR DESCRIPTION
Already applied to every `api-gateway` where CloudFront was used.

The best pattern to do so seems to be to

1. switch the `subdomains` of `cloudfront` to `subdomains-without-dns` as that is just a DNS deletion rather than a tens-of-minutes CloudFront update. 
1. Switch the `subdomains` of `fastly` from a fake value to the real one, that had been freed by CloudFront.

The process takes a few minutes. If someone still has a cached DNS value, it will end up on CloudFront for the time being, until we retire it (should have zero traffic at that point).