### PR TITLE
Provide commit statuses for Python versions test suites

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,7 +1,9 @@
 elifePipeline {
 
+    def commit
     stage 'Checkout', {
         checkout scm
+        commit = elifeGitRevision()
         // temporary
         elifeNotifyAtomist 'STARTED', 'STARTED'
     }
@@ -21,11 +23,13 @@ elifePipeline {
         for (int i = 0; i < pythons.size(); i++) {
             def python = pythons.get(i)
             actions["Test ${python}"] = {
-                try {
-                    sh "tox -e ${python}"
-                } finally {
-                    step([$class: "JUnitResultArchiver", testResults: "build/pytest-${python}.xml"])
-                }
+                withCommitStatus({
+                    try {
+                        sh "tox -e ${python}"
+                    } finally {
+                        step([$class: "JUnitResultArchiver", testResults: "build/pytest-${python}.xml"])
+                    }
+                }, python, commit)
             }
         }
         // currently unstable due to CloudFormation rate limiting


### PR DESCRIPTION
Separate commit statuses, but can't run in parallel for now, see #290 for that.