### PR TITLE
Read CUSTOM_SSH_KEY also for EC2 access

### DIFF
--- a/docs/ssh-key.md
+++ b/docs/ssh-key.md
@@ -1,12 +1,32 @@
 # custom ssh key
 
+## Default
+
 builder relies on a keypair (private and public key) being present at `~/.ssh/id_rsa` and `~/.ssh/id_rsa.pub`.
 
-If you with to use a different path, specify the private key path as the CUSTOM_SSH_KEY environment variable in your vagrant commands:
+If you with to use a different path, specify the private key path as the CUSTOM_SSH_KEY environment variable in your commands:
 
 ```
 CUSTOM_SSH_KEY=~/.ssh/my_key ./update.sh
-CUSTOM_SSH_KEY=~/.ssh/my_key vagrant up
 ```
 
 The corresponding public key, which is used to access the virtual machine through SSH, is assumed to be at `${CUSTOM_SSH_KEY}.pub`.
+
+## Vagrant
+
+Vagrant will use your private key to authenticate with Github and checkout repositories through the SSH protocol
+
+```
+CUSTOM_SSH_KEY=~/.ssh/my_key vagrant up
+CUSTOM_SSH_KEY=~/.ssh/my_key vagrant provisioning
+```
+
+## EC2
+
+builder mainly interacts with EC2 through a custom key kept in `.cfn/keypairs`, which is synchronized using the state S3 bucket.
+
+The `./bldr ssh` command allows the user to open an interactive SSH session on a node, and will use the user's key. It accepts `CUSTOM_SSH_KEY`:
+
+```
+CUSTOM_SSH_KEY=~/.ssh/my_key ./bldr ssh
+```

--- a/src/buildercore/config.py
+++ b/src/buildercore/config.py
@@ -131,6 +131,7 @@ if 'SETTINGS_FILE' in os.environ:
 else:
     SETTINGS_FILE = join(PROJECT_PATH, 'settings.yml')
 
+USER_PRIVATE_KEY = os.environ.get('CUSTOM_SSH_KEY', '~/.ssh/id_rsa')
 
 #
 # logic

--- a/src/cfn.py
+++ b/src/cfn.py
@@ -12,7 +12,7 @@ from buildercore import core, cfngen, utils as core_utils, bootstrap, project, c
 from buildercore.concurrency import concurrency_for
 from buildercore.core import stack_conn, stack_pem, stack_all_ec2_nodes
 from buildercore.decorators import PredicateException
-from buildercore.config import DEPLOY_USER, BOOTSTRAP_USER, FabricException
+from buildercore.config import DEPLOY_USER, BOOTSTRAP_USER, USER_PRIVATE_KEY, FabricException
 from buildercore.utils import lmap
 
 import logging
@@ -283,7 +283,7 @@ def ssh(stackname, node=None, username=DEPLOY_USER):
     if not instances:
         return
     public_ip = _pick_node(instances, node).ip_address
-    _interactive_ssh("ssh %s@%s" % (username, public_ip))
+    _interactive_ssh("ssh %s@%s -i %s" % (username, public_ip, USER_PRIVATE_KEY))
 
 @task
 @requires_aws_stack


### PR DESCRIPTION
Would have put it into `settings.yml` as a user setting to specify only once, but that isn't read by the Vagrantfile which uses this environment variable.