### PR TITLE
ELPP-3598 Setup harcoded response object and condition for each error code

### DIFF
--- a/projects/elife.yaml
+++ b/projects/elife.yaml
@@ -379,6 +379,11 @@ api-gateway:
                     bucket: end2end-elife-fastly
                     path: api-gateway--test/
                     period: 600
+                errors:
+                    url: https://prod-elife-error-pages.s3-website-us-east-1.amazonaws.com/
+                    codes:
+                        503: "5xx.html"
+                        404: "404.html"
                 healthcheck:
                     path: /ping-fastly
                     check-interval: 30000

--- a/projects/elife.yaml
+++ b/projects/elife.yaml
@@ -383,8 +383,9 @@ api-gateway:
                 errors:
                     url: https://prod-elife-error-pages.s3.amazonaws.com/
                     codes:
-                        503: "5xx.html"
                         404: "404.html"
+                        # temporarily disabled because of non-ASCII characters
+                        #503: "5xx.html"
                 healthcheck:
                     path: /ping-fastly
                     check-interval: 30000

--- a/projects/elife.yaml
+++ b/projects/elife.yaml
@@ -135,6 +135,7 @@ defaults:
                 cname: u2.shared.global.fastly.net
             gcslogging: false
             healthcheck: false
+            errors: false
             vcl: []
         subdomains: []
         elasticache:

--- a/projects/elife.yaml
+++ b/projects/elife.yaml
@@ -380,7 +380,7 @@ api-gateway:
                     path: api-gateway--test/
                     period: 600
                 errors:
-                    url: https://prod-elife-error-pages.s3-website-us-east-1.amazonaws.com/
+                    url: https://prod-elife-error-pages.s3.amazonaws.com/
                     codes:
                         503: "5xx.html"
                         404: "404.html"

--- a/src/buildercore/cfngen.py
+++ b/src/buildercore/cfngen.py
@@ -264,6 +264,7 @@ def build_context_fastly(context, parameterize):
             'subdomains-without-dns': [build_subdomain(x) for x in context['project']['aws']['fastly']['subdomains-without-dns']],
             'dns': context['project']['aws']['fastly']['dns'],
             'healthcheck': context['project']['aws']['fastly']['healthcheck'],
+            'errors': context['project']['aws']['fastly']['errors'],
             # TODO: add templating of bucket name
             'gcslogging': context['project']['aws']['fastly']['gcslogging'],
             'vcl': context['project']['aws']['fastly']['vcl'],

--- a/src/buildercore/terraform.py
+++ b/src/buildercore/terraform.py
@@ -66,6 +66,10 @@ FASTLY_LOG_LINE_PREFIX = 'blank' # no prefix
 # https://github.com/terraform-providers/terraform-provider-fastly/issues/7 tracks when snippets could become available in Terraform
 FASTLY_MAIN_VCL_KEY = 'main'
 
+FASTLY_ERRORS_RESPONSE = {
+    404: 'Not Found',
+    503: 'Service Unavailable',
+}
 
 def render(context):
     if not context['fastly']:
@@ -137,9 +141,9 @@ def render(context):
             response_objects.append({
                 'name': 'error-%s' % code,
                 'status': int(code),
-                # TODO: replace
+                'response': FASTLY_ERRORS_RESPONSE[int(code)],
                 'content': '${data.http.error-page-%s.body}' % code,
-                'content_type': 'text/html; charset=iso-8859-1',
+                'content_type': 'text/html; charset=us-ascii',
                 'cache_condition': cache_condition['name'],
             })
             data[DATA_TYPE_HTTP]['error-page-%d' % code] = {

--- a/src/buildercore/terraform.py
+++ b/src/buildercore/terraform.py
@@ -11,10 +11,13 @@ from . import fastly
 EMPTY_TEMPLATE = '{}'
 PROVIDER_FASTLY_VERSION = '0.1.4',
 PROVIDER_VAULT_VERSION = '1.1'
+
 RESOURCE_TYPE_FASTLY = 'fastly_service_v1'
 RESOURCE_NAME_FASTLY = 'fastly-cdn'
-RESOURCE_TYPE_VAULT = 'vault_generic_secret'
-RESOURCE_NAME_VAULT_GCS_LOGGING = 'fastly-gcs-logging'
+
+DATA_TYPE_VAULT_GENERIC_SECRET = 'vault_generic_secret'
+DATA_TYPE_HTTP = 'http'
+DATA_NAME_VAULT_GCS_LOGGING = 'fastly-gcs-logging'
 
 FASTLY_GZIP_TYPES = ['text/html', 'application/x-javascript', 'text/css', 'application/javascript',
                      'text/javascript', 'application/json', 'application/vnd.ms-fontobject',
@@ -123,7 +126,7 @@ def render(context):
         errors = context['fastly']['errors']
         response_objects = []
         cache_conditions = []
-        data['http'] = {}
+        data[DATA_TYPE_HTTP] = {}
         for code, path in errors['codes'].items():
             cache_condition = {
                 'name': 'condition-%s' % code,
@@ -139,7 +142,7 @@ def render(context):
                 'content_type': 'text/html; charset=iso-8859-1',
                 'cache_condition': cache_condition['name'],
             })
-            data['http']['error-page-%d' % code] = {
+            data[DATA_TYPE_HTTP]['error-page-%d' % code] = {
                 'url': '%s%s' % (errors['url'], path),
             }
         tf_file['resource'][RESOURCE_TYPE_FASTLY][RESOURCE_NAME_FASTLY]['response_object'] = response_objects
@@ -161,11 +164,11 @@ def render(context):
             # not supported yet
             #'format_version': FASTLY_LOG_FORMAT_VERSION,
             'message_type': FASTLY_LOG_LINE_PREFIX,
-            'email': "${data.%s.%s.data[\"email\"]}" % (RESOURCE_TYPE_VAULT, RESOURCE_NAME_VAULT_GCS_LOGGING),
-            'secret_key': "${data.%s.%s.data[\"secret_key\"]}" % (RESOURCE_TYPE_VAULT, RESOURCE_NAME_VAULT_GCS_LOGGING),
+            'email': "${data.%s.%s.data[\"email\"]}" % (DATA_TYPE_VAULT_GENERIC_SECRET, DATA_NAME_VAULT_GCS_LOGGING),
+            'secret_key': "${data.%s.%s.data[\"secret_key\"]}" % (DATA_TYPE_VAULT_GENERIC_SECRET, DATA_NAME_VAULT_GCS_LOGGING),
         }
-        data[RESOURCE_TYPE_VAULT] = {
-            RESOURCE_NAME_VAULT_GCS_LOGGING: {
+        data[DATA_TYPE_VAULT_GENERIC_SECRET] = {
+            DATA_NAME_VAULT_GCS_LOGGING: {
                 'path': 'secret/builder/apikey/fastly-gcs-logging',
             }
         }

--- a/src/buildercore/terraform.py
+++ b/src/buildercore/terraform.py
@@ -66,9 +66,6 @@ FASTLY_LOG_LINE_PREFIX = 'blank' # no prefix
 # https://github.com/terraform-providers/terraform-provider-fastly/issues/7 tracks when snippets could become available in Terraform
 FASTLY_MAIN_VCL_KEY = 'main'
 
-# e.g. 404: 'Not Found'
-FASTLY_RESPONSE_REASON_PHRASES = http_responses()
-
 def render(context):
     if not context['fastly']:
         return EMPTY_TEMPLATE
@@ -139,7 +136,7 @@ def render(context):
             response_objects.append({
                 'name': 'error-%s' % code,
                 'status': int(code),
-                'response': FASTLY_RESPONSE_REASON_PHRASES[int(code)],
+                'response': http_responses()[int(code)],
                 'content': '${data.http.error-page-%s.body}' % code,
                 'content_type': 'text/html; charset=us-ascii',
                 'cache_condition': cache_condition['name'],

--- a/src/buildercore/terraform.py
+++ b/src/buildercore/terraform.py
@@ -5,7 +5,7 @@ import shutil
 from python_terraform import Terraform
 from .config import BUILDER_BUCKET, BUILDER_REGION, TERRAFORM_DIR, ConfigurationError
 from .context_handler import only_if
-from .utils import ensure, mkdir_p
+from .utils import ensure, mkdir_p, http_responses
 from . import fastly
 
 EMPTY_TEMPLATE = '{}'
@@ -66,10 +66,8 @@ FASTLY_LOG_LINE_PREFIX = 'blank' # no prefix
 # https://github.com/terraform-providers/terraform-provider-fastly/issues/7 tracks when snippets could become available in Terraform
 FASTLY_MAIN_VCL_KEY = 'main'
 
-FASTLY_ERRORS_RESPONSE = {
-    404: 'Not Found',
-    503: 'Service Unavailable',
-}
+# e.g. 404: 'Not Found'
+FASTLY_RESPONSE_REASON_PHRASES = http_responses()
 
 def render(context):
     if not context['fastly']:
@@ -141,7 +139,7 @@ def render(context):
             response_objects.append({
                 'name': 'error-%s' % code,
                 'status': int(code),
-                'response': FASTLY_ERRORS_RESPONSE[int(code)],
+                'response': FASTLY_RESPONSE_REASON_PHRASES[int(code)],
                 'content': '${data.http.error-page-%s.body}' % code,
                 'content_type': 'text/html; charset=us-ascii',
                 'cache_condition': cache_condition['name'],

--- a/src/buildercore/terraform.py
+++ b/src/buildercore/terraform.py
@@ -106,8 +106,8 @@ def render(context):
                 }
             }
         },
-        'data': {},
     }
+    data = {}
 
     if context['fastly']['healthcheck']:
         tf_file['resource'][RESOURCE_TYPE_FASTLY][RESOURCE_NAME_FASTLY]['healthcheck'] = {
@@ -123,7 +123,7 @@ def render(context):
         errors = context['fastly']['errors']
         response_objects = []
         cache_conditions = []
-        tf_file['data']['http'] = {}
+        data['http'] = {}
         for code, path in errors['codes'].items():
             cache_condition = {
                 'name': 'condition-%s' % code,
@@ -139,7 +139,7 @@ def render(context):
                 'content_type': 'text/html; charset=iso-8859-1',
                 'cache_condition': cache_condition['name'],
             })
-            tf_file['data']['http']['error-page-%d' % code] = {
+            data['http']['error-page-%d' % code] = {
                 'url': '%s%s' % (errors['url'], path),
             }
         tf_file['resource'][RESOURCE_TYPE_FASTLY][RESOURCE_NAME_FASTLY]['response_object'] = response_objects
@@ -164,7 +164,7 @@ def render(context):
             'email': "${data.%s.%s.data[\"email\"]}" % (RESOURCE_TYPE_VAULT, RESOURCE_NAME_VAULT_GCS_LOGGING),
             'secret_key': "${data.%s.%s.data[\"secret_key\"]}" % (RESOURCE_TYPE_VAULT, RESOURCE_NAME_VAULT_GCS_LOGGING),
         }
-        tf_file['data'][RESOURCE_TYPE_VAULT] = {
+        data[RESOURCE_TYPE_VAULT] = {
             RESOURCE_NAME_VAULT_GCS_LOGGING: {
                 'path': 'secret/builder/apikey/fastly-gcs-logging',
             }
@@ -191,6 +191,9 @@ def render(context):
             ),
             'main': True,
         })
+
+    if data:
+        tf_file['data'] = data
 
     return json.dumps(tf_file)
 

--- a/src/buildercore/terraform.py
+++ b/src/buildercore/terraform.py
@@ -136,6 +136,7 @@ def render(context):
                 'status': int(code),
                 # TODO: replace
                 'content': '${data.http.error-page-%s.body}' % code,
+                'content_type': 'text/html; charset=iso-8859-1',
                 'cache_condition': cache_condition['name'],
             })
             tf_file['data']['http']['error-page-%d' % code] = {

--- a/src/buildercore/utils.py
+++ b/src/buildercore/utils.py
@@ -373,3 +373,13 @@ def tempdir():
     # usage: tempdir, killer = tempdir(); killer()
     name = tempfile.mkdtemp()
     return (name, lambda: shutil.rmtree(name))
+
+def http_responses():
+    try:
+        # Python 2
+        import httplib
+        return httplib.responses
+    except ImportError:
+        # Python 3
+        import http.client
+        return http.client.responses

--- a/src/buildercore/utils.py
+++ b/src/buildercore/utils.py
@@ -8,6 +8,7 @@ from collections import OrderedDict, Iterable
 from os.path import join
 from more_itertools import unique_everseen
 import logging
+from kids.cache import cache as cached
 from fabric.operations import get, put
 import tempfile, shutil
 
@@ -374,7 +375,11 @@ def tempdir():
     name = tempfile.mkdtemp()
     return (name, lambda: shutil.rmtree(name))
 
+@cached
 def http_responses():
+    """a map of integers to response reason phrases
+
+    e.g. 404: 'Not Found'"""
     try:
         # Python 2
         import httplib

--- a/src/tests/fixtures/projects/dummy-project.yaml
+++ b/src/tests/fixtures/projects/dummy-project.yaml
@@ -99,6 +99,7 @@ defaults:
                 cname: something.fastly.net
             gcslogging: false
             healthcheck: false
+            errors: false
             vcl: []
         subdomains: []
         elasticache:

--- a/src/tests/fixtures/projects/dummy-project.yaml
+++ b/src/tests/fixtures/projects/dummy-project.yaml
@@ -333,6 +333,10 @@ project-with-fastly-complex:
                 path: /ping-fastly
                 check-interval: 30000
                 timeout: 10000
+            errors:
+                url: https://example.com
+                codes:
+                    503: "/"
             vcl:
                 - "gzip-by-content-type-suffix"
 

--- a/src/tests/test_buildercore_terraform.py
+++ b/src/tests/test_buildercore_terraform.py
@@ -146,6 +146,21 @@ class TestBuildercoreTerraform(base.BaseCase):
                                 'check_interval': 30000,
                                 'timeout': 10000,
                             },
+                            'condition': [
+                                {
+                                    'name': 'condition-503',
+                                    'statement': 'beresp.status == 503',
+                                    'type': 'CACHE',
+                                },
+                            ],
+                            'response_object': [
+                                {
+                                    'name': 'error-503',
+                                    'status': 503,
+                                    'content': 'Error HTML for 503',
+                                    'cache_condition': 'condition-503',
+                                },
+                            ],
                             'vcl': [
                                 {
                                     'name': 'gzip-by-content-type-suffix',

--- a/src/tests/test_buildercore_terraform.py
+++ b/src/tests/test_buildercore_terraform.py
@@ -93,6 +93,13 @@ class TestBuildercoreTerraform(base.BaseCase):
         template = self._parse_template(terraform_template)
         self.assertEqual(
             {
+                'data': {
+                    'http': {
+                        'error-page-503': {
+                            'url': 'https://example.com/'
+                        },
+                    },
+                },
                 'resource': {
                     'fastly_service_v1': {
                         # must be unique but only in a certain context like this, use some constants
@@ -157,7 +164,7 @@ class TestBuildercoreTerraform(base.BaseCase):
                                 {
                                     'name': 'error-503',
                                     'status': 503,
-                                    'content': 'Error HTML for 503',
+                                    'content': '${data.http.error-page-503.body}',
                                     'cache_condition': 'condition-503',
                                 },
                             ],

--- a/src/tests/test_buildercore_terraform.py
+++ b/src/tests/test_buildercore_terraform.py
@@ -164,6 +164,7 @@ class TestBuildercoreTerraform(base.BaseCase):
                                 {
                                     'name': 'error-503',
                                     'status': 503,
+                                    'response': 'Service Unavailable',
                                     'content': '${data.http.error-page-503.body}',
                                     'content_type': 'text/html; charset=iso-8859-1',
                                     'cache_condition': 'condition-503',

--- a/src/tests/test_buildercore_terraform.py
+++ b/src/tests/test_buildercore_terraform.py
@@ -166,7 +166,7 @@ class TestBuildercoreTerraform(base.BaseCase):
                                     'status': 503,
                                     'response': 'Service Unavailable',
                                     'content': '${data.http.error-page-503.body}',
-                                    'content_type': 'text/html; charset=iso-8859-1',
+                                    'content_type': 'text/html; charset=us-ascii',
                                     'cache_condition': 'condition-503',
                                 },
                             ],

--- a/src/tests/test_buildercore_terraform.py
+++ b/src/tests/test_buildercore_terraform.py
@@ -39,6 +39,7 @@ class TestBuildercoreTerraform(base.BaseCase):
         template = self._parse_template(terraform_template)
         self.assertEqual(
             {
+                'data': {},
                 'resource': {
                     'fastly_service_v1': {
                         # must be unique but only in a certain context like this, use some constants
@@ -165,6 +166,7 @@ class TestBuildercoreTerraform(base.BaseCase):
                                     'name': 'error-503',
                                     'status': 503,
                                     'content': '${data.http.error-page-503.body}',
+                                    'content_type': 'text/html; charset=iso-8859-1',
                                     'cache_condition': 'condition-503',
                                 },
                             ],

--- a/src/tests/test_buildercore_terraform.py
+++ b/src/tests/test_buildercore_terraform.py
@@ -39,7 +39,6 @@ class TestBuildercoreTerraform(base.BaseCase):
         template = self._parse_template(terraform_template)
         self.assertEqual(
             {
-                'data': {},
                 'resource': {
                     'fastly_service_v1': {
                         # must be unique but only in a certain context like this, use some constants


### PR DESCRIPTION
Contrived example at https://test--cdn-gateway.elifesciences.org/not-found where the sample gateway (which shouldn't even return non-JSON responses) returns the HTML error page.

Implemented using https://www.terraform.io/docs/providers/http/data_source.html to make Terraform load the URLs and dynamically pass them in.