### PR TITLE
Allow masterless master server builds

### DIFF
--- a/scripts/update-master.sh
+++ b/scripts/update-master.sh
@@ -17,7 +17,12 @@ for formula in *; do
         cd "$formula"
         git reset --hard
         git clean -d --force
-        git pull --rebase
+        current_branch=$(git rev-parse --abbrev-ref HEAD)
+        if [ "$current_branch" != 'HEAD' ]; then
+            git pull --rebase
+        else
+            echo "Repository on a detached HEAD, not pulling any branch"
+        fi
     )
 done
 


### PR DESCRIPTION
Builds like https://github.com/elifesciences/master-server-formula/pull/1 seem to fail because the update of master servers attempts to unpin the formulas the have. In case of a masterless server, we should leave the formulas alone as one of them can be the master-server-formula being tested. In general, we can avoid unpinning these repositories.

This is a safe operation as unpinning would have failed anyway before: if this were regularly happening we would have seen it:

```
i[54.204.241.31] out: + git pull --rebase
[54.204.241.31] out: You are not currently on a branch.
[54.204.241.31] out: Please specify which branch you want to rebase against.
[54.204.241.31] out: See git-pull(1) for details.
[54.204.241.31] out:
[54.204.241.31] out:     git pull <remote> <branch>
```