### PR TITLE
fixes circular dependency issue with aws.py

### DIFF
--- a/src/askmaster.py
+++ b/src/askmaster.py
@@ -6,12 +6,12 @@ from buildercore import core
 from fabric.api import sudo, task
 from decorators import echo_output
 from buildercore.core import stack_conn
-import aws
 from buildercore.decorators import osissue
+import utils
 
 def salt_master_cmd(cmd, module='cmd.run', minions=r'\*'):
     "runs the given command on all aws instances. given command must escape double quotes"
-    with stack_conn(core.find_master(aws.find_region())):
+    with stack_conn(core.find_master(utils.find_region())):
         sudo("salt %(minions)s %(module)s %(cmd)s --timeout=30" % locals())
 
 @task

--- a/src/aws.py
+++ b/src/aws.py
@@ -1,34 +1,8 @@
 from buildercore import core
 import utils
 from decorators import requires_aws_stack, debugtask, echo_output
-from buildercore.core import MultipleRegionsError
-
 import logging
 LOG = logging.getLogger(__name__)
-
-def find_region(stackname=None):
-    """tries to find the region, but falls back to user input if there are multiple regions available.
-
-    Uses stackname, if provided, to filter the available regions"""
-    try:
-        return core.find_region(stackname)
-    except MultipleRegionsError as e:
-        print("many possible regions found!")
-        return utils._pick('region', e.regions())
-
-def stack_list(region=None):
-    "returns a list of realized stacks. does not include deleted stacks"
-    if not region:
-        region = find_region()
-    return core.active_stack_names(region)
-
-#
-#
-#
-
-#
-#
-#
 
 @debugtask
 @requires_aws_stack
@@ -45,7 +19,7 @@ def rds_snapshots(stackname):
 @debugtask
 @echo_output
 def detailed_stack_list(project=None):
-    region = find_region()
+    region = utils.find_region()
     results = core.active_aws_stacks(region, formatter=None)
     all_stacks = dict([(i.stack_name, vars(i)) for i in results])
     if project:

--- a/src/cfn.py
+++ b/src/cfn.py
@@ -6,7 +6,7 @@ from fabric.api import task, local, run, sudo, put, get, abort, settings
 import fabric.exceptions
 import fabric.state
 from fabric.contrib import files
-import aws, utils, buildvars
+import utils, buildvars
 from decorators import requires_project, requires_aws_stack, requires_steady_stack, echo_output, setdefault, debugtask, timeit
 from buildercore import core, cfngen, utils as core_utils, bootstrap, project, checks, lifecycle as core_lifecycle, context_handler
 from buildercore.concurrency import concurrency_for
@@ -122,7 +122,7 @@ def update_infrastructure(stackname):
 # TODO: deprecated, this task now lives in `master.py`
 @debugtask
 def update_master():
-    master_stackname = core.find_master(aws.find_region())
+    master_stackname = core.find_master(utils.find_region())
     bootstrap.update_stack(master_stackname, service_list=[
         'ec2' # master-server should be a self-contained EC2 instance
     ])
@@ -214,7 +214,7 @@ def pillar(stackname):
 @echo_output
 def aws_stack_list():
     "returns a list of realized stacks. does not include deleted stacks"
-    region = aws.find_region()
+    region = utils.find_region()
     return core.active_stack_names(region)
 
 def _pick_node(instance_list, node):

--- a/src/decorators.py
+++ b/src/decorators.py
@@ -70,7 +70,7 @@ def requires_aws_project_stack(*plist):
     def wrap1(func):
         @wraps(func)
         def _wrapper(stackname=None, *args, **kwargs):
-            region = aws.find_region(stackname)
+            region = utils.find_region(stackname)
             asl = core.active_stack_names(region)
             if not asl:
                 print('\nno AWS stacks exist, cannot continue.')
@@ -91,7 +91,7 @@ def requires_aws_stack(func):
     @wraps(func)
     def call(*args, **kwargs):
         stackname = first(args) or os.environ.get('INSTANCE')
-        region = aws.find_region(stackname)
+        region = utils.find_region(stackname)
         if stackname:
             args = args[1:]
             return func(stackname, *args, **kwargs)
@@ -107,7 +107,7 @@ def requires_aws_stack(func):
 def requires_steady_stack(func):
     @wraps(func)
     def call(*args, **kwargs):
-        ss = core.steady_aws_stacks(aws.find_region())
+        ss = core.steady_aws_stacks(utils.find_region())
         keys = lmap(first, ss)
         idx = dict(zip(keys, ss))
         helpfn = lambda pick: idx[pick][1]
@@ -160,8 +160,3 @@ def echo_output(func):
             return res
         return func(*args, **kwargs)
     return _wrapper
-
-
-# avoid circular dependencies.
-# TODO: this is a design smell. refactor.
-import aws

--- a/src/fabfile.py
+++ b/src/fabfile.py
@@ -9,7 +9,6 @@ PROJECT_DIR = os.path.dirname(SRC_DIR)    # elife-builder/
 
 from cfn import *
 
-# aws tasks are not working for some reason.. possibly circular dependency
 import aws
 import metrics
 import tasks

--- a/src/master.py
+++ b/src/master.py
@@ -3,7 +3,7 @@
 See `askmaster.py` for tasks that are run on minions."""
 
 import os, time
-import aws, buildvars, utils
+import buildvars, utils
 from fabric.api import sudo, local
 from buildercore import core, bootstrap, config, keypair, project, cfngen, context_handler
 from buildercore.utils import lmap, exsubdict, mkidx
@@ -16,7 +16,7 @@ LOG = logging.getLogger(__name__)
 @debugtask
 def update(master_stackname=None):
     "same as `cfn.update` but also removes any orphaned minion keys"
-    master_stackname = master_stackname or core.find_master(aws.find_region())
+    master_stackname = master_stackname or core.find_master(utils.find_region())
     bootstrap.update_stack(master_stackname, service_list=[
         'ec2' # master-server should be a self-contained EC2 instance
     ])
@@ -82,7 +82,7 @@ def server_access():
 @echo_output
 def aws_update_many_projects(pname_list):
     minions = ' or '.join([pname + "-*" for pname in pname_list])
-    region = aws.find_region()
+    region = utils.find_region()
     with core.stack_conn(core.find_master(region)):
         sudo("salt -C '%s' state.highstate --retcode-passthrough" % minions)
 
@@ -168,7 +168,7 @@ def update_salt(stackname):
 @debugtask
 def update_salt_master(region=None):
     "update the version of Salt installed on the master-server."
-    region = region or aws.find_region()
+    region = region or utils.find_region()
     current_master_stackname = core.find_master(region)
     return remaster(current_master_stackname, current_master_stackname)
 
@@ -200,7 +200,7 @@ def remaster_all(new_master_stackname):
     pname_list = sorted(ec2stacks.keys()) # lets do this alphabetically
 
     # only update ec2 instances in the same region as the new master
-    region = aws.find_region(new_master_stackname)
+    region = utils.find_region(new_master_stackname)
     active_stacks = core.active_stack_names(region)
     stack_idx = mkidx(lambda v: core.parse_stackname(v)[0], active_stacks)
 

--- a/src/utils.py
+++ b/src/utils.py
@@ -1,7 +1,7 @@
 import os, sys
 from buildercore.utils import second, last, gtpy2
-from buildercore.decorators import osissue
 from fabric.api import local
+from buildercore import core
 
 # totally is assigned :(
 # pylint: disable=global-variable-not-assigned
@@ -40,7 +40,6 @@ def get_input(message):
     fn = input if gtpy2() else raw_input
     return fn(message)
 
-@osissue("renamed from `_pick` to something. `choose` ?")
 def _pick(name, pick_list, default_file=None, helpfn=None, message='please pick:'):
     default = None
     if default_file:
@@ -118,3 +117,12 @@ def table(rows, keys):
     for row in rows:
         lines.append(', '.join([getattr(row, key) for key in keys]))
     return "\n".join(lines)
+
+def find_region(stackname=None):
+    """tries to find the region, but falls back to user input if there are multiple regions available.
+    Uses stackname, if provided, to filter the available regions"""
+    try:
+        return core.find_region(stackname)
+    except core.MultipleRegionsError as e:
+        print("many possible regions found!")
+        return _pick('region', e.regions())


### PR DESCRIPTION
aws.find_region has been shifted into utils.
aws.py is probably a deletion candidate

a tiny peace offering in lieu of the gigantic boto3 port coming up.