### PR TITLE
ELPP-3598 Force SSL in Fastly

### DIFF
--- a/src/buildercore/terraform.py
+++ b/src/buildercore/terraform.py
@@ -31,6 +31,10 @@ def render(context):
                         'ssl_cert_hostname': context['full_hostname'],
                         'ssl_check_cert': True,
                     },
+                    'request_setting': {
+                        'name': 'default',
+                        'force_ssl': True,
+                    },
                     'force_destroy': True
                 }
             }

--- a/src/buildercore/terraform.py
+++ b/src/buildercore/terraform.py
@@ -34,6 +34,11 @@ def render(context):
                     'request_setting': {
                         'name': 'default',
                         'force_ssl': True,
+                        # shouldn't need to replicate the defaults
+                        # https://github.com/terraform-providers/terraform-provider-fastly/issues/50
+                        # https://github.com/terraform-providers/terraform-provider-fastly/issues/67
+                        'timer_support': True,
+                        'xff': 'leave',
                     },
                     'force_destroy': True
                 }

--- a/src/tests/test_buildercore_terraform.py
+++ b/src/tests/test_buildercore_terraform.py
@@ -37,6 +37,10 @@ class TestBuildercoreTerraform(base.BaseCase):
                                 'ssl_cert_hostname': 'prod--www.example.org',
                                 'ssl_check_cert': True,
                             },
+                            'request_setting': {
+                                'name': 'default',
+                                'force_ssl': True,
+                            },
                             'force_destroy': True
                         }
                     }
@@ -74,6 +78,10 @@ class TestBuildercoreTerraform(base.BaseCase):
                                 'use_ssl': True,
                                 'ssl_cert_hostname': 'prod--www.example.org',
                                 'ssl_check_cert': True
+                            },
+                            'request_setting': {
+                                'name': 'default',
+                                'force_ssl': True,
                             },
                             'force_destroy': True
                         }

--- a/src/tests/test_buildercore_terraform.py
+++ b/src/tests/test_buildercore_terraform.py
@@ -40,6 +40,8 @@ class TestBuildercoreTerraform(base.BaseCase):
                             'request_setting': {
                                 'name': 'default',
                                 'force_ssl': True,
+                                'timer_support': True,
+                                'xff': 'leave',
                             },
                             'force_destroy': True
                         }
@@ -82,6 +84,8 @@ class TestBuildercoreTerraform(base.BaseCase):
                             'request_setting': {
                                 'name': 'default',
                                 'force_ssl': True,
+                                'timer_support': True,
+                                'xff': 'leave',
                             },
                             'force_destroy': True
                         }


### PR DESCRIPTION
Seems to also set `xff` to `append`, probably the Fastly default too.