### PR TITLE
Configure master server DNS for Vault

### DIFF
--- a/projects/elife.yaml
+++ b/projects/elife.yaml
@@ -238,9 +238,10 @@ heavybox:
         ram: 2048
 
 master-server:
+    subdomain: master-server
     # formula-repo for the 'master-server' project should contain the
     # confidential pillar data, master config and state top file.
-    # see: https://github.com/elifesciences/builder-private-example
+    # see: https://github.com/elifesciences/builder-private
     formula-repo: https://github.com/elifesciences/master-server-formula
     aws:
         ec2: {}
@@ -252,7 +253,11 @@ master-server:
             - 4505: # salt return port
                 cidr-ip: 10.0.0.0/16
             - 8080 # chemist, Github webhooks for formulas
-    aws-alt: {}
+            - 9200 # Vault, secrets management
+    aws-alt:
+        '2018-04-09-2':
+            subdomains:
+                - master-server
     vagrant: {}
 
 lax:


### PR DESCRIPTION
- Added `2018-04-09-2--master-server.elifescience.org`
- Added `master-server.elifesciences.org` CNAME that can be used for the canonical master server
- Opened port 8200 for Vault remote usage