### PR TITLE
[WIP] ELPP-3598 Enable Fastly GZIPping

### DIFF
--- a/src/buildercore/terraform.py
+++ b/src/buildercore/terraform.py
@@ -31,6 +31,9 @@ def render(context):
                         'ssl_cert_hostname': context['full_hostname'],
                         'ssl_check_cert': True,
                     },
+                    'gzip': {
+                        'name': context['stackname'],
+                    },
                     'force_destroy': True
                 }
             }

--- a/src/tests/test_buildercore_terraform.py
+++ b/src/tests/test_buildercore_terraform.py
@@ -37,6 +37,9 @@ class TestBuildercoreTerraform(base.BaseCase):
                                 'ssl_cert_hostname': 'prod--www.example.org',
                                 'ssl_check_cert': True,
                             },
+                            'gzip': {
+                                'name': 'project-with-fastly-minimal--prod',
+                            },
                             'force_destroy': True
                         }
                     }
@@ -74,6 +77,9 @@ class TestBuildercoreTerraform(base.BaseCase):
                                 'use_ssl': True,
                                 'ssl_cert_hostname': 'prod--www.example.org',
                                 'ssl_check_cert': True
+                            },
+                            'gzip': {
+                                'name': 'project-with-fastly-complex--prod',
                             },
                             'force_destroy': True
                         }


### PR DESCRIPTION
Need to test whether https://github.com/terraform-providers/terraform-provider-fastly/issues/66 happens.

The API also has lots of custom content types (eg `application/vnd.elife.article-vor+json;version=1`) which won't be included currently, but according https://docs.fastly.com/guides/basic-configuration/enabling-automatic-gzipping we can't use regex here. Ideally anything `+json` would be included.

/cc @giorgiosironi 