### PR TITLE
ELPP-3521 Correct Terraform file extension

### DIFF
--- a/src/buildercore/bootstrap.py
+++ b/src/buildercore/bootstrap.py
@@ -19,6 +19,7 @@ from .config import BOOTSTRAP_USER
 from fabric.api import sudo, show
 import fabric.exceptions as fabric_exceptions
 from fabric.contrib import files
+import backoff
 import boto # boto2
 import botocore
 from kids.cache import cache as cached
@@ -43,6 +44,7 @@ def put_script(script_filename, remote_script):
     temporary_script = _put_temporary_script(script_filename)
     sudo("mv %s %s && chmod +x %s" % (temporary_script, remote_script, remote_script))
 
+@backoff.on_exception(backoff.expo, fabric_exceptions.NetworkError, max_time=60)
 def run_script(script_filename, *script_params, **environment_variables):
     """uploads a script for SCRIPTS_PATH and executes it in the /tmp dir with given params.
     WARN: assumes you are connected to a stack"""

--- a/src/buildercore/cfngen.py
+++ b/src/buildercore/cfngen.py
@@ -21,7 +21,7 @@ import netaddr
 from slugify import slugify
 from . import utils, cloudformation, terraform, core, project, context_handler
 from .utils import ensure, lmap
-from .config import STACK_DIR, TERRAFORM_DIR
+from .config import STACK_DIR
 
 import logging
 

--- a/src/buildercore/cfngen.py
+++ b/src/buildercore/cfngen.py
@@ -308,6 +308,7 @@ def write_template(stackname, contents):
     # return [cfn, tfm]
     pass
 
+# TODO: move implementation to cloudformation.py
 # TODO: perhaps add terraform support?
 def read_template(stackname):
     "returns the contents of a cloudformation template as a python data structure"

--- a/src/buildercore/cfngen.py
+++ b/src/buildercore/cfngen.py
@@ -300,10 +300,6 @@ def write_cloudformation_template(stackname, contents):
     open(output_fname, 'w').write(contents)
     return output_fname
 
-# TODO: move to terraform.py
-def write_terraform_template(stackname, contents):
-    terraform.write_template(stackname, contents)
-
 # TODO: prefer this single dispatch function for handling creation of template files
 def write_template(stackname, contents):
     "writes any provider templates and returns a list of paths to templates"
@@ -382,7 +378,7 @@ def generate_stack(pname, **more_context):
 
     context_handler.write_context(stackname, context)
     cloudformation_template_file = write_cloudformation_template(stackname, cloudformation_template)
-    terraform_template_file = write_terraform_template(stackname, terraform_template)
+    terraform_template_file = terraform.write_template(stackname, terraform_template)
     return context, cloudformation_template_file, terraform_template_file
 
 #
@@ -524,7 +520,7 @@ def merge_delta(stackname, delta):
     template = read_template(stackname)
     apply_delta(template, delta)
     write_cloudformation_template(stackname, json.dumps(template))
-    write_terraform_template(stackname, delta.terraform)
+    terraform.write_template(stackname, delta.terraform)
     return template
 
 def apply_delta(template, delta):

--- a/src/buildercore/cfngen.py
+++ b/src/buildercore/cfngen.py
@@ -20,7 +20,7 @@ from collections import OrderedDict, namedtuple
 import netaddr
 from slugify import slugify
 from . import utils, cloudformation, terraform, core, project, context_handler
-from .utils import ensure, lmap, mkdir_p
+from .utils import ensure, lmap
 from .config import STACK_DIR, TERRAFORM_DIR
 
 import logging
@@ -302,14 +302,7 @@ def write_cloudformation_template(stackname, contents):
 
 # TODO: move to terraform.py
 def write_terraform_template(stackname, contents):
-    "optionally, store a terraform configuration file for the stack"
-    # if the template isn't empty ...?
-    if json.loads(contents):
-        output_dir = os.path.join(TERRAFORM_DIR, stackname)
-        mkdir_p(output_dir)
-        output_fname = os.path.join(output_dir, "generated.tf")
-        open(output_fname, 'w').write(contents)
-        return output_fname
+    terraform.write_template(stackname, contents)
 
 # TODO: prefer this single dispatch function for handling creation of template files
 def write_template(stackname, contents):

--- a/src/buildercore/terraform.py
+++ b/src/buildercore/terraform.py
@@ -2,9 +2,9 @@ import json
 import os
 from os.path import join
 from python_terraform import Terraform
-from buildercore.utils import ensure
 from .config import BUILDER_BUCKET, BUILDER_REGION, TERRAFORM_DIR, ConfigurationError
 from .context_handler import only_if
+from .utils import ensure, mkdir_p
 
 PROVIDER_FASTLY_VERSION = '0.1.4',
 RESOURCE_TYPE_FASTLY = 'fastly_service_v1'
@@ -62,6 +62,25 @@ def render(context):
         },
     }
     return json.dumps(tf_file)
+
+def write_template(stackname, contents):
+    "optionally, store a terraform configuration file for the stack"
+    # if the template isn't empty ...?
+    if json.loads(contents):
+        output_dir = join(TERRAFORM_DIR, stackname)
+        mkdir_p(output_dir)
+        output_fname = join(output_dir, "generated.tf")
+        with open(output_fname, 'w') as fp:
+            fp.write(contents)
+            return output_fname
+
+def read_template(stackname):
+    output_dir = join(TERRAFORM_DIR, stackname)
+    mkdir_p(output_dir)
+    output_fname = join(output_dir, "generated.tf")
+    with open(output_fname, 'r') as fp:
+        return fp.read()
+
 
 def init(stackname):
     working_dir = join(TERRAFORM_DIR, stackname) # ll: ./.cfn/terraform/project--prod/

--- a/src/buildercore/terraform.py
+++ b/src/buildercore/terraform.py
@@ -78,7 +78,7 @@ def read_template(stackname):
 def init(stackname):
     working_dir = join(TERRAFORM_DIR, stackname) # ll: ./.cfn/terraform/project--prod/
     terraform = Terraform(working_dir=working_dir)
-    with _open(stackname, backend, 'w') as fp:
+    with _open(stackname, 'backend', 'w') as fp:
         fp.write(json.dumps({
             'terraform': {
                 'backend': {

--- a/src/buildercore/terraform.py
+++ b/src/buildercore/terraform.py
@@ -1,6 +1,6 @@
 import json
 import os
-from os.path import join
+from os.path import exists, join
 from python_terraform import Terraform
 from .config import BUILDER_BUCKET, BUILDER_REGION, TERRAFORM_DIR, ConfigurationError
 from .context_handler import only_if
@@ -69,7 +69,7 @@ def write_template(stackname, contents):
     if json.loads(contents):
         with _open(stackname, 'generated', 'w') as fp:
             fp.write(contents)
-            return _file_path(stackname, generated)
+            return _file_path(stackname, 'generated')
 
 def read_template(stackname):
     with _open(stackname, 'generated', 'r') as fp:
@@ -115,9 +115,13 @@ def destroy(stackname, context):
     # TODO: also destroy files
 
 def _file_path(stackname, name):
-    return join(TERRAFORM_DIR, stackname, name)
+    return join(TERRAFORM_DIR, stackname, '%s.tf.json' % name)
 
 def _open(stackname, name, mode):
     output_dir = join(TERRAFORM_DIR, stackname)
     mkdir_p(output_dir)
+    # remove deprecated file
+    deprecated_path = join(TERRAFORM_DIR, stackname, '%s.tf' % name)
+    if exists(deprecated_path):
+        os.remove(deprecated_path)
     return open(_file_path(stackname, name), mode)

--- a/src/tests/test_buildercore_terraform.py
+++ b/src/tests/test_buildercore_terraform.py
@@ -1,6 +1,7 @@
 import os
+import shutil
 import yaml
-from os.path import join
+from os.path import exists, join
 from . import base
 from buildercore import cfngen, terraform
 
@@ -8,6 +9,9 @@ class TestBuildercoreTerraform(base.BaseCase):
     def setUp(self):
         self.project_config = join(self.fixtures_dir, 'projects', "dummy-project.yaml")
         os.environ['LOGNAME'] = 'my_user'
+        test_directory = join(terraform.TERRAFORM_DIR, 'dummy1--test')
+        if exists(test_directory):
+            shutil.rmtree(test_directory)
 
     def tearDown(self):
         del os.environ['LOGNAME']

--- a/src/tests/test_buildercore_terraform.py
+++ b/src/tests/test_buildercore_terraform.py
@@ -128,6 +128,11 @@ class TestBuildercoreTerraform(base.BaseCase):
             data
         )
 
+    def test_write_template(self):
+        contents = '{"key":"value"}'
+        terraform.write_template('dummy1--test', contents)
+        self.assertEqual(terraform.read_template('dummy1--test'), contents)
+
     def _parse_template(self, terraform_template):
         """use yaml module to load JSON to avoid large u'foo' vs 'foo' string diffs
         https://stackoverflow.com/a/16373377/91590"""

--- a/src/tests/test_buildercore_terraform.py
+++ b/src/tests/test_buildercore_terraform.py
@@ -132,7 +132,7 @@ class TestBuildercoreTerraform(base.BaseCase):
             data
         )
 
-    def test_write_template(self):
+    def test_generated_template_file_storage(self):
         contents = '{"key":"value"}'
         terraform.write_template('dummy1--test', contents)
         self.assertEqual(terraform.read_template('dummy1--test'), contents)


### PR DESCRIPTION
Following https://www.terraform.io/docs/configuration/index.html although the `.tf` extension has worked so far. Separates all the handling of files into the `buildercore.terraform` module.