### PR TITLE
ELPP-3598 Healthcheck real world feedback

### DIFF
--- a/projects/elife.yaml
+++ b/projects/elife.yaml
@@ -374,7 +374,7 @@ api-gateway:
                 healthcheck:
                     path: /ping-fastly
                     check-interval: 30000
-                    timeout: 10000
+                    timeout: 2000
     vagrant:
         box: ubuntu/trusty64 # Ubuntu 14.04, deprecated
         ports:

--- a/projects/elife.yaml
+++ b/projects/elife.yaml
@@ -370,9 +370,11 @@ api-gateway:
                 gcslogging:
                     bucket: end2end-elife-fastly
                     path: api-gateway--test/
-                    period: 1800
+                    period: 600
                 healthcheck:
                     path: /ping-fastly
+                    check-interval: 30000
+                    timeout: 10000
     vagrant:
         box: ubuntu/trusty64 # Ubuntu 14.04, deprecated
         ports:

--- a/src/buildercore/terraform.py
+++ b/src/buildercore/terraform.py
@@ -37,6 +37,7 @@ FASTLY_LOG_FORMAT = """{
   "request_user_agent":"%{cstr_escape(req.http.User-Agent)}V",
   "request_accept_language":"%{cstr_escape(req.http.Accept-Language)}V",
   "request_accept_charset":"%{cstr_escape(req.http.Accept-Charset)}V",
+  "response_status": "%>s",
   "cache_status":"%{regsub(fastly_info.state, "^(HIT-(SYNTH)|(HITPASS|HIT|MISS|PASS|ERROR|PIPE)).*", "\\\\2\\\\3") }V"
 }"""
 

--- a/src/buildercore/terraform.py
+++ b/src/buildercore/terraform.py
@@ -102,6 +102,8 @@ def render(context):
             'name': 'default',
             'host': context['full_hostname'],
             'path': context['fastly']['healthcheck']['path'],
+            'check_interval': context['fastly']['healthcheck']['check-interval'],
+            'timeout': context['fastly']['healthcheck']['timeout'],
         }
         tf_file['resource'][RESOURCE_TYPE_FASTLY][RESOURCE_NAME_FASTLY]['backend']['healthcheck'] = 'default'
 

--- a/src/tests/fixtures/projects/dummy-project.yaml
+++ b/src/tests/fixtures/projects/dummy-project.yaml
@@ -328,6 +328,8 @@ project-with-fastly-complex:
                 - "future"
             healthcheck:
                 path: /ping-fastly
+                check-interval: 30000
+                timeout: 10000
 
 project-with-fastly-gcs:
     repo: ssh://git@github.com/elifesciences/dummy3

--- a/src/tests/test_buildercore_terraform.py
+++ b/src/tests/test_buildercore_terraform.py
@@ -131,6 +131,8 @@ class TestBuildercoreTerraform(base.BaseCase):
                                 'host': 'prod--www.example.org',
                                 'name': 'default',
                                 'path': '/ping-fastly',
+                                'check_interval': 30000,
+                                'timeout': 10000,
                             },
                             'force_destroy': True
                         }


### PR DESCRIPTION
New Relic probes from Brazil and Japan fail completely due to the local Fastly servers not reaching the origin within the healthcheck timeouts.