### PR TITLE
ELPP-3521 Extend Fastly Terraform template to include GCS logging

### DIFF
--- a/projects/elife.yaml
+++ b/projects/elife.yaml
@@ -369,7 +369,7 @@ api-gateway:
                 gcslogging:
                     bucket: end2end-elife-fastly
                     path: api-gateway--test/
-                    period: 120
+                    period: 3600
     vagrant:
         box: ubuntu/trusty64 # Ubuntu 14.04, deprecated
         ports:

--- a/projects/elife.yaml
+++ b/projects/elife.yaml
@@ -133,6 +133,7 @@ defaults:
             subdomains-without-dns: []
             dns:
                 cname: u2.shared.global.fastly.net
+            gcslogging: false
         subdomains: []
         elasticache:
             # elasticache defaults only used if an `rds` section present in project
@@ -361,6 +362,13 @@ api-gateway:
                 subdomains:
                     - "{instance}--cdn-gateway"
                     - api
+        test:
+            fastly:
+                subdomains:
+                    - "{instance}--cdn-gateway"
+                gcslogging:
+                    bucket: end2end-elife-fastly
+                    path: api-gateway--test/
     vagrant:
         box: ubuntu/trusty64 # Ubuntu 14.04, deprecated
         ports:

--- a/projects/elife.yaml
+++ b/projects/elife.yaml
@@ -369,6 +369,7 @@ api-gateway:
                 gcslogging:
                     bucket: end2end-elife-fastly
                     path: api-gateway--test/
+                    period: 120
     vagrant:
         box: ubuntu/trusty64 # Ubuntu 14.04, deprecated
         ports:

--- a/src/buildercore/cfngen.py
+++ b/src/buildercore/cfngen.py
@@ -261,6 +261,8 @@ def build_context_fastly(context, parameterize):
             'subdomains': [build_subdomain(x) for x in context['project']['aws']['fastly']['subdomains']],
             'subdomains-without-dns': [build_subdomain(x) for x in context['project']['aws']['fastly']['subdomains-without-dns']],
             'dns': context['project']['aws']['fastly']['dns'],
+            # TODO: add templating of bucket name
+            'gcslogging': context['project']['aws']['fastly']['gcslogging'],
         }
     else:
         context['fastly'] = False

--- a/src/buildercore/terraform.py
+++ b/src/buildercore/terraform.py
@@ -61,6 +61,16 @@ def render(context):
             }
         },
     }
+    if context['fastly']['gcslogging']:
+        gcslogging = context['fastly']['gcslogging']
+        # TODO: require FASTLY_GCS_EMAIL env variable
+        # TODO: require FASTLY_GCS_SECRET env variable
+        tf_file['resource'][RESOURCE_TYPE_FASTLY][RESOURCE_NAME_FASTLY]['gcslogging'] = {
+            'name': 'default',
+            'bucket_name': gcslogging['bucket'],
+            # TODO: validate it starts with /
+            'path': gcslogging['path'],
+        }
     return json.dumps(tf_file)
 
 def write_template(stackname, contents):

--- a/src/buildercore/terraform.py
+++ b/src/buildercore/terraform.py
@@ -66,6 +66,8 @@ def render(context):
         gcslogging = context['fastly']['gcslogging']
         # TODO: require FASTLY_GCS_EMAIL env variable
         # TODO: require FASTLY_GCS_SECRET env variable
+        # how to define an env variable with new lines:
+        # https://stackoverflow.com/a/36439943/91590
         tf_file['resource'][RESOURCE_TYPE_FASTLY][RESOURCE_NAME_FASTLY]['gcslogging'] = {
             'name': 'default',
             'bucket_name': gcslogging['bucket'],

--- a/src/buildercore/terraform.py
+++ b/src/buildercore/terraform.py
@@ -73,6 +73,7 @@ def render(context):
             'bucket_name': gcslogging['bucket'],
             # TODO: validate it starts with /
             'path': gcslogging['path'],
+            'period': gcslogging.get('period', 3600),
         }
     return json.dumps(tf_file)
 

--- a/src/cfn.py
+++ b/src/cfn.py
@@ -21,8 +21,7 @@ LOG = logging.getLogger(__name__)
 def strtobool(x):
     return x if isinstance(x, bool) else bool(_strtobool(x))
 
-# these aliases are deprecated
-@task(alias='aws_delete_stack')
+@task
 @requires_steady_stack
 def destroy(stackname):
     "tell aws to delete a stack."
@@ -49,8 +48,7 @@ def ensure_destroyed(stackname):
             return
         raise
 
-# these aliases are deprecated
-@task(alias='aws_update_stack')
+@task()
 @requires_aws_stack
 @timeit
 def update(stackname, autostart="0", concurrency='serial'):
@@ -124,16 +122,6 @@ def update_infrastructure(stackname):
     if context.get('s3', {}):
         bootstrap.update_stack(stackname, service_list=['s3'])
 
-
-# TODO: deprecated, this task now lives in `master.py`
-@debugtask
-def update_master():
-    master_stackname = core.find_master(utils.find_region())
-    bootstrap.update_stack(master_stackname, service_list=[
-        'ec2' # master-server should be a self-contained EC2 instance
-    ])
-    bootstrap.remove_all_orphaned_keys(master_stackname)
-
 @requires_project
 def generate_stack_from_input(pname, instance_id=None, alt_config=None):
     """creates a new CloudFormation file for the given project."""
@@ -165,8 +153,7 @@ def generate_stack_from_input(pname, instance_id=None, alt_config=None):
     cfngen.generate_stack(pname, **more_context)
     return stackname
 
-# these aliases are deprecated
-@task(alias='aws_launch_instance')
+@task
 @requires_project
 def launch(pname, instance_id=None, alt_config=None, **kwargs):
     try:

--- a/src/cfn.py
+++ b/src/cfn.py
@@ -96,12 +96,18 @@ def update_infrastructure(stackname):
 
     context_handler.write_context(stackname, context)
 
+    # TODO: move to cloudformation module?
+    # bootstrap.update_stack(stackname, service_list=['cloudformation'])?
     if delta.non_empty:
         new_template = cfngen.merge_delta(stackname, delta)
         bootstrap.update_template(stackname, new_template)
     else:
         # attempting to apply an empty change set would result in an error
         LOG.info("Nothing to update on CloudFormation")
+
+    # Fastly via Terraform
+    if context.get('fastly', {}):
+        bootstrap.update_stack(stackname, service_list=['terraform'])
 
     # TODO: move inside bootstrap.update_stack
     # EC2
@@ -118,9 +124,6 @@ def update_infrastructure(stackname):
     if context.get('s3', {}):
         bootstrap.update_stack(stackname, service_list=['s3'])
 
-    # Fastly via Terraform
-    if context.get('fastly', {}):
-        bootstrap.update_stack(stackname, service_list=['terraform'])
 
 
 # TODO: deprecated, this task now lives in `master.py`

--- a/src/cfn.py
+++ b/src/cfn.py
@@ -193,6 +193,9 @@ def launch(pname, instance_id=None, alt_config=None, **kwargs):
             bootstrap.create_stack(stackname)
 
         LOG.info('updating stack %s', stackname)
+        # TODO: highstate.sh (think it's run inside here) doesn't detect:
+        # [34.234.95.137] out: [CRITICAL] The Salt Master has rejected this minion's public key!
+        # TODO: should not run terraform (triggered by update fastly, probably triggered by update all)
         bootstrap.update_stack(stackname, **kwargs)
         setdefault('.active-stack', stackname)
 

--- a/src/cfn.py
+++ b/src/cfn.py
@@ -125,7 +125,6 @@ def update_infrastructure(stackname):
         bootstrap.update_stack(stackname, service_list=['s3'])
 
 
-
 # TODO: deprecated, this task now lives in `master.py`
 @debugtask
 def update_master():

--- a/src/cfn.py
+++ b/src/cfn.py
@@ -61,8 +61,12 @@ def update(stackname, autostart="0", concurrency='serial'):
         return
     return bootstrap.update_stack(stackname, service_list=['ec2'], concurrency=concurrency)
 
-# DEPRECATED: remove alias
-@task(alias='update_template')
+@task
+def update_template(stackname):
+    print('This task has been renamed to update_infrastructure.')
+    exit(1)
+
+@task
 @timeit
 def update_infrastructure(stackname):
     """Limited update of the Cloudformation template and/or Terraform template.

--- a/src/master.py
+++ b/src/master.py
@@ -126,7 +126,7 @@ def remaster(stackname, new_master_stackname):
     if context['ec2'].get('master_ip') == master_ip:
         LOG.info("already remastered: %s", stackname)
         try:
-            utils.get_input('any key to skip, ctrl-c to carry on')
+            utils.confirm("Skip?")
             return
         except KeyboardInterrupt:
             LOG.info("not skipping")

--- a/src/master.py
+++ b/src/master.py
@@ -7,7 +7,7 @@ import buildvars, utils
 from fabric.api import sudo, local, task
 from buildercore import core, bootstrap, config, keypair, project, cfngen, context_handler
 from buildercore.utils import lmap, exsubdict, mkidx
-from decorators import debugtask, echo_output, requires_project, requires_aws_stack, requires_feature
+from decorators import debugtask, echo_output, requires_aws_stack, requires_feature
 from kids.cache import cache as cached
 import logging
 

--- a/src/master.py
+++ b/src/master.py
@@ -78,21 +78,6 @@ def server_access():
     result = local('ssh -o "StrictHostKeyChecking no" %s@%s "exit"' % (config.BOOTSTRAP_USER, public_ip))
     return result.return_code == 0
 
-# TODO: deletion candidate
-@echo_output
-def aws_update_many_projects(pname_list):
-    minions = ' or '.join([pname + "-*" for pname in pname_list])
-    region = utils.find_region()
-    with core.stack_conn(core.find_master(region)):
-        sudo("salt -C '%s' state.highstate --retcode-passthrough" % minions)
-
-# TODO: deletion candidate
-@debugtask
-@requires_project
-def aws_update_projects(pname):
-    "calls state.highstate on ALL projects matching <projectname>-*"
-    return aws_update_many_projects([pname])
-
 @cached
 def _cached_master_ip(master_stackname):
     "provides a small time saving when remastering many minions"

--- a/src/tests/fixtures/projects/dummy-project.yaml
+++ b/src/tests/fixtures/projects/dummy-project.yaml
@@ -97,6 +97,7 @@ defaults:
             subdomains-without-dns: []
             dns:
                 cname: something.fastly.net
+            gcslogging: false
         subdomains: []
         elasticache:
             # elasticache defaults only used if an `rds` section present in project
@@ -324,6 +325,19 @@ project-with-fastly-complex:
                 - "{instance}--cdn2-of-www"
             subdomains-without-dns:
                 - "future"
+
+project-with-fastly-gcs:
+    repo: ssh://git@github.com/elifesciences/dummy3
+    subdomain: www
+    aws:
+        ports:
+            - 80
+        fastly:
+            subdomains:
+                - "{instance}--cdn-of-www"
+            gcslogging:
+                bucket: my-bucket
+                path: my-project/
 
 project-with-cluster:
     repo: ssh://git@github.com/elifesciences/dummy3

--- a/src/tests/fixtures/projects/dummy-project.yaml
+++ b/src/tests/fixtures/projects/dummy-project.yaml
@@ -338,6 +338,7 @@ project-with-fastly-gcs:
             gcslogging:
                 bucket: my-bucket
                 path: my-project/
+                period: 1800
 
 project-with-cluster:
     repo: ssh://git@github.com/elifesciences/dummy3

--- a/src/tests/test_buildercore_project.py
+++ b/src/tests/test_buildercore_project.py
@@ -9,7 +9,7 @@ ALL_PROJECTS = [
     'dummy1', 'dummy2', 'dummy3',
     'just-some-sns', 'project-with-sqs', 'project-with-s3',
     'project-with-ext', 'project-with-cloudfront', 'project-with-cloudfront-minimal',
-    'project-with-cloudfront-error-pages', 'project-with-cloudfront-origins', 'project-with-fastly-minimal', 'project-with-fastly-complex',
+    'project-with-cloudfront-error-pages', 'project-with-cloudfront-origins', 'project-with-fastly-minimal', 'project-with-fastly-complex', 'project-with-fastly-gcs',
     'project-with-cluster', 'project-with-cluster-suppressed', 'project-with-cluster-overrides', 'project-with-stickiness', 'project-with-multiple-elb-listeners',
     'project-with-cluster-integration-tests', 'project-with-db-params', 'project-with-rds-only', 'project-with-elasticache-redis', 'project-with-multiple-elasticaches', 'project-with-fully-overridden-elasticaches',
 ]

--- a/src/tests/test_buildercore_terraform.py
+++ b/src/tests/test_buildercore_terraform.py
@@ -132,6 +132,24 @@ class TestBuildercoreTerraform(base.BaseCase):
             data
         )
 
+    def test_fastly_template_gcs_logging(self):
+        extra = {
+            'stackname': 'project-with-fastly-gcs--prod',
+        }
+        context = cfngen.build_context('project-with-fastly-gcs', **extra)
+        terraform_template = terraform.render(context)
+        data = self._parse_template(terraform_template)
+        service = data['resource']['fastly_service_v1']['fastly-cdn']
+        self.assertIn('gcslogging', service)
+        self.assertEqual(
+            service['gcslogging'],
+            {
+                'name': 'default',
+                'bucket_name': 'my-bucket',
+                'path': 'my-project/',
+            }
+        )
+
     def test_generated_template_file_storage(self):
         contents = '{"key":"value"}'
         terraform.write_template('dummy1--test', contents)

--- a/src/tests/test_buildercore_terraform.py
+++ b/src/tests/test_buildercore_terraform.py
@@ -147,6 +147,7 @@ class TestBuildercoreTerraform(base.BaseCase):
                 'name': 'default',
                 'bucket_name': 'my-bucket',
                 'path': 'my-project/',
+                'period': 1800,
             }
         )
 

--- a/src/utils.py
+++ b/src/utils.py
@@ -95,7 +95,7 @@ def uin(param, default=0xDEADBEEF):
 
 def confirm(message):
     print(message)
-    print('press any key to confirm (ctrl-c to quit)')
+    print('press Enter to confirm (ctrl-c to quit)')
     get_input('')
 
 def walk_nested_struct(val, fn):


### PR DESCRIPTION
Like CloudFront, a CDN has its own servers so if you want access logs to analyze, you need to configure it to dump them somewhere.

CloudFront did this to an S3 bucket. Fastly can do the same but with many different targets, one that could be useful for us is Google Cloud Storage which could then be imported into Google Big Query.

Credentials manipulation will be needed - Fastly will need a service account (like we do with AWS IAM users called `lax`) which I created, and I'm now figuring out the correct permissions to give it. This PR forces the user to configure two environment variables before being able to use the `fastly.gcslogging` feature.