### PR TITLE
ELPP-3623 Allow Vault child tokens

### DIFF
--- a/.vault/builder-user.hcl
+++ b/.vault/builder-user.hcl
@@ -13,6 +13,12 @@ path "auth/token/revoke-self" {
     capabilities = ["update"]
 }
 
+# Allow a token to create child tokens
+path "auth/token/create" {
+    capabilities = ["create", "update"]
+}
+
+
 # Allow a token to look up its own capabilities on a path
 path "sys/capabilities-self" {
     capabilities = ["update"]

--- a/src/vault.py
+++ b/src/vault.py
@@ -23,13 +23,19 @@ def logout():
     local(cmd)
 
 @task
+def policies_update():
+    _warning_root_token()
+    cmd = "VAULT_ADDR=%s vault policy write %s .vault/%s.hcl" % (vault_addr(), vault_policy(), vault_policy())
+    local(cmd)
+
+@task
 def token_lookup(token):
     cmd = "VAULT_ADDR=%s VAULT_TOKEN=%s vault token lookup" % (vault_addr(), token)
     local(cmd)
 
 @task
 def token_create():
-    print("Warning: you should be authenticated with a root token to effectively create a new token here")
+    _warning_root_token()
     token = utils.get_input('token display name: ')
     if not token or not token.strip():
         print("a token display name is required")
@@ -41,3 +47,6 @@ def token_create():
 def token_revoke(token):
     cmd = "VAULT_ADDR=%s vault token revoke %s" % (vault_addr(), token)
     local(cmd)
+
+def _warning_root_token():
+    print("Warning: you should probably be authenticated with a root token for this operation")

--- a/src/vault.py
+++ b/src/vault.py
@@ -29,6 +29,7 @@ def token_lookup(token):
 
 @task
 def token_create():
+    print("Warning: you should be authenticated with a root token to effectively create a new token here")
     token = utils.get_input('token display name: ')
     if not token or not token.strip():
         print("a token display name is required")


### PR DESCRIPTION
Widens the policy for builder users to be able to create child tokens from their own. Child tokens are created by Terraform, and are revoked as soon as their parent (the user's token) is revoked.

This lets me run `bldr update_infrastructure:api-gateway--test` when logged in with a user's token.