### PR TITLE
Run tests in parallel

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -7,6 +7,7 @@ show_missing = false
 precision = 0
 exclude_lines = true
 omit =
+    */src/integration_tests/*
     */src/tests/*
     */venv/*
     */.tox/*

--- a/.coveragerc
+++ b/.coveragerc
@@ -7,5 +7,6 @@ show_missing = false
 precision = 0
 exclude_lines = true
 omit =
+    */src/tests/*
     */venv/*
     */.tox/*

--- a/.run-tests-ci.sh
+++ b/.run-tests-ci.sh
@@ -12,7 +12,6 @@ fi
 echo "Running tests"
 export PYTHONPATH="src"
 pytest \
-    --cov=src \
     -n 4 \
     -s \
     --junitxml=build/pytest-$envname.xml \

--- a/.run-tests-ci.sh
+++ b/.run-tests-ci.sh
@@ -13,6 +13,7 @@ echo "Running tests"
 export PYTHONPATH="src"
 pytest \
     -n 4 \
+    --dist=loadscope \
     -s \
     --junitxml=build/pytest-$envname.xml \
     src/tests src/integration_tests

--- a/.run-tests-ci.sh
+++ b/.run-tests-ci.sh
@@ -11,15 +11,20 @@ fi
 
 echo "Running tests"
 export PYTHONPATH="src"
+if [ "$envname" = "py27" ]; then
+    coverage_options="--cov-config=.coveragerc --cov-report= --cov=src"
+else
+    coverage_options=
+fi
 pytest \
-    --cov-config=.coveragerc \
-    --cov-report= \
-    --cov=src \
+    $coverage_options
     -n 4 \
     --dist=loadscope \
     -s \
-    --junitxml=build/pytest-$envname.xml \
+    --junitxml="build/pytest-$envname.xml" \
     src/tests src/integration_tests
 
-echo "Checking coverage report"
-coverage report --fail-under=50
+if [ ! -z "$coverage_options" ]; then
+    echo "Checking coverage report"
+    coverage report --fail-under=50
+fi

--- a/.run-tests-ci.sh
+++ b/.run-tests-ci.sh
@@ -26,5 +26,5 @@ pytest \
 
 if [ ! -z "$coverage_options" ]; then
     echo "Checking coverage report"
-    coverage report --fail-under=50
+    coverage report --fail-under=69
 fi

--- a/.run-tests-ci.sh
+++ b/.run-tests-ci.sh
@@ -9,6 +9,7 @@ if [ -z "$envname" ]; then
     exit 1
 fi
 
+echo "Running tests"
 export PYTHONPATH="src"
 pytest \
     --cov=src \
@@ -17,4 +18,5 @@ pytest \
     --junitxml=build/pytest-$envname.xml \
     src/tests src/integration_tests
 
+echo "Checking coverage report"
 coverage report --fail-under=67

--- a/.run-tests-ci.sh
+++ b/.run-tests-ci.sh
@@ -12,7 +12,7 @@ fi
 export PYTHONPATH="src"
 pytest \
     --cov=src \
-    -n 2 \
+    -n 4 \
     -s \
     --junitxml=build/pytest-$envname.xml \
     src/tests src/integration_tests

--- a/.run-tests-ci.sh
+++ b/.run-tests-ci.sh
@@ -12,6 +12,9 @@ fi
 echo "Running tests"
 export PYTHONPATH="src"
 pytest \
+    --cov-config=.coveragerc \
+    --cov-report= \
+    --cov=src \
     -n 4 \
     --dist=loadscope \
     -s \

--- a/.run-tests-ci.sh
+++ b/.run-tests-ci.sh
@@ -18,4 +18,4 @@ pytest \
     src/tests src/integration_tests
 
 echo "Checking coverage report"
-coverage report --fail-under=67
+coverage report --fail-under=50

--- a/.run-tests-ci.sh
+++ b/.run-tests-ci.sh
@@ -17,7 +17,7 @@ else
     coverage_options=
 fi
 pytest \
-    $coverage_options
+    $coverage_options \
     -n 4 \
     --dist=loadscope \
     -s \

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -23,9 +23,11 @@ elifePipeline {
 
     lock('builder') {
         def pythons = ['py27', 'py35']
+        def majorVersions = [2, 3]
         def actions = [:]
         for (int i = 0; i < pythons.size(); i++) {
             def python = pythons.get(i)
+            def majorVersion = majorVersions.get(i)
             actions["Test ${python}"] = {
                 withCommitStatus({
                     try {
@@ -35,37 +37,18 @@ elifePipeline {
                     }
                 }, python, commit)
             }
+
+            actions["Docker ${python}"] = {
+                withCommitStatus({
+                    node('containers-jenkins-plugin') {
+                        checkout scm
+                        sh "./docker-smoke.sh ${majorVersion}"
+                    }
+                }, "docker-${python}", commit)
+            }
         }
-        // currently unstable due to CloudFormation rate limiting
-        //parallel actions
-        stage "Test py27", {
-            def py2Actions = [
-                'host': { actions["Test py27"]() },
-                'docker': {
-                    withCommitStatus({
-                        node('containers-jenkins-plugin') {
-                            checkout scm
-                            sh './docker-smoke.sh 2'
-                        }
-                    }, 'docker-py27', commit)
-                }
-            ]
-            parallel py2Actions
-        }
-        stage "Test py35", {
-            def py3Actions = [
-                'host': { actions["Test py35"]() },
-                'docker': {
-                    withCommitStatus({
-                        node('containers-jenkins-plugin') {
-                            checkout scm
-                            sh './docker-smoke.sh 3'
-                        }
-                    }, 'docker-py27', commit)
-                }
-            ]
-            parallel py3Actions
-        }
+
+        parallel actions
     }
 
     elifeMainlineOnly {

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -34,7 +34,7 @@ elifePipeline {
                         sh "tox -e ${python}"
                     } finally {
                         // https://issues.jenkins-ci.org/browse/JENKINS-27395?focusedCommentId=345589&page=com.atlassian.jira.plugin.system.issuetabpanels%3Acomment-tabpanel#comment-345589
-                        junit testResults: 'build/pytest-${python}.xml'
+                        junit testResults: "build/pytest-${python}.xml"
                     }
                 }, python, commit)
             }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -33,7 +33,8 @@ elifePipeline {
                     try {
                         sh "tox -e ${python}"
                     } finally {
-                        step([$class: "JUnitResultArchiver", testResults: "build/pytest-${python}.xml"])
+                        // https://issues.jenkins-ci.org/browse/JENKINS-27395?focusedCommentId=345589&page=com.atlassian.jira.plugin.system.issuetabpanels%3Acomment-tabpanel#comment-345589
+                        junit testResults: 'build/pytest-${python}.xml'
                     }
                 }, python, commit)
             }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -49,7 +49,9 @@ elifePipeline {
             }
         }
 
-        parallel actions
+        stage 'Project tests', {
+            parallel actions
+        }
     }
 
     elifeMainlineOnly {

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,0 +1,2 @@
+[pytest]
+addopts = -s

--- a/src/buildercore/config.py
+++ b/src/buildercore/config.py
@@ -97,7 +97,8 @@ ROOTLOG.addHandler(FILE_HANDLER)
 
 LOG = logging.getLogger(__name__)
 logging.getLogger('paramiko.transport').setLevel(logging.ERROR)
-logging.getLogger('botocore.vendored').setLevel(logging.ERROR)
+# TODO: leave on for FILE_HANDLER but not for CONSOLE_HANDLER
+#logging.getLogger('botocore.vendored').setLevel(logging.ERROR)
 
 def get_logger(name):
     "ensures logging is setup before handing out a Logger object to use"

--- a/src/buildercore/config.py
+++ b/src/buildercore/config.py
@@ -81,19 +81,19 @@ ROOTLOG = logging.getLogger() # important! this is the *root LOG*
 ROOTLOG.setLevel(logging.DEBUG) # *default* output level for all LOGs
 
 # StreamHandler sends to stderr by default
-H1 = logging.StreamHandler()
-H1.setLevel(logging.INFO) # output level for *this handler*
-H1.setFormatter(CONSOLE_FORMAT)
+CONSOLE_HANDLER = logging.StreamHandler()
+CONSOLE_HANDLER.setLevel(logging.INFO) # output level for *this handler*
+CONSOLE_HANDLER.setFormatter(CONSOLE_FORMAT)
 
 
 # FileHandler sends to a named file
-H2 = logging.FileHandler(LOG_FILE)
+FILE_HANDLER = logging.FileHandler(LOG_FILE)
 _log_level = os.environ.get('LOG_LEVEL_FILE', 'INFO')
-H2.setLevel(getattr(logging, _log_level))
-H2.setFormatter(FORMAT)
+FILE_HANDLER.setLevel(getattr(logging, _log_level))
+FILE_HANDLER.setFormatter(FORMAT)
 
-ROOTLOG.addHandler(H1)
-ROOTLOG.addHandler(H2)
+ROOTLOG.addHandler(CONSOLE_HANDLER)
+ROOTLOG.addHandler(FILE_HANDLER)
 
 LOG = logging.getLogger(__name__)
 logging.getLogger('paramiko.transport').setLevel(logging.ERROR)

--- a/src/buildercore/config.py
+++ b/src/buildercore/config.py
@@ -99,6 +99,10 @@ LOG = logging.getLogger(__name__)
 logging.getLogger('paramiko.transport').setLevel(logging.ERROR)
 logging.getLogger('botocore.vendored').setLevel(logging.ERROR)
 
+def get_logger(name):
+    "ensures logging is setup before handing out a Logger object to use"
+    return logging.getLogger(name)
+
 #
 # remote
 #

--- a/src/buildercore/config.py
+++ b/src/buildercore/config.py
@@ -98,7 +98,7 @@ ROOTLOG.addHandler(FILE_HANDLER)
 LOG = logging.getLogger(__name__)
 logging.getLogger('paramiko.transport').setLevel(logging.ERROR)
 # TODO: leave on for FILE_HANDLER but not for CONSOLE_HANDLER
-#logging.getLogger('botocore.vendored').setLevel(logging.ERROR)
+# logging.getLogger('botocore.vendored').setLevel(logging.ERROR)
 
 def get_logger(name):
     "ensures logging is setup before handing out a Logger object to use"

--- a/src/buildercore/config.py
+++ b/src/buildercore/config.py
@@ -97,6 +97,7 @@ ROOTLOG.addHandler(H2)
 
 LOG = logging.getLogger(__name__)
 logging.getLogger('paramiko.transport').setLevel(logging.ERROR)
+logging.getLogger('botocore.vendored').setLevel(logging.ERROR)
 
 #
 # remote

--- a/src/conftest.py
+++ b/src/conftest.py
@@ -1,4 +1,8 @@
+import logging
 import pytest
+import buildercore.config
+
+LOG = logging.getLogger("conftest")
 
 def pytest_addoption(parser):
     parser.addoption("--filter-project-name",
@@ -9,3 +13,9 @@ def pytest_addoption(parser):
 @pytest.fixture
 def filter_project_name(request):
     return request.config.getoption('--filter-project-name')
+
+def pytest_runtest_setup(item):
+    LOG.info("Setting up %s::%s", item.cls, item.name)
+
+def pytest_runtest_teardown(item, nextitem):
+    LOG.info("Tearing down up %s::%s", item.cls, item.name)

--- a/src/conftest.py
+++ b/src/conftest.py
@@ -1,5 +1,8 @@
+import logging
 import pytest
-from buildercore.config import get_logger
+from buildercore.config import get_logger, CONSOLE_HANDLER
+
+CONSOLE_HANDLER.setLevel(logging.CRITICAL)
 
 LOG = get_logger("conftest")
 

--- a/src/conftest.py
+++ b/src/conftest.py
@@ -1,8 +1,7 @@
-import logging
 import pytest
-import buildercore.config
+from buildercore.config import get_logger
 
-LOG = logging.getLogger("conftest")
+LOG = get_logger("conftest")
 
 def pytest_addoption(parser):
     parser.addoption("--filter-project-name",

--- a/src/integration_tests/test_provisioning.py
+++ b/src/integration_tests/test_provisioning.py
@@ -10,7 +10,7 @@ import logging
 
 logging.disable(logging.NOTSET) # re-enables logging during integration testing
 
-class TestProvisioning(base.BaseCase):
+class TestProvisioning(base.BaseIntegrationCase):
     def setUp(self):
         self.stacknames = []
         self.environment = base.generate_environment_name()

--- a/src/integration_tests/test_provisioning.py
+++ b/src/integration_tests/test_provisioning.py
@@ -49,10 +49,6 @@ class TestProvisioning(base.BaseIntegrationCase):
             buildvars.switch_revision(stackname, 'master')
             buildvars.force(stackname, 'answer', 'forty-two')
 
-            # TODO: remove as it is tested separately?
-            lifecycle.stop(stackname)
-            lifecycle.start(stackname)
-
             cfn.cmd(stackname, "ls -l /", username=BOOTSTRAP_USER, concurrency='parallel')
             cfn.cmd(stackname, "ls -l /", username=BOOTSTRAP_USER, concurrency='parallel', node=1)
 

--- a/src/integration_tests/test_provisioning.py
+++ b/src/integration_tests/test_provisioning.py
@@ -49,6 +49,7 @@ class TestProvisioning(base.BaseIntegrationCase):
             buildvars.switch_revision(stackname, 'master')
             buildvars.force(stackname, 'answer', 'forty-two')
 
+            # TODO: remove as it is tested separately?
             lifecycle.stop(stackname)
             lifecycle.start(stackname)
 

--- a/src/integration_tests/test_with_instance.py
+++ b/src/integration_tests/test_with_instance.py
@@ -16,11 +16,11 @@ class TestWithInstance(base.BaseIntegrationCase):
     @classmethod
     def setUpClass(cls):
         super(TestWithInstance, cls).setUpClass()
-        cls.setup_stack(project='dummy1', explicitly_start=True)
+        cls.set_up_stack(project='dummy1', explicitly_start=True)
 
     @classmethod
     def tearDownClass(cls):
-        cls.tear_down_stack(cls)
+        cls.tear_down_stack()
         super(TestWithInstance, cls).tearDownClass()
 
     def test_bootstrap_create_stack_idempotence(self):

--- a/src/integration_tests/test_with_instance.py
+++ b/src/integration_tests/test_with_instance.py
@@ -1,11 +1,7 @@
-import os, json
-from fabric.api import settings
-from tests import base
-from buildercore import bootstrap, cfngen, cloudformation, lifecycle, utils, core, config
-from buildercore.config import BOOTSTRAP_USER
-import cfn
 import logging
-#import mock
+from tests import base
+from buildercore import bootstrap, cloudformation, utils, core
+from buildercore.config import BOOTSTRAP_USER
 
 logging.disable(logging.NOTSET) # re-enables logging during integration testing
 
@@ -16,69 +12,16 @@ LOG = logging.getLogger(__name__)
 # * run any logic against it that needs a running ec2 instance
 # * optionally leave the instance running while debugging happens
 
-class One(base.BaseCase):
+class TestWithInstance(base.BaseIntegrationCase):
     @classmethod
-    def setUpClass(self): # cls, not self
-        super(One, self).setUpClass()
-        base.switch_in_test_settings()
-
-        # to re-use an existing stack, ensure self.reuse_existing_stack is True
-        # this will read the instance name from a temporary file (if it exists) and
-        # look for that, creating it if doesn't exist yet
-        # also ensure self.cleanup is False so the instance isn't destroyed after tests complete
-        self.reuse_existing_stack = config.TWI_REUSE_STACK
-        self.cleanup = config.TWI_CLEANUP
-
-        self.stacknames = []
-        self.environment = base.generate_environment_name()
-        # self.temp_dir, self.rm_temp_dir = utils.tempdir()
-
-        # debugging only, where we keep an instance up between processes
-        self.state, self.statefile = {}, '/tmp/.open-test-instances.txt'
-        project = 'dummy1'
-
-        if self.reuse_existing_stack and os.path.exists(self.statefile):
-            # evidence of a previous instance and we've been told to re-use old instances
-            old_state = json.load(open(self.statefile, 'r'))
-            old_env = old_state.get('environment')
-
-            # test if the old stack still exists ...
-            if old_env and core.describe_stack(project + "--" + old_env, allow_missing=True):
-                self.state = old_state
-                self.environment = old_env
-            else:
-                # nope. old statefile is bogus, delete it
-                os.unlink(self.statefile)
-
-        self.state['environment'] = self.environment # will be saved later
-
-        with settings(abort_on_prompts=True):
-            self.stackname = '%s--%s' % (project, self.environment)
-            self.stacknames.append(self.stackname)
-
-            if self.cleanup:
-                cfn.ensure_destroyed(self.stackname)
-
-            self.context, self.cfn_template, _ = cfngen.generate_stack(project, stackname=self.stackname)
-            self.region = self.context['aws']['region']
-            bootstrap.create_stack(self.stackname)
-
-            lifecycle.start(self.stackname)
+    def setUpClass(cls):
+        super(TestWithInstance, cls).setUpClass()
+        cls.setup_stack(project='dummy1', explicitly_start=True)
 
     @classmethod
-    def tearDownClass(self): # cls, not self
-        super(One, self).tearDownClass()
-        try:
-            if self.reuse_existing_stack:
-                json.dump(self.state, open(self.statefile, 'w'))
-            if self.cleanup:
-                for stackname in self.stacknames:
-                    cfn.ensure_destroyed(stackname)
-            # self.rm_temp_dir()
-            # self.assertFalse(os.path.exists(self.temp_dir), "failed to delete path %r in tearDown" % self.temp_dir)
-        except BaseException:
-            # important, as anything in body will silently fail
-            LOG.exception('uncaught error tearing down test class')
+    def tearDownClass(cls):
+        cls.tear_down_stack(cls)
+        super(TestWithInstance, cls).tearDownClass()
 
     def test_bootstrap_create_stack_idempotence(self):
         "the same stack cannot be created multiple times"

--- a/src/integration_tests/test_with_many_nodes.py
+++ b/src/integration_tests/test_with_many_nodes.py
@@ -11,8 +11,6 @@ LOG = logging.getLogger(__name__)
 # * run any logic that requires multiple ec2 nodes
 # * optionally leave the nodes running while debugging happens
 
-# TODO: this class is a copy with `test_with_instance.py` with one value tweaked
-# turn into a base class perhaps?
 class TestWithManyNodes(base.BaseIntegrationCase):
     @classmethod
     def setUpClass(cls):

--- a/src/integration_tests/test_with_many_nodes.py
+++ b/src/integration_tests/test_with_many_nodes.py
@@ -1,11 +1,6 @@
-import os, json
-from fabric.api import settings
-from tests import base
-from buildercore import bootstrap, cfngen, lifecycle, core, config
-
-import cfn
 import logging
-
+from tests import base
+from buildercore import lifecycle, core
 
 logging.disable(logging.NOTSET) # re-enables logging during integration testing
 
@@ -18,69 +13,20 @@ LOG = logging.getLogger(__name__)
 
 # TODO: this class is a copy with `test_with_instance.py` with one value tweaked
 # turn into a base class perhaps?
-class One(base.BaseCase):
+class TestWithManyNodes(base.BaseIntegrationCase):
     @classmethod
-    def setUpClass(self): # cls, not self
-        super(One, self).setUpClass()
-        base.switch_in_test_settings()
+    def setUpClass(cls):
+        super(TestWithManyNodes, cls).setUpClass()
 
-        # to re-use an existing stack, ensure self.reuse_existing_stack is True
-        # this will read the instance name from a temporary file (if it exists) and
-        # look for that, creating it if doesn't exist yet
-        # also ensure self.cleanup is False so the stack isn't destroyed after tests complete
-        self.reuse_existing_stack = config.TWI_REUSE_STACK
-        self.cleanup = config.TWI_CLEANUP
-
-        self.stacknames = []
-        self.environment = base.generate_environment_name()
-        # self.temp_dir, self.rm_temp_dir = utils.tempdir()
-
-        # debugging only, where we keep an instance up between processes
-        self.state, self.statefile = {}, '/tmp/.open-test-instances.txt'
-        project = 'project-with-cluster-integration-tests'
-
-        if self.reuse_existing_stack and os.path.exists(self.statefile):
-            # evidence of a previous instance and we've been told to re-use old instances
-            old_state = json.load(open(self.statefile, 'r'))
-            old_env = old_state.get('environment')
-
-            # test if the old stack still exists ...
-            if old_env and core.describe_stack(project + "--" + old_env, allow_missing=True):
-                self.state = old_state
-                self.environment = old_env
-            else:
-                # nope. old statefile is bogus, delete it
-                os.unlink(self.statefile)
-
-        self.state['environment'] = self.environment # will be saved later
-
-        with settings(abort_on_prompts=True):
-            self.stackname = '%s--%s' % (project, self.environment)
-            self.stacknames.append(self.stackname)
-
-            if self.cleanup:
-                cfn.ensure_destroyed(self.stackname)
-
-            self.context, self.cfn_template, _ = cfngen.generate_stack(project, stackname=self.stackname)
-            self.region = self.context['aws']['region']
-            bootstrap.create_stack(self.stackname)
-
-            # lifecycle.start(self.stackname) # see self.setUp
+        cls.setup_stack(
+            project='project-with-cluster-integration-tests',
+            explicitly_start=False # see self.setUp
+        )
 
     @classmethod
-    def tearDownClass(self): # cls, not self
-        super(One, self).tearDownClass()
-        try:
-            if self.reuse_existing_stack:
-                json.dump(self.state, open(self.statefile, 'w'))
-            if self.cleanup:
-                for stackname in self.stacknames:
-                    cfn.ensure_destroyed(stackname)
-            # self.rm_temp_dir()
-            # self.assertFalse(os.path.exists(self.temp_dir), "failed to delete path %r in tearDown" % self.temp_dir)
-        except BaseException:
-            # important, as anything in body will silently fail
-            LOG.exception('uncaught error tearing down test class')
+    def tearDownClass(cls):
+        cls.tear_down_stack(cls)
+        super(TestWithManyNodes, cls).tearDownClass()
 
     def setUp(self):
         lifecycle.start(self.stackname)

--- a/src/integration_tests/test_with_many_nodes.py
+++ b/src/integration_tests/test_with_many_nodes.py
@@ -18,14 +18,14 @@ class TestWithManyNodes(base.BaseIntegrationCase):
     def setUpClass(cls):
         super(TestWithManyNodes, cls).setUpClass()
 
-        cls.setup_stack(
+        cls.set_up_stack(
             project='project-with-cluster-integration-tests',
             explicitly_start=False # see self.setUp
         )
 
     @classmethod
     def tearDownClass(cls):
-        cls.tear_down_stack(cls)
+        cls.tear_down_stack()
         super(TestWithManyNodes, cls).tearDownClass()
 
     def setUp(self):

--- a/src/tests/__init__.py
+++ b/src/tests/__init__.py
@@ -1,5 +1,0 @@
-import logging
-
-from buildercore.config import CONSOLE_HANDLER
-
-CONSOLE_HANDLER.setLevel(logging.CRITICAL)

--- a/src/tests/__init__.py
+++ b/src/tests/__init__.py
@@ -1,2 +1,5 @@
 import logging
-logging.disable(logging.CRITICAL)
+
+from buildercore.config import CONSOLE_HANDLER
+
+CONSOLE_HANDLER.setLevel(logging.CRITICAL)

--- a/src/tests/base.py
+++ b/src/tests/base.py
@@ -85,7 +85,7 @@ class BaseCase(TestCase):
 
 class BaseIntegrationCase(BaseCase):
     @classmethod
-    def setup_stack(cls, project, explicitly_start=False):
+    def set_up_stack(cls, project, explicitly_start=False):
         switch_in_test_settings()
 
         # to re-use an existing stack, ensure cls.reuse_existing_stack is True
@@ -122,22 +122,26 @@ class BaseIntegrationCase(BaseCase):
             cls.stacknames.append(cls.stackname)
 
             if cls.cleanup:
+                LOG.info("ensure_destroyed %s", cls.stackname)
                 cfn.ensure_destroyed(cls.stackname)
 
             cls.context, cls.cfn_template, _ = cfngen.generate_stack(project, stackname=cls.stackname)
             cls.region = cls.context['aws']['region']
+            LOG.info("create_stack %s", cls.stackname)
             bootstrap.create_stack(cls.stackname)
 
             if explicitly_start:
+                LOG.info("start %s", cls.stackname)
                 lifecycle.start(cls.stackname)
 
     @classmethod
-    def tearDownStack(cls):
+    def tear_down_stack(cls):
         try:
             if cls.reuse_existing_stack:
                 json.dump(cls.state, open(cls.statefile, 'w'))
             if cls.cleanup:
                 for stackname in cls.stacknames:
+                    LOG.info("ensure_destroyed %s", stackname)
                     cfn.ensure_destroyed(stackname)
             # cls.rm_temp_dir()
             # cls.assertFalse(os.path.exists(cls.temp_dir), "failed to delete path %r in tearDown" % cls.temp_dir)

--- a/testing-times.md
+++ b/testing-times.md
@@ -1,8 +1,0 @@
-## local
-
-src/tests serial: 40s
-src/integration_tests serial: 19m
-src/integration_tests parallel on 2 processes: 15m
-src/integration_tests parallel on 3 processes: 13m30s
-src/integration_tests parallel on 3 processes, --dist=loadscope: 11m40s
-src/integration_tests parallel on 4 processes, --dist=loadscope: 16m15s

--- a/testing-times.md
+++ b/testing-times.md
@@ -1,0 +1,8 @@
+## local
+
+src/tests serial: 40s
+src/integration_tests serial: 19m
+src/integration_tests parallel on 2 processes: 15m
+src/integration_tests parallel on 3 processes: 13m30s
+src/integration_tests parallel on 3 processes, --dist=loadscope: 11m40s
+src/integration_tests parallel on 4 processes, --dist=loadscope: 16m15s


### PR DESCRIPTION
~If this works and assuming CloudFormation rate limiting has been correctly solved, this could shave off 6-7 minutes in each build.~

Final result is 13-14 minutes rather than 30 per build.