### PR TITLE
Use terraform plan to produce a diff of what is going to happen

### DIFF
--- a/py2-requirements.txt
+++ b/py2-requirements.txt
@@ -4,7 +4,6 @@ boto==2.46.1
 botocore==1.5.95
 boto3==1.4.4
 coverage==4.3.4
-deepdiff==3.3.0
 Fabric==1.13.2
 green==2.7.0
 kids.cache==0.0.4

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,7 +4,6 @@ boto==2.48.0
 boto3==1.6.8
 botocore==1.9.8
 coverage==4.5.1
-deepdiff==3.3.0
 Fabric3==1.14.post1
 green==2.12.1
 ipython==5.5.0

--- a/src/buildercore/cfngen.py
+++ b/src/buildercore/cfngen.py
@@ -408,11 +408,6 @@ def template_delta(context):
     template = json.loads(cloudformation.render_template(context))
     new_terraform_template_file = terraform.EMPTY_TEMPLATE
     if context['fastly']:
-        # TODO: disabled as not all people may have the old file locally
-        # (or its latest version)
-        # to perform a diff, we should actually be syncing the file with S3...
-        # at this point, we may as well run `terraform plan` instead
-        #old_terraform_template_file = terraform.read_template(context['stackname'])
         new_terraform_template_file = terraform.render(context)
 
     def _related_to_ec2(output):

--- a/src/buildercore/cfngen.py
+++ b/src/buildercore/cfngen.py
@@ -16,7 +16,7 @@ We want to add an external volume to an EC2 instance to increase available space
 """
 import os, json, copy
 import re
-from collections import OrderedDict, namedtuple
+from collections import OrderedDict
 import netaddr
 from . import utils, cloudformation, terraform, core, project, context_handler
 from .utils import ensure, lmap
@@ -399,31 +399,6 @@ UPDATABLE_TITLE_PATTERNS = ['^CloudFront.*', '^ElasticLoadBalancer.*', '^EC2Inst
 REMOVABLE_TITLE_PATTERNS = ['^CloudFront.*', '^CnameDNS\\d+$', 'FastlyDNS\\d+$', '^ExtDNS$', '^ExtraStorage.+$', '^MountPoint.+$', '^.+Queue$', '^EC2Instance.+$', '^IntDNS.*$', '^ElastiCache.*$', '^.+Topic$']
 EC2_NOT_UPDATABLE_PROPERTIES = ['ImageId', 'Tags', 'UserData']
 
-# CloudFormation is nicely chopped up into:
-# * what to add
-# * what to modify
-# * what to remove
-# What we see here is the new Terraform generated.tf file, containing all resources (just Fastly so far).
-# We can do a diff with the current one which would already be an improvement, but ultimately the source of truth
-# is changing it and running a terraform plan to see proposed changes. We should however roll it back if the user
-# doesn't confirm.
-"""represents a delta between and old and new CloudFormation generated template, showing which resources are being added, updated, or removed
-
-Extends the namedtuple-generated class to add custom methods."""
-class Delta(namedtuple('Delta', ['plus', 'edit', 'minus', 'terraform'])):
-    @property
-    def non_empty(self):
-        return any([
-            self.plus['Resources'],
-            self.plus['Outputs'],
-            self.edit['Resources'],
-            self.edit['Outputs'],
-            self.minus['Resources'],
-            self.minus['Outputs'],
-            self.terraform
-        ])
-_empty_cloudformation_dictionary = {'Resources': {}, 'Outputs': {}}
-Delta.__new__.__defaults__ = (_empty_cloudformation_dictionary, _empty_cloudformation_dictionary, _empty_cloudformation_dictionary, None)
 
 def template_delta(context):
     """given an already existing template, regenerates it and produces a delta containing only the new resources.
@@ -515,7 +490,7 @@ def template_delta(context):
     delta_minus_resources = {r: v for r, v in old_template['Resources'].items() if r not in template['Resources'] and _title_is_removable(r)}
     delta_minus_outputs = {o: v for o, v in old_template.get('Outputs', {}).items() if o not in template.get('Outputs', {})}
 
-    return Delta(
+    return cloudformation.CloudFormationDelta(
         {
             'Resources': delta_plus_resources,
             'Outputs': delta_plus_outputs,

--- a/src/buildercore/cfngen.py
+++ b/src/buildercore/cfngen.py
@@ -406,7 +406,6 @@ def template_delta(context):
     Some the existing resources are treated as immutable and not put in the delta. Most that support non-destructive updates like CloudFront are instead included"""
     old_template = read_template(context['stackname'])
     template = json.loads(cloudformation.render_template(context))
-    old_terraform_template_file = terraform.EMPTY_TEMPLATE
     new_terraform_template_file = terraform.EMPTY_TEMPLATE
     if context['fastly']:
         # TODO: disabled as not all people may have the old file locally

--- a/src/buildercore/cfngen.py
+++ b/src/buildercore/cfngen.py
@@ -504,8 +504,10 @@ def merge_delta(stackname, delta):
     """Merges the new resources in delta in the local copy of the Cloudformation  template"""
     template = read_template(stackname)
     apply_delta(template, delta)
+    # TODO: possibly pre-write the cloudformation template
+    # the source of truth can always be redownloaded from the CloudFormation API
     write_cloudformation_template(stackname, json.dumps(template))
-    terraform.write_template(stackname, str(delta.terraform))
+    # nothing to do on Terraform as the plan file is already there
     return template
 
 def apply_delta(template, delta):

--- a/src/buildercore/cfngen.py
+++ b/src/buildercore/cfngen.py
@@ -17,7 +17,6 @@ We want to add an external volume to an EC2 instance to increase available space
 import os, json, copy
 import re
 from collections import OrderedDict, namedtuple
-import deepdiff
 import netaddr
 from . import utils, cloudformation, terraform, core, project, context_handler
 from .utils import ensure, lmap
@@ -426,16 +425,6 @@ class Delta(namedtuple('Delta', ['plus', 'edit', 'minus', 'terraform'])):
 _empty_cloudformation_dictionary = {'Resources': {}, 'Outputs': {}}
 Delta.__new__.__defaults__ = (_empty_cloudformation_dictionary, _empty_cloudformation_dictionary, _empty_cloudformation_dictionary, None)
 
-"""represents a delta between and old and new Terraform generated template, showing which resources are being added, updated, or removed.
-
-Extends the namedtuple-generated class to add custom methods."""
-class TerraformDelta(namedtuple('TerraformDelta', ['old_contents', 'new_contents'])):
-    def __str__(self):
-        return self.new_contents
-
-    def diff(self):
-        return deepdiff.DeepDiff(json.loads(self.old_contents), json.loads(self.new_contents))
-
 def template_delta(context):
     """given an already existing template, regenerates it and produces a delta containing only the new resources.
 
@@ -539,7 +528,7 @@ def template_delta(context):
             'Resources': delta_minus_resources,
             'Outputs': delta_minus_outputs,
         },
-        TerraformDelta(old_terraform_template_file, new_terraform_template_file)
+        terraform.generate_delta(context, new_terraform_template_file)
     )
 
 def merge_delta(stackname, delta):

--- a/src/buildercore/cloudformation.py
+++ b/src/buildercore/cloudformation.py
@@ -1,3 +1,4 @@
+from collections import namedtuple
 import logging
 import backoff
 import botocore
@@ -20,3 +21,29 @@ def validate_template(pname, rendered_template):
     "remote cloudformation template checks."
     conn = core.boto_conn(pname, 'cloudformation', client=True)
     return conn.validate_template(TemplateBody=rendered_template)
+
+# CloudFormation is nicely chopped up into:
+# * what to add
+# * what to modify
+# * what to remove
+# What we see here is the new Terraform generated.tf file, containing all resources (just Fastly so far).
+# We can do a diff with the current one which would already be an improvement, but ultimately the source of truth
+# is changing it and running a terraform plan to see proposed changes. We should however roll it back if the user
+# doesn't confirm.
+class CloudFormationDelta(namedtuple('CloudFormationDelta', ['plus', 'edit', 'minus', 'terraform'])):
+    """represents a delta between and old and new CloudFormation generated template, showing which resources are being added, updated, or removed
+
+    Extends the namedtuple-generated class to add custom methods."""
+    @property
+    def non_empty(self):
+        return any([
+            self.plus['Resources'],
+            self.plus['Outputs'],
+            self.edit['Resources'],
+            self.edit['Outputs'],
+            self.minus['Resources'],
+            self.minus['Outputs'],
+            self.terraform
+        ])
+_empty_cloudformation_dictionary = {'Resources': {}, 'Outputs': {}}
+CloudFormationDelta.__new__.__defaults__ = (_empty_cloudformation_dictionary, _empty_cloudformation_dictionary, _empty_cloudformation_dictionary, None)

--- a/src/buildercore/cloudformation.py
+++ b/src/buildercore/cloudformation.py
@@ -1,3 +1,4 @@
+from collections import namedtuple
 import logging
 import backoff
 import botocore
@@ -20,3 +21,18 @@ def validate_template(pname, rendered_template):
     "remote cloudformation template checks."
     conn = core.boto_conn(pname, 'cloudformation', client=True)
     return conn.validate_template(TemplateBody=rendered_template)
+
+class CloudFormationDelta(namedtuple('Delta', ['plus', 'edit', 'minus'])):
+    """represents a delta between and old and new CloudFormation generated template, showing which resources are being added, updated, or removed
+
+    Extends the namedtuple-generated class to add custom methods."""
+    @property
+    def non_empty(self):
+        return any([
+            self.plus['Resources'],
+            self.plus['Outputs'],
+            self.edit['Resources'],
+            self.edit['Outputs'],
+            self.minus['Resources'],
+            self.minus['Outputs'],
+        ])

--- a/src/buildercore/cloudformation.py
+++ b/src/buildercore/cloudformation.py
@@ -1,4 +1,3 @@
-from collections import namedtuple
 import logging
 import backoff
 import botocore
@@ -21,29 +20,3 @@ def validate_template(pname, rendered_template):
     "remote cloudformation template checks."
     conn = core.boto_conn(pname, 'cloudformation', client=True)
     return conn.validate_template(TemplateBody=rendered_template)
-
-# CloudFormation is nicely chopped up into:
-# * what to add
-# * what to modify
-# * what to remove
-# What we see here is the new Terraform generated.tf file, containing all resources (just Fastly so far).
-# We can do a diff with the current one which would already be an improvement, but ultimately the source of truth
-# is changing it and running a terraform plan to see proposed changes. We should however roll it back if the user
-# doesn't confirm.
-class CloudFormationDelta(namedtuple('CloudFormationDelta', ['plus', 'edit', 'minus', 'terraform'])):
-    """represents a delta between and old and new CloudFormation generated template, showing which resources are being added, updated, or removed
-
-    Extends the namedtuple-generated class to add custom methods."""
-    @property
-    def non_empty(self):
-        return any([
-            self.plus['Resources'],
-            self.plus['Outputs'],
-            self.edit['Resources'],
-            self.edit['Outputs'],
-            self.minus['Resources'],
-            self.minus['Outputs'],
-            self.terraform
-        ])
-_empty_cloudformation_dictionary = {'Resources': {}, 'Outputs': {}}
-CloudFormationDelta.__new__.__defaults__ = (_empty_cloudformation_dictionary, _empty_cloudformation_dictionary, _empty_cloudformation_dictionary, None)

--- a/src/buildercore/terraform.py
+++ b/src/buildercore/terraform.py
@@ -1,5 +1,4 @@
 from collections import namedtuple
-import deepdiff
 import json
 import os
 from os.path import exists, join, basename

--- a/src/buildercore/terraform.py
+++ b/src/buildercore/terraform.py
@@ -1,8 +1,11 @@
+from collections import namedtuple
+import deepdiff
 import json
 import os
 from os.path import exists, join, basename
+import re
 import shutil
-from python_terraform import Terraform
+from python_terraform import Terraform, IsFlagged, IsNotFlagged
 from .config import BUILDER_BUCKET, BUILDER_REGION, TERRAFORM_DIR, ConfigurationError
 from .context_handler import only_if
 from .utils import ensure, mkdir_p
@@ -194,6 +197,29 @@ def read_template(stackname):
     with _open(stackname, 'generated', mode='r') as fp:
         return fp.read()
 
+class TerraformDelta(namedtuple('TerraformDelta', ['plan_output'])):
+    """represents a delta between and old and new Terraform generated template, showing which resources are being added, updated, or removed.
+
+    Extends the namedtuple-generated class to add custom methods."""
+
+    def __str__(self):
+        return self.plan_output
+
+def generate_delta(context, new_template):
+    write_template(context['stackname'], new_template)
+    terraform = init(context['stackname'], context)
+    terraform.plan(input=False, no_color=IsFlagged, capture_output=False, raise_on_error=True, detailed_exitcode=IsNotFlagged, out='out.plan')
+    return_code, stdout, stderr = terraform.plan('out.plan', input=False, no_color=IsFlagged, raise_on_error=True, detailed_exitcode=IsNotFlagged)
+    ensure(return_code == 0, "Exit code of `terraform plan out.plan` should be 0, not %s" % return_code)
+    ensure(stderr == '', "Stderr of `terraform plan out.plan` should be empty:\n%s" % stderr)
+    return TerraformDelta(_clean_stdout(stdout))
+
+def _clean_stdout(stdout):
+    stdout = re.sub(re.compile(r"The plan command .* as an argument.", re.MULTILINE | re.DOTALL), "", stdout)
+    stdout = re.sub(re.compile(r"Note: .* is subsequently run.", re.MULTILINE | re.DOTALL), "", stdout)
+    stdout = re.sub(re.compile(r"\n+", re.MULTILINE), "\n", stdout)
+    return stdout
+
 def init(stackname, context):
     working_dir = join(TERRAFORM_DIR, stackname) # ll: ./.cfn/terraform/project--prod/
     terraform = Terraform(working_dir=working_dir)
@@ -230,6 +256,7 @@ def init(stackname, context):
 def update(stackname, context):
     ensure('FASTLY_API_KEY' in os.environ, "a FASTLY_API_KEY environment variable is required to provision Fastly resources. See https://manage.fastly.com/account/personal/tokens", ConfigurationError)
     terraform = init(stackname, context)
+    # TODO: use out.plan
     terraform.apply(input=False, capture_output=False, raise_on_error=True)
 
 @only_if('fastly')

--- a/src/buildercore/terraform.py
+++ b/src/buildercore/terraform.py
@@ -205,6 +205,11 @@ class TerraformDelta(namedtuple('TerraformDelta', ['plan_output'])):
         return self.plan_output
 
 def generate_delta(context, new_template):
+    # simplification: unless Fastly is involved, the TerraformDelta will be empty
+    # this should eventually be removed, for example after test_buildercore_cfngen tests have been ported to test_buildercore_cloudformation
+    if not context['fastly']:
+        return None
+
     write_template(context['stackname'], new_template)
     terraform = init(context['stackname'], context)
     terraform.plan(input=False, no_color=IsFlagged, capture_output=False, raise_on_error=True, detailed_exitcode=IsNotFlagged, out='out.plan')

--- a/src/buildercore/terraform.py
+++ b/src/buildercore/terraform.py
@@ -255,8 +255,7 @@ def init(stackname, context):
 def update(stackname, context):
     ensure('FASTLY_API_KEY' in os.environ, "a FASTLY_API_KEY environment variable is required to provision Fastly resources. See https://manage.fastly.com/account/personal/tokens", ConfigurationError)
     terraform = init(stackname, context)
-    # TODO: use out.plan
-    terraform.apply(input=False, capture_output=False, raise_on_error=True)
+    terraform.apply('out.plan', input=False, capture_output=False, raise_on_error=True)
 
 @only_if('fastly')
 def destroy(stackname, context):

--- a/src/cfn.py
+++ b/src/cfn.py
@@ -88,8 +88,8 @@ def update_infrastructure(stackname):
     LOG.info("Create: %s", pformat(delta.plus))
     LOG.info("Update: %s", pformat(delta.edit))
     LOG.info("Delete: %s", pformat(delta.minus))
-    LOG.info("Terraform delta: %s", pformat(delta.terraform.diff()))
-    utils.confirm('Confirming changes to the stack template? This will rewrite the context and the CloudFormation template. Notice the delta *only shows changes to the template*, not to the context.')
+    LOG.info("Terraform delta: %s", delta.terraform)
+    utils.confirm('Confirming changes to CloudFormation and Terraform templates?')
 
     context_handler.write_context(stackname, context)
 

--- a/src/integration_tests/test_with_many_nodes.py
+++ b/src/integration_tests/test_with_many_nodes.py
@@ -91,18 +91,14 @@ class One(base.BaseCase):
         # two nodes rebooting in serial, node 1 first, both running
         expected_history = [
             [(1, 'running'), (2, 'running')],
-            [(1, 'stopping'), (2, 'running')],
             [(1, 'stopped'), (2, 'running')],
-            [(1, 'pending'), (2, 'running')],
             [(1, 'running'), (2, 'running')],
 
             # node2, stopped -> running
-            [(1, 'running'), (2, 'stopping')],
             [(1, 'running'), (2, 'stopped')],
-            [(1, 'running'), (2, 'pending')],
             [(1, 'running'), (2, 'running')],
         ]
-        self.assertEqual(expected_history, history)
+        self.assertEqual(expected_history, self._remove_transient_states(history))
 
     def test_restart_all_stopped(self):
         "multiple nodes can be restarted from a stopped state"
@@ -113,14 +109,12 @@ class One(base.BaseCase):
         expected_history = [
             # node1, stopped -> running
             [(1, 'stopped'), (2, 'stopped')],
-            [(1, 'pending'), (2, 'stopped')],
             [(1, 'running'), (2, 'stopped')],
 
             # node2, stopped -> running
-            [(1, 'running'), (2, 'pending')],
             [(1, 'running'), (2, 'running')],
         ]
-        self.assertEqual(expected_history, history)
+        self.assertEqual(expected_history, self._remove_transient_states(history))
 
     def test_restart_one_stopped(self):
         "multiple nodes can be restarted from a mixed state"
@@ -133,13 +127,18 @@ class One(base.BaseCase):
         expected_history = [
             # node1, stopped -> running
             [(1, 'stopped'), (2, 'running')],
-            [(1, 'pending'), (2, 'running')],
             [(1, 'running'), (2, 'running')],
 
             # node2, running -> stopped -> running
-            [(1, 'running'), (2, 'stopping')],
             [(1, 'running'), (2, 'stopped')],
-            [(1, 'running'), (2, 'pending')],
             [(1, 'running'), (2, 'running')]
         ]
-        self.assertEqual(expected_history, history)
+        self.assertEqual(expected_history, self._remove_transient_states(history))
+
+    def _remove_transient_states(self, history):
+        """We may or may not observe transient states while polling: if the transition is faster than our client, the state won't be in the history. For the test to be stable, transient states have to be stripped"""
+        transient_states = ['pending', 'stopping']
+
+        def _no_transient_states(snapshot):
+            return len([state for (node, state) in snapshot if state in transient_states]) > 0
+        return [snapshot for snapshot in history if _no_transient_states(snapshot)]

--- a/src/integration_tests/test_with_many_nodes.py
+++ b/src/integration_tests/test_with_many_nodes.py
@@ -140,5 +140,5 @@ class One(base.BaseCase):
         transient_states = ['pending', 'stopping']
 
         def _no_transient_states(snapshot):
-            return len([state for (node, state) in snapshot if state in transient_states]) > 0
+            return len([state for (node, state) in snapshot if state in transient_states]) == 0
         return [snapshot for snapshot in history if _no_transient_states(snapshot)]

--- a/src/integration_tests/test_with_many_nodes.py
+++ b/src/integration_tests/test_with_many_nodes.py
@@ -139,6 +139,6 @@ class One(base.BaseCase):
         """We may or may not observe transient states while polling: if the transition is faster than our client, the state won't be in the history. For the test to be stable, transient states have to be stripped"""
         transient_states = ['pending', 'stopping']
 
-        def _no_transient_states(snapshot):
-            return len([state for (node, state) in snapshot if state in transient_states]) == 0
-        return [snapshot for snapshot in history if _no_transient_states(snapshot)]
+        def _transient_states(snapshot):
+            return len([state for (node, state) in snapshot if state in transient_states]) > 0
+        return [snapshot for snapshot in history if not _transient_states(snapshot)]

--- a/src/tests/test_buildercore_cfngen.py
+++ b/src/tests/test_buildercore_cfngen.py
@@ -174,7 +174,7 @@ class TestUpdates(base.BaseCase):
                 'C': 3,
             }
         }
-        cfngen.apply_delta(template, cloudformation.CloudFormationDelta({'Resources': {'D': 4}}, {'Resources': {'C': 30}}, {'Resources': {'B': 2}}))
+        cfngen.apply_delta(template, cfngen.Delta({'Resources': {'D': 4}}, {'Resources': {'C': 30}}, {'Resources': {'B': 2}}))
         self.assertEqual(template, {'Resources': {'A': 1, 'C': 30, 'D': 4}})
 
     def test_apply_delta_may_add_components_which_werent_there(self):
@@ -183,7 +183,7 @@ class TestUpdates(base.BaseCase):
                 'A': 1,
             }
         }
-        cfngen.apply_delta(template, cloudformation.CloudFormationDelta({'Outputs': {'B': 2}}, {}, {}))
+        cfngen.apply_delta(template, cfngen.Delta({'Outputs': {'B': 2}}, {}, {}))
         self.assertEqual(template, {'Resources': {'A': 1}, 'Outputs': {'B': 2}})
 
     def _base_context(self, project_name='dummy1', in_memory=False, existing_context=None):

--- a/src/tests/test_buildercore_cfngen.py
+++ b/src/tests/test_buildercore_cfngen.py
@@ -174,7 +174,7 @@ class TestUpdates(base.BaseCase):
                 'C': 3,
             }
         }
-        cfngen.apply_delta(template, cfngen.Delta({'Resources': {'D': 4}}, {'Resources': {'C': 30}}, {'Resources': {'B': 2}}))
+        cfngen.apply_delta(template, cloudformation.CloudFormationDelta({'Resources': {'D': 4}}, {'Resources': {'C': 30}}, {'Resources': {'B': 2}}))
         self.assertEqual(template, {'Resources': {'A': 1, 'C': 30, 'D': 4}})
 
     def test_apply_delta_may_add_components_which_werent_there(self):
@@ -183,7 +183,7 @@ class TestUpdates(base.BaseCase):
                 'A': 1,
             }
         }
-        cfngen.apply_delta(template, cfngen.Delta({'Outputs': {'B': 2}}, {}, {}))
+        cfngen.apply_delta(template, cloudformation.CloudFormationDelta({'Outputs': {'B': 2}}, {}, {}))
         self.assertEqual(template, {'Resources': {'A': 1}, 'Outputs': {'B': 2}})
 
     def _base_context(self, project_name='dummy1', in_memory=False, existing_context=None):


### PR DESCRIPTION
At first, we tried using a computed difference of the `.tf` files as a stopgap, but it falls short of different people running `update_infrastructure` on different laptops, as they have no way to get at the old `.tf` files.

Terraform has first-class support for generating a diff of specification and actual infrastructure, so let's use `terraform plan` to do it. This will take into account the actual state of remote resources rather than just the local files.