### PR TITLE
ELPP-3242 Update bldr stop_if_running_for

### DIFF
--- a/src/buildercore/lifecycle.py
+++ b/src/buildercore/lifecycle.py
@@ -114,7 +114,8 @@ def _last_ec2_start_time(stackname):
     nodes = find_ec2_instances(stackname, allow_empty=True)
 
     def _parse_datetime(value):
-        return datetime.strptime(value, "%Y-%m-%dT%H:%M:%S.%fZ")
+        assert value.tzname() == 'UTC', 'datetime object returned by the EC2 API is not UTC, needs timezone conversion'
+        return value.replace(tzinfo=None)
     return {node.id: _parse_datetime(node.launch_time) for node in nodes}
 
 def _stop(stackname, ec2_to_be_stopped, rds_to_be_stopped):

--- a/src/integration_tests/test_provisioning.py
+++ b/src/integration_tests/test_provisioning.py
@@ -63,3 +63,5 @@ class TestProvisioning(base.BaseCase):
 
             cfn.download_file(stackname, "/bin/pwd", "subfolder/pwd", use_bootstrap_user="true")
             self.assertTrue(os.path.isfile("./subfolder/pwd"))
+
+            lifecycle.stop_if_running_for(stackname, minimum_minutes=60 * 24 * 365) # should exercise the code but do nothing, as this test's instance can't have been running for a year


### PR DESCRIPTION
The task was relying on a string being returned in the field describing how long an instance has been running, this is now a `datetime` object.

/cc @lsh-0