### PR TITLE
Add commands for token administration in Vault

### DIFF
--- a/src/vault.py
+++ b/src/vault.py
@@ -34,6 +34,18 @@ def token_lookup(token):
     local(cmd)
 
 @task
+def token_list_accessors():
+    _warning_root_token()
+    cmd = "VAULT_ADDR=%s vault list auth/token/accessors" % (vault_addr())
+    local(cmd)
+
+@task
+def token_lookup_accessor(accessor):
+    _warning_root_token()
+    cmd = "VAULT_ADDR=%s vault token lookup -accessor %s" % (vault_addr(), accessor)
+    local(cmd)
+
+@task
 def token_create():
     _warning_root_token()
     token = utils.get_input('token display name: ')


### PR DESCRIPTION
Using the root token, list and access the names of all other tokens; possibly revoke some of them.

The values printed are not the tokens themselves, but the `token
accessors` which are aliases only allowing for lookup and revoking
rather than actual token usage.