### PR TITLE
Raise NoPublicIps in case of node not having been assigned one yet on boot

### DIFF
--- a/src/buildercore/core.py
+++ b/src/buildercore/core.py
@@ -270,7 +270,7 @@ def stack_all_ec2_nodes(stackname, workfn, username=config.DEPLOY_USER, concurre
         workfn, work_kwargs = workfn
 
     data = stack_data(stackname)
-    public_ips = {ec2['InstanceId']: ec2['PublicIpAddress'] for ec2 in data}
+    public_ips = {ec2['InstanceId']: ec2.get('PublicIpAddress') for ec2 in data}
     nodes = {ec2['InstanceId']: int(tags2dict(ec2['Tags'])['Node']) if 'Node' in tags2dict(ec2['Tags']) else 1 for ec2 in data}
     if node:
         nodes = {k: v for k, v in nodes.items() if v == node}

--- a/src/tests/test_buildercore_core.py
+++ b/src/tests/test_buildercore_core.py
@@ -161,6 +161,17 @@ class SimpleCases(base.BaseCase):
                 # https://bugs.python.org/issue17866
                 self.assertCountEqual(expected_subs, actual_subs)
 
+class Errors(base.BaseCase):
+    @patch('buildercore.core.stack_data')
+    def test_no_public_ips_available(self, stack_data):
+        stack_data.return_value = [
+            {'InstanceId': 'i-1', 'PublicIpAddress': None, 'Tags': []},
+        ]
+        self.assertRaises(
+            core.NoPublicIps,
+            core.stack_all_ec2_nodes, 'dummy1--test', lambda: True
+        )
+
 class TestCoreNewProjectData(base.BaseCase):
     def setUp(self):
         self.dummy1_config = join(self.fixtures_dir, 'dummy1-project.json')


### PR DESCRIPTION
From an error in https://alfred.elifesciences.org/blue/organizations/jenkins/dependencies-search-update-api-sdk-php/detail/dependencies-search-update-api-sdk-php/45/pipeline
In case a node is being booted an IP address may not be available yet. In this case `NoPublicIps` will be caught by the `lifecycle` module, letting the polling continue.
Probably caused by the SDK change, as this may have been a field set to `None` before and now it's instead a key missing from the dictionary.