### PR TITLE
ELPP-3598 Fastly healthchecks

### DIFF
--- a/projects/elife.yaml
+++ b/projects/elife.yaml
@@ -134,6 +134,7 @@ defaults:
             dns:
                 cname: u2.shared.global.fastly.net
             gcslogging: false
+            healthcheck: false
         subdomains: []
         elasticache:
             # elasticache defaults only used if an `rds` section present in project
@@ -370,6 +371,8 @@ api-gateway:
                     bucket: end2end-elife-fastly
                     path: api-gateway--test/
                     period: 1800
+                healthcheck:
+                    path: /ping-fastly
     vagrant:
         box: ubuntu/trusty64 # Ubuntu 14.04, deprecated
         ports:

--- a/src/buildercore/cfngen.py
+++ b/src/buildercore/cfngen.py
@@ -261,6 +261,7 @@ def build_context_fastly(context, parameterize):
             'subdomains': [build_subdomain(x) for x in context['project']['aws']['fastly']['subdomains']],
             'subdomains-without-dns': [build_subdomain(x) for x in context['project']['aws']['fastly']['subdomains-without-dns']],
             'dns': context['project']['aws']['fastly']['dns'],
+            'healthcheck': context['project']['aws']['fastly']['healthcheck'],
             # TODO: add templating of bucket name
             'gcslogging': context['project']['aws']['fastly']['gcslogging'],
         }

--- a/src/buildercore/terraform.py
+++ b/src/buildercore/terraform.py
@@ -95,6 +95,15 @@ def render(context):
             }
         },
     }
+
+    if context['fastly']['healthcheck']:
+        tf_file['resource'][RESOURCE_TYPE_FASTLY][RESOURCE_NAME_FASTLY]['healthcheck'] = {
+            'name': 'default',
+            'host': context['full_hostname'],
+            'path': context['fastly']['healthcheck']['path'],
+        }
+        tf_file['resource'][RESOURCE_TYPE_FASTLY][RESOURCE_NAME_FASTLY]['backend']['healthcheck'] = 'default'
+
     if context['fastly']['gcslogging']:
         gcslogging = context['fastly']['gcslogging']
         # TODO: require FASTLY_GCS_EMAIL env variable

--- a/src/tests/fixtures/projects/dummy-project.yaml
+++ b/src/tests/fixtures/projects/dummy-project.yaml
@@ -98,6 +98,7 @@ defaults:
             dns:
                 cname: something.fastly.net
             gcslogging: false
+            healthcheck: false
         subdomains: []
         elasticache:
             # elasticache defaults only used if an `rds` section present in project
@@ -325,6 +326,8 @@ project-with-fastly-complex:
                 - "{instance}--cdn2-of-www"
             subdomains-without-dns:
                 - "future"
+            healthcheck:
+                path: /ping-fastly
 
 project-with-fastly-gcs:
     repo: ssh://git@github.com/elifesciences/dummy3

--- a/src/tests/test_buildercore_terraform.py
+++ b/src/tests/test_buildercore_terraform.py
@@ -103,7 +103,8 @@ class TestBuildercoreTerraform(base.BaseCase):
                                 'port': 443,
                                 'use_ssl': True,
                                 'ssl_cert_hostname': 'prod--www.example.org',
-                                'ssl_check_cert': True
+                                'ssl_check_cert': True,
+                                'healthcheck': 'default',
                             },
                             'request_setting': {
                                 'name': 'default',
@@ -125,6 +126,11 @@ class TestBuildercoreTerraform(base.BaseCase):
                                                   'text/plain', 'text/xml'],
                                 'extensions': ['css', 'eot', 'html', 'ico', 'js', 'json', 'otf',
                                                'ttf'],
+                            },
+                            'healthcheck': {
+                                'host': 'prod--www.example.org',
+                                'name': 'default',
+                                'path': '/ping-fastly',
                             },
                             'force_destroy': True
                         }


### PR DESCRIPTION
Use default values, apart from the path specified as `/ping-fastly`.