### PR TITLE
Double space available to xpub containers

### DIFF
--- a/projects/elife.yaml
+++ b/projects/elife.yaml
@@ -1718,7 +1718,7 @@ elife-xpub:
             - 80
         ext:
             # external hdd
-            size: 10 # GB
+            size: 20 # GB
             device: /dev/sdh
     aws-alt: {}
     vagrant:

--- a/projects/elife.yaml
+++ b/projects/elife.yaml
@@ -1720,6 +1720,7 @@ elife-xpub:
             # external hdd
             size: 20 # GB
             device: /dev/sdh
+            type: gp2
     aws-alt: {}
     vagrant:
         ram: 2048


### PR DESCRIPTION
Despite running docker-prune often, we had several cases of builds failing due to lack of disk space.

Currently appling to `ci` and then `demo`. However their disk seems to be `magnetic` so can't be expanded in place, will have to recreate it (probably the whole server).