### PR TITLE
Add fastly to iiif, incremental rollout

### DIFF
--- a/projects/elife.yaml
+++ b/projects/elife.yaml
@@ -1487,6 +1487,9 @@ iiif:
                     - "{instance}--cdn-iiif"
                 headers:
                     - Host
+            fastly:
+                subdomains-without-dns:
+                    - "{instance}--cdn-iiif"
         # manual tests
         continuumtest:
             ports:

--- a/projects/elife.yaml
+++ b/projects/elife.yaml
@@ -129,7 +129,7 @@ defaults:
         fastly:
             # fastly defaults only used if a 'fastly' section present in project
             subdomains: []
-            subdomains-without-dns:
+            subdomains-without-dns: []
             dns:
                 cname: u2.shared.global.fastly.net
         subdomains: []

--- a/projects/elife.yaml
+++ b/projects/elife.yaml
@@ -116,6 +116,7 @@ defaults:
         s3: {}
         cloudfront: 
             # cloudfront defaults only used if a 'cloudfront' section present in project
+            subdomains: []
             subdomains-without-dns: []
             domains: []
             origins: {}
@@ -1483,12 +1484,12 @@ iiif:
                 healthcheck:
                     path: /
             cloudfront:
-                subdomains: 
+                subdomains-without-dns: 
                     - "{instance}--cdn-iiif"
                 headers:
                     - Host
             fastly:
-                subdomains-without-dns:
+                subdomains:
                     - "{instance}--cdn-iiif"
         # manual tests
         continuumtest:

--- a/projects/elife.yaml
+++ b/projects/elife.yaml
@@ -1527,11 +1527,18 @@ iiif:
                 healthcheck:
                     path: /
             cloudfront:
-                subdomains: 
+                subdomains-without-dns:
                     - "{instance}--cdn-iiif"
+                subdomains:
+                    - "{instance}--placeholder-iiif"
                     - iiif
                 headers:
                     - Host
+            fastly:
+                subdomains:
+                    - "{instance}--cdn-iiif"
+                subdomains-without-dns:
+                    - iiif
     vagrant:
         box: ubuntu/trusty64 # Ubuntu 14.04, deprecated
         ports:

--- a/projects/elife.yaml
+++ b/projects/elife.yaml
@@ -1509,6 +1509,9 @@ iiif:
                     - "{instance}--cdn-iiif"
                 headers:
                     - Host
+            fastly:
+                subdomains-without-dns:
+                    - "{instance}--cdn-iiif"
         prod:
             ports:
                 - 22

--- a/projects/elife.yaml
+++ b/projects/elife.yaml
@@ -1505,12 +1505,12 @@ iiif:
                 healthcheck:
                     path: /
             cloudfront:
-                subdomains: 
+                subdomains-without-dns: 
                     - "{instance}--cdn-iiif"
                 headers:
                     - Host
             fastly:
-                subdomains-without-dns:
+                subdomains:
                     - "{instance}--cdn-iiif"
         prod:
             ports:

--- a/projects/elife.yaml
+++ b/projects/elife.yaml
@@ -129,6 +129,7 @@ defaults:
         fastly:
             # fastly defaults only used if a 'fastly' section present in project
             subdomains: []
+            subdomains-without-dns:
             dns:
                 cname: u2.shared.global.fastly.net
         subdomains: []

--- a/src/buildercore/cfngen.py
+++ b/src/buildercore/cfngen.py
@@ -349,7 +349,6 @@ def more_validation(json_template_str):
 #
 #
 
-# TODO: shift this into testing and make each validation call a subTest
 def validate_project(pname, **extra):
     """validates all of project's possible cloudformation templates.
     only called during testing"""

--- a/src/buildercore/cfngen.py
+++ b/src/buildercore/cfngen.py
@@ -259,8 +259,7 @@ def build_context_fastly(context, parameterize):
     if 'fastly' in context['project']['aws']:
         context['fastly'] = {
             'subdomains': [build_subdomain(x) for x in context['project']['aws']['fastly']['subdomains']],
-            # future use
-            'subdomains-without-dns': [],
+            'subdomains-without-dns': [build_subdomain(x) for x in context['project']['aws']['fastly']['subdomains-without-dns']],
             'dns': context['project']['aws']['fastly']['dns'],
         }
     else:

--- a/src/buildercore/terraform.py
+++ b/src/buildercore/terraform.py
@@ -58,7 +58,7 @@ def init(stackname):
 
 @only_if('fastly')
 def update(stackname, context):
-    ensure('FASTLY_API_KEY' in os.environ, "a FASTLY_API_KEY environment variable is required to provision Fastly resources", ConfigurationError)
+    ensure('FASTLY_API_KEY' in os.environ, "a FASTLY_API_KEY environment variable is required to provision Fastly resources. See https://manage.fastly.com/account/personal/tokens", ConfigurationError)
     terraform = init(stackname)
     terraform.apply(input=False, capture_output=False, raise_on_error=True)
 

--- a/src/buildercore/terraform.py
+++ b/src/buildercore/terraform.py
@@ -13,6 +13,7 @@ def render(context):
     if not context['fastly']:
         return '{}'
 
+    all_allowed_subdomains = context['fastly']['subdomains'] + context['fastly']['subdomains-without-dns']
     tf_file = {
         'resource': {
             RESOURCE_TYPE_FASTLY: {
@@ -20,7 +21,7 @@ def render(context):
                 RESOURCE_NAME_FASTLY: {
                     'name': context['stackname'],
                     'domain': [
-                        {'name': subdomain} for subdomain in context['fastly']['subdomains']
+                        {'name': subdomain} for subdomain in all_allowed_subdomains
                     ],
                     'backend': {
                         'address': context['full_hostname'],

--- a/src/integration_tests/test_validation.py
+++ b/src/integration_tests/test_validation.py
@@ -22,6 +22,10 @@ class TestValidation(base.BaseCase):
         self.switch_out_test_settings()
 
         for pname in project.aws_projects().keys():
+            # TODO: subTest doesn't work very well here because there's no way to filter a single pname when re-running after a failure
+            # a solution like
+            # https://github.com/elifesciences/elife-spectrum/blob/master/spectrum/test_article.py#L15-L19
+            # could help, but require to run tests with pytest only
             with self.subTest(pname):
                 cfngen.validate_project(pname)
 

--- a/src/tests/fixtures/projects/dummy-project.yaml
+++ b/src/tests/fixtures/projects/dummy-project.yaml
@@ -94,6 +94,7 @@ defaults:
         fastly:
             # fastly defaults only used if a 'fastly' section present in project
             subdomains: []
+            subdomains-without-dns: []
             dns:
                 cname: something.fastly.net
         subdomains: []
@@ -321,6 +322,8 @@ project-with-fastly-complex:
             subdomains:
                 - "{instance}--cdn1-of-www"
                 - "{instance}--cdn2-of-www"
+            subdomains-without-dns:
+                - "future"
 
 project-with-cluster:
     repo: ssh://git@github.com/elifesciences/dummy3

--- a/src/tests/test_buildercore_terraform.py
+++ b/src/tests/test_buildercore_terraform.py
@@ -1,5 +1,6 @@
 import json  # , yaml
 import os
+import yaml
 from os.path import join
 from . import base
 from buildercore import cfngen, terraform
@@ -18,7 +19,7 @@ class TestBuildercoreTerraform(base.BaseCase):
         }
         context = cfngen.build_context('project-with-fastly-minimal', **extra)
         terraform_template = terraform.render(context)
-        data = json.loads(terraform_template)
+        data = self._parse_template(terraform_template)
         self.assertEqual(
             {
                 'resource': {
@@ -51,7 +52,7 @@ class TestBuildercoreTerraform(base.BaseCase):
         }
         context = cfngen.build_context('project-with-fastly-complex', **extra)
         terraform_template = terraform.render(context)
-        data = json.loads(terraform_template)
+        data = self._parse_template(terraform_template)
         self.assertEqual(
             {
                 'resource': {
@@ -82,3 +83,7 @@ class TestBuildercoreTerraform(base.BaseCase):
             },
             data
         )
+
+    def _parse_template(self, terraform_template):
+        """use yaml to load JSON due to https://stackoverflow.com/a/16373377/91590"""
+        return yaml.safe_load(terraform_template)

--- a/src/tests/test_buildercore_terraform.py
+++ b/src/tests/test_buildercore_terraform.py
@@ -67,6 +67,9 @@ class TestBuildercoreTerraform(base.BaseCase):
                                 {
                                     'name': 'prod--cdn2-of-www.example.org'
                                 },
+                                {
+                                    'name': 'future.example.org'
+                                },
                             ],
                             'backend': {
                                 'address': 'prod--www.example.org',

--- a/src/tests/test_buildercore_terraform.py
+++ b/src/tests/test_buildercore_terraform.py
@@ -87,5 +87,7 @@ class TestBuildercoreTerraform(base.BaseCase):
         )
 
     def _parse_template(self, terraform_template):
-        """use yaml to load JSON due to https://stackoverflow.com/a/16373377/91590"""
+        """use yaml module to load JSON to avoid large u'foo' vs 'foo' string diffs
+        
+        https://stackoverflow.com/a/16373377/91590"""
         return yaml.safe_load(terraform_template)

--- a/src/tests/test_buildercore_terraform.py
+++ b/src/tests/test_buildercore_terraform.py
@@ -1,4 +1,3 @@
-import json  # , yaml
 import os
 import yaml
 from os.path import join

--- a/src/tests/test_buildercore_terraform.py
+++ b/src/tests/test_buildercore_terraform.py
@@ -88,6 +88,5 @@ class TestBuildercoreTerraform(base.BaseCase):
 
     def _parse_template(self, terraform_template):
         """use yaml module to load JSON to avoid large u'foo' vs 'foo' string diffs
-        
         https://stackoverflow.com/a/16373377/91590"""
         return yaml.safe_load(terraform_template)


### PR DESCRIPTION
Will only affect `iiif--end2end`, adding an unused Fastly CDN alongside the current CloudFront one.
First attempt failed because the instance was turned off (unrelated CloudFormation woes), will do it correctly tomorrow with locking.