### PR TITLE
Configure custom Fastly log format

### DIFF
--- a/projects/elife.yaml
+++ b/projects/elife.yaml
@@ -369,7 +369,7 @@ api-gateway:
                 gcslogging:
                     bucket: end2end-elife-fastly
                     path: api-gateway--test/
-                    period: 3600
+                    period: 1800
     vagrant:
         box: ubuntu/trusty64 # Ubuntu 14.04, deprecated
         ports:

--- a/src/buildercore/terraform.py
+++ b/src/buildercore/terraform.py
@@ -25,6 +25,8 @@ FASTLY_LOG_FORMAT = """{
   "client_ip":"%{req.http.Fastly-Client-IP}V",
   "geo_city":"%{client.geo.city}V",
   "geo_country_code":"%{client.geo.country_code}V",
+  "pop_datacenter": "%{server.datacenter}V",
+  "pop_region": "%{server.region}V",
   "request":"%{req.request}V",
   "host":"%{req.http.Fastly-Orig-Host}V",
   "url":"%{cstr_escape(req.url)}V",

--- a/src/buildercore/terraform.py
+++ b/src/buildercore/terraform.py
@@ -21,6 +21,8 @@ FASTLY_GZIP_EXTENSIONS = ['css', 'js', 'html', 'eot', 'ico', 'otf', 'ttf', 'json
 FASTLY_LOG_FORMAT = """{
   "timestamp":"%{begin:%Y-%m-%dT%H:%M:%S}t",
   "time_elapsed":%{time.elapsed.usec}V,
+  "object_hits": %{obj.hits}V,
+  "object_lastuse": "%{obj.lastuse}V",
   "is_tls":%{if(req.is_ssl, "true", "false")}V,
   "client_ip":"%{req.http.Fastly-Client-IP}V",
   "geo_city":"%{client.geo.city}V",

--- a/src/buildercore/terraform.py
+++ b/src/buildercore/terraform.py
@@ -34,9 +34,15 @@ FASTLY_LOG_FORMAT = """{
   "request_accept_charset":"%{cstr_escape(req.http.Accept-Charset)}V",
   "cache_status":"%{regsub(fastly_info.state, "^(HIT-(SYNTH)|(HITPASS|HIT|MISS|PASS|ERROR|PIPE)).*", "\\\\2\\\\3") }V"
 }"""
+
 # Fastly proprietary evolutions of the standard Apache log format
 # https://docs.fastly.com/guides/streaming-logs/custom-log-formats#advantages-of-using-the-version-2-custom-log-format
-FASTLY_LOG_FORMAT_VERSION = '2'
+# It's in the API:
+# https://docs.fastly.com/api/logging#logging_gcs
+# Not supported yet by Terraform however:
+# https://www.terraform.io/docs/providers/fastly/r/service_v1.html#name-12
+# FASTLY_LOG_FORMAT_VERSION = 2
+
 # what to prefix lines with, syslog heritage
 # see https://docs.fastly.com/guides/streaming-logs/changing-log-line-formats#available-message-formats
 FASTLY_LOG_LINE_PREFIX = 'blank' # no prefix
@@ -97,7 +103,8 @@ def render(context):
             'path': gcslogging['path'],
             'period': gcslogging.get('period', 3600),
             'format': FASTLY_LOG_FORMAT,
-            'format_version': FASTLY_LOG_FORMAT_VERSION,
+            # not supported yet
+            #'format_version': FASTLY_LOG_FORMAT_VERSION,
             'message_type': FASTLY_LOG_LINE_PREFIX,
         }
     return json.dumps(tf_file)

--- a/src/buildercore/terraform.py
+++ b/src/buildercore/terraform.py
@@ -27,6 +27,7 @@ FASTLY_LOG_FORMAT = """{
   "geo_country_code":"%{client.geo.country_code}V",
   "pop_datacenter": "%{server.datacenter}V",
   "pop_region": "%{server.region}V",
+  "shield": "%{req.http.x-shield}V"
   "request":"%{req.request}V",
   "host":"%{req.http.Fastly-Orig-Host}V",
   "url":"%{cstr_escape(req.url)}V",

--- a/src/buildercore/terraform.py
+++ b/src/buildercore/terraform.py
@@ -34,6 +34,9 @@ FASTLY_LOG_FORMAT = """{
   "request_accept_charset":"%{cstr_escape(req.http.Accept-Charset)}V",
   "cache_status":"%{regsub(fastly_info.state, "^(HIT-(SYNTH)|(HITPASS|HIT|MISS|PASS|ERROR|PIPE)).*", "\\\\2\\\\3") }V"
 }"""
+# Fastly proprietary evolutions of the standard Apache log format
+# https://docs.fastly.com/guides/streaming-logs/custom-log-formats#advantages-of-using-the-version-2-custom-log-format
+FASTLY_LOG_FORMAT_VERSION = '2'
 # what to prefix lines with, syslog heritage
 # see https://docs.fastly.com/guides/streaming-logs/changing-log-line-formats#available-message-formats
 FASTLY_LOG_LINE_PREFIX = 'blank' # no prefix
@@ -94,6 +97,7 @@ def render(context):
             'path': gcslogging['path'],
             'period': gcslogging.get('period', 3600),
             'format': FASTLY_LOG_FORMAT,
+            'format_version': FASTLY_LOG_FORMAT_VERSION,
             'message_type': FASTLY_LOG_LINE_PREFIX,
         }
     return json.dumps(tf_file)

--- a/src/buildercore/terraform.py
+++ b/src/buildercore/terraform.py
@@ -18,6 +18,22 @@ FASTLY_GZIP_TYPES = ['text/html', 'application/x-javascript', 'text/css', 'appli
                      'font/otf', 'image/svg+xml', 'image/vnd.microsoft.icon', 'text/plain',
                      'text/xml']
 FASTLY_GZIP_EXTENSIONS = ['css', 'js', 'html', 'eot', 'ico', 'otf', 'ttf', 'json']
+FASTLY_LOG_FORMAT = """{
+  "timestamp":"%{begin:%Y-%m-%dT%H:%M:%S}t",
+  "time_elapsed":%{time.elapsed.usec}V,
+  "is_tls":%{if(req.is_ssl, "true", "false")}V,
+  "client_ip":"%{req.http.Fastly-Client-IP}V",
+  "geo_city":"%{client.geo.city}V",
+  "geo_country_code":"%{client.geo.country_code}V",
+  "request":"%{req.request}V",
+  "host":"%{req.http.Fastly-Orig-Host}V",
+  "url":"%{cstr_escape(req.url)}V",
+  "request_referer":"%{cstr_escape(req.http.Referer)}V",
+  "request_user_agent":"%{cstr_escape(req.http.User-Agent)}V",
+  "request_accept_language":"%{cstr_escape(req.http.Accept-Language)}V",
+  "request_accept_charset":"%{cstr_escape(req.http.Accept-Charset)}V",
+  "cache_status":"%{regsub(fastly_info.state, "^(HIT-(SYNTH)|(HITPASS|HIT|MISS|PASS|ERROR|PIPE)).*", "\\2\\3") }V"
+}"""
 
 def render(context):
     if not context['fastly']:
@@ -74,6 +90,7 @@ def render(context):
             # TODO: validate it starts with /
             'path': gcslogging['path'],
             'period': gcslogging.get('period', 3600),
+            'format': FASTLY_LOG_FORMAT,
         }
     return json.dumps(tf_file)
 

--- a/src/buildercore/terraform.py
+++ b/src/buildercore/terraform.py
@@ -29,7 +29,7 @@ FASTLY_LOG_FORMAT = """{
   "geo_country_code":"%{client.geo.country_code}V",
   "pop_datacenter": "%{server.datacenter}V",
   "pop_region": "%{server.region}V",
-  "shield": "%{req.http.x-shield}V"
+  "shield": "%{req.http.x-shield}V",
   "request":"%{req.request}V",
   "host":"%{req.http.Fastly-Orig-Host}V",
   "url":"%{cstr_escape(req.url)}V",

--- a/src/buildercore/terraform.py
+++ b/src/buildercore/terraform.py
@@ -34,6 +34,9 @@ FASTLY_LOG_FORMAT = """{
   "request_accept_charset":"%{cstr_escape(req.http.Accept-Charset)}V",
   "cache_status":"%{regsub(fastly_info.state, "^(HIT-(SYNTH)|(HITPASS|HIT|MISS|PASS|ERROR|PIPE)).*", "\\\\2\\\\3") }V"
 }"""
+# what to prefix lines with, syslog heritage
+# see https://docs.fastly.com/guides/streaming-logs/changing-log-line-formats#available-message-formats
+FASTLY_LOG_LINE_PREFIX = 'blank' # no prefix
 
 def render(context):
     if not context['fastly']:
@@ -91,6 +94,7 @@ def render(context):
             'path': gcslogging['path'],
             'period': gcslogging.get('period', 3600),
             'format': FASTLY_LOG_FORMAT,
+            'message_type': FASTLY_LOG_LINE_PREFIX,
         }
     return json.dumps(tf_file)
 

--- a/src/buildercore/terraform.py
+++ b/src/buildercore/terraform.py
@@ -32,7 +32,7 @@ FASTLY_LOG_FORMAT = """{
   "request_user_agent":"%{cstr_escape(req.http.User-Agent)}V",
   "request_accept_language":"%{cstr_escape(req.http.Accept-Language)}V",
   "request_accept_charset":"%{cstr_escape(req.http.Accept-Charset)}V",
-  "cache_status":"%{regsub(fastly_info.state, "^(HIT-(SYNTH)|(HITPASS|HIT|MISS|PASS|ERROR|PIPE)).*", "\\2\\3") }V"
+  "cache_status":"%{regsub(fastly_info.state, "^(HIT-(SYNTH)|(HITPASS|HIT|MISS|PASS|ERROR|PIPE)).*", "\\\\2\\\\3") }V"
 }"""
 
 def render(context):

--- a/src/tests/test_buildercore_terraform.py
+++ b/src/tests/test_buildercore_terraform.py
@@ -145,6 +145,7 @@ class TestBuildercoreTerraform(base.BaseCase):
         self.assertEqual(service['gcslogging'].get('bucket_name'), 'my-bucket')
         self.assertEqual(service['gcslogging'].get('path'), 'my-project/')
         self.assertEqual(service['gcslogging'].get('period'), 1800)
+        self.assertEqual(service['gcslogging'].get('message_type'), 'blank')
 
         log_format = service['gcslogging'].get('format')
         # the non-rendered log_format is not even valid JSON

--- a/src/tests/test_buildercore_terraform.py
+++ b/src/tests/test_buildercore_terraform.py
@@ -1,3 +1,4 @@
+import json
 import os
 import shutil
 import yaml
@@ -141,15 +142,15 @@ class TestBuildercoreTerraform(base.BaseCase):
         data = self._parse_template(terraform_template)
         service = data['resource']['fastly_service_v1']['fastly-cdn']
         self.assertIn('gcslogging', service)
-        self.assertEqual(
-            service['gcslogging'],
-            {
-                'name': 'default',
-                'bucket_name': 'my-bucket',
-                'path': 'my-project/',
-                'period': 1800,
-            }
-        )
+        self.assertEqual(service['gcslogging'].get('name'), 'default')
+        self.assertEqual(service['gcslogging'].get('bucket_name'), 'my-bucket')
+        self.assertEqual(service['gcslogging'].get('path'), 'my-project/')
+        self.assertEqual(service['gcslogging'].get('period'), 1800)
+
+        log_format = service['gcslogging'].get('format')
+        # the non-rendered log_format is not even valid JSON
+        self.assertIsNotNone(log_format)
+        self.assertRegex(log_format, "\{.*\}")
 
     def test_generated_template_file_storage(self):
         contents = '{"key":"value"}'

--- a/src/tests/test_buildercore_terraform.py
+++ b/src/tests/test_buildercore_terraform.py
@@ -157,14 +157,13 @@ class TestBuildercoreTerraform(base.BaseCase):
     def test_sanity_of_rendered_log_format(self):
         def _render_log_format_with_dummy_data():
             return re.sub(
-                r"%\{.+\}(V|t)", 
+                r"%\{.+\}(V|t)",
                 '42',
                 terraform.FASTLY_LOG_FORMAT,
             )
         log_sample = json.loads(_render_log_format_with_dummy_data())
         self.assertEqual(log_sample.get('object_hits'), 42)
         self.assertEqual(log_sample.get('geo_city'), '42')
-
 
     def test_generated_template_file_storage(self):
         contents = '{"key":"value"}'

--- a/src/tests/test_buildercore_terraform.py
+++ b/src/tests/test_buildercore_terraform.py
@@ -146,7 +146,6 @@ class TestBuildercoreTerraform(base.BaseCase):
         self.assertEqual(service['gcslogging'].get('path'), 'my-project/')
         self.assertEqual(service['gcslogging'].get('period'), 1800)
         self.assertEqual(service['gcslogging'].get('message_type'), 'blank')
-        self.assertEqual(service['gcslogging'].get('format_version'), '2')
 
         log_format = service['gcslogging'].get('format')
         # the non-rendered log_format is not even valid JSON

--- a/src/tests/test_buildercore_terraform.py
+++ b/src/tests/test_buildercore_terraform.py
@@ -1,4 +1,3 @@
-import json
 import os
 import shutil
 import yaml

--- a/src/tests/test_buildercore_terraform.py
+++ b/src/tests/test_buildercore_terraform.py
@@ -146,6 +146,7 @@ class TestBuildercoreTerraform(base.BaseCase):
         self.assertEqual(service['gcslogging'].get('path'), 'my-project/')
         self.assertEqual(service['gcslogging'].get('period'), 1800)
         self.assertEqual(service['gcslogging'].get('message_type'), 'blank')
+        self.assertEqual(service['gcslogging'].get('format_version'), '2')
 
         log_format = service['gcslogging'].get('format')
         # the non-rendered log_format is not even valid JSON

--- a/src/tests/test_buildercore_terraform.py
+++ b/src/tests/test_buildercore_terraform.py
@@ -1,4 +1,6 @@
+import json
 import os
+import re
 import shutil
 import yaml
 from os.path import exists, join
@@ -151,6 +153,18 @@ class TestBuildercoreTerraform(base.BaseCase):
         # the non-rendered log_format is not even valid JSON
         self.assertIsNotNone(log_format)
         self.assertRegex(log_format, "\{.*\}")
+
+    def test_sanity_of_rendered_log_format(self):
+        def _render_log_format_with_dummy_data():
+            return re.sub(
+                r"%\{.+\}(V|t)", 
+                '42',
+                terraform.FASTLY_LOG_FORMAT,
+            )
+        log_sample = json.loads(_render_log_format_with_dummy_data())
+        self.assertEqual(log_sample.get('object_hits'), 42)
+        self.assertEqual(log_sample.get('geo_city'), '42')
+
 
     def test_generated_template_file_storage(self):
         contents = '{"key":"value"}'


### PR DESCRIPTION
Not making this configurable per-service because it's too tricky to get right. Example comes from https://docs.fastly.com/guides/streaming-logs/log-streaming-google-bigquery#example-format with some backslashing on top.

Sample:
```
<134>2018-04-27T15:46:36Z cache-lhr6322 default[482709]: {   "timestamp":"2018-04-27T15:46:35",   "time_elapsed":365501,   "is_tls":true,   "client_ip":"212.44.25.140",   "geo_city":"birmingham",   "geo_country_code":"GB",   "request":"GET",   "host":"(null)",   "url":"/ping",   "request_referer":"",   "request_user_agent":"curl/7.47.0",   "request_accept_language":"",   "request_accept_charset":"",   "cache_status":"PASS" }
<134>2018-04-27T15:58:58Z cache-lhr6335 default[167433]: {   "timestamp":"2018-04-27T15:58:58",   "time_elapsed":81599,   "is_tls":true,   "client_ip":"212.44.25.140",   "geo_city":"birmingham",   "geo_country_code":"GB",   "request":"GET",   "host":"(null)",   "url":"/ping",   "request_referer":"",   "request_user_agent":"Mozilla/5.0 (X11; Ubuntu; Linux x86_64; rv:59.0) Gecko/20100101 Firefox/59.0",   "request_accept_language":"en-US,en;q=0.5",   "request_accept_charset":"",   "cache_status":"PASS" }
```