### PR TITLE
ELPP-3522 Multiple Fastly backends

### DIFF
--- a/projects/elife.yaml
+++ b/projects/elife.yaml
@@ -732,19 +732,29 @@ generic-cdn:
     intdomain: null
     aws:
         ec2: false
-        cloudfront:
+        #cloudfront:
+        #    subdomains:
+        #        - "{instance}-cdn"
+        #    origins:
+        #        # first is default
+        #        default:
+        #            hostname: elife-cdn.s3.amazonaws.com
+        #        articles:
+        #            hostname: "{instance}-elife-published.s3.amazonaws.com"
+        #            pattern: articles/*
+        #    default-ttl: 86400 # seconds
+        #    headers:
+        #        - Origin
+        fastly:
             subdomains:
-                - "{instance}-cdn"
-            origins:
+                - "{instance}-fastly"
+            backends:
                 # first is default
                 default:
                     hostname: elife-cdn.s3.amazonaws.com
                 articles:
                     hostname: "{instance}-elife-published.s3.amazonaws.com"
-                    pattern: articles/*
-            default-ttl: 86400 # seconds
-            headers:
-                - Origin
+                    condition: req.url ~ "^/articles" 
 
 journal-cms:
     subdomain: journal-cms # journal-cms.elifesciences.org

--- a/src/buildercore/bootstrap.py
+++ b/src/buildercore/bootstrap.py
@@ -474,6 +474,8 @@ def write_environment_info(stackname, overwrite=False):
 def update_stack(stackname, service_list=None, **kwargs):
     """updates the given stack. if a list of services are provided (s3, ec2, sqs, etc)
     then only those services will be updated"""
+    # TODO: partition away at least ec2
+    # TODO: partition away also terraform
     # Has too many responsibilities:
     #    - ec2: deploys
     #    - s3, sqs, ...: infrastructure updates

--- a/src/buildercore/bootstrap.py
+++ b/src/buildercore/bootstrap.py
@@ -103,6 +103,8 @@ def _create_generic_stack(stackname, parameters=None, on_start=_noop, on_error=_
         _wait_until_in_progress(stackname)
         context = context_handler.load_context(stackname)
         # setup various resources after creation, where necessary
+        # TODO: extract 2 calls into terraform.bootstrap(context)?
+        terraform.plan(context)
         terraform.update(stackname, context)
         setup_ec2(stackname, context)
         return True

--- a/src/buildercore/cfngen.py
+++ b/src/buildercore/cfngen.py
@@ -253,12 +253,19 @@ def build_context_cloudfront(context, parameterize):
         context['cloudfront'] = False
 
 def build_context_fastly(context, parameterize):
-    def build_subdomain(x):
+    def _build_subdomain(x):
         return complete_domain(parameterize(x), context['domain'])
+    def _parameterize_hostname(b):
+        b['hostname'] = parameterize(b['hostname'])
+        return b
+
     if 'fastly' in context['project']['aws']:
+        backends = context['project']['aws']['fastly'].get('backends', {})
+        print backends
         context['fastly'] = {
-            'subdomains': [build_subdomain(x) for x in context['project']['aws']['fastly']['subdomains']],
-            'subdomains-without-dns': [build_subdomain(x) for x in context['project']['aws']['fastly']['subdomains-without-dns']],
+            'backends': {n: _parameterize_hostname(b) for n, b in backends.items()},
+            'subdomains': [_build_subdomain(x) for x in context['project']['aws']['fastly']['subdomains']],
+            'subdomains-without-dns': [_build_subdomain(x) for x in context['project']['aws']['fastly']['subdomains-without-dns']],
             'dns': context['project']['aws']['fastly']['dns'],
             'healthcheck': context['project']['aws']['fastly']['healthcheck'],
             'errors': context['project']['aws']['fastly']['errors'],

--- a/src/buildercore/cfngen.py
+++ b/src/buildercore/cfngen.py
@@ -255,6 +255,7 @@ def build_context_cloudfront(context, parameterize):
 def build_context_fastly(context, parameterize):
     def _build_subdomain(x):
         return complete_domain(parameterize(x), context['domain'])
+
     def _parameterize_hostname(b):
         b['hostname'] = parameterize(b['hostname'])
         return b

--- a/src/buildercore/terraform.py
+++ b/src/buildercore/terraform.py
@@ -266,6 +266,9 @@ def generate_delta(context, new_template):
         return None
 
     write_template(context['stackname'], new_template)
+    return plan(context)
+
+def plan(context):
     terraform = init(context['stackname'], context)
     terraform.plan(input=False, no_color=IsFlagged, capture_output=False, raise_on_error=True, detailed_exitcode=IsNotFlagged, out='out.plan')
     return_code, stdout, stderr = terraform.plan('out.plan', input=False, no_color=IsFlagged, raise_on_error=True, detailed_exitcode=IsNotFlagged)

--- a/src/buildercore/terraform.py
+++ b/src/buildercore/terraform.py
@@ -151,7 +151,6 @@ def render(context):
     if context['fastly']['errors']:
         errors = context['fastly']['errors']
         response_objects = []
-        cache_conditions = []
         data[DATA_TYPE_HTTP] = {}
         for code, path in errors['codes'].items():
             cache_condition = {
@@ -159,7 +158,7 @@ def render(context):
                 'statement': 'beresp.status == %d' % code,
                 'type': 'CACHE',
             }
-            cache_conditions.append(cache_condition)
+            conditions.append(cache_condition)
             response_objects.append({
                 'name': 'error-%s' % code,
                 'status': int(code),
@@ -172,7 +171,6 @@ def render(context):
                 'url': '%s%s' % (errors['url'], path),
             }
         tf_file['resource'][RESOURCE_TYPE_FASTLY][RESOURCE_NAME_FASTLY]['response_object'] = response_objects
-        tf_file['resource'][RESOURCE_TYPE_FASTLY][RESOURCE_NAME_FASTLY]['condition'] = cache_conditions
 
     if context['fastly']['gcslogging']:
         gcslogging = context['fastly']['gcslogging']
@@ -220,6 +218,9 @@ def render(context):
             ),
             'main': True,
         })
+
+    if conditions:
+        tf_file['resource'][RESOURCE_TYPE_FASTLY][RESOURCE_NAME_FASTLY]['condition'] = conditions
 
     if data:
         tf_file['data'] = data

--- a/src/buildercore/terraform.py
+++ b/src/buildercore/terraform.py
@@ -84,7 +84,7 @@ def render(context):
                 'ssl_cert_hostname': backend['hostname'],
                 'ssl_check_cert': True,
             }
-            if backend.get('condition'): 
+            if backend.get('condition'):
                 condition_name = 'backend-%s-condition' % name
                 conditions.append({
                     'name': condition_name,

--- a/src/cfn.py
+++ b/src/cfn.py
@@ -183,8 +183,7 @@ def launch(pname, instance_id=None, alt_config=None, **kwargs):
         LOG.info('updating stack %s', stackname)
         # TODO: highstate.sh (think it's run inside here) doesn't detect:
         # [34.234.95.137] out: [CRITICAL] The Salt Master has rejected this minion's public key!
-        # TODO: should not run terraform (triggered by update fastly, probably triggered by update all)
-        bootstrap.update_stack(stackname, **kwargs)
+        bootstrap.update_stack(stackname, service_list=['ec2', 'sqs', 's3'])
         setdefault('.active-stack', stackname)
 
     except core.NoMasterException as e:

--- a/src/tests/fixtures/projects/dummy-project.yaml
+++ b/src/tests/fixtures/projects/dummy-project.yaml
@@ -325,6 +325,12 @@ project-with-fastly-complex:
         ports:
             - 80
         fastly:
+            backends:
+                default:
+                    hostname: defaultdummy3.example.org
+                articles:
+                    hostname: "{instance}--defaultdummy3.example.org"
+                    condition: req.url ~ "^/articles" 
             subdomains:
                 - "{instance}--cdn1-of-www"
                 - "{instance}--cdn2-of-www"

--- a/src/tests/test_buildercore_terraform.py
+++ b/src/tests/test_buildercore_terraform.py
@@ -179,6 +179,11 @@ class TestBuildercoreTerraform(base.BaseCase):
                             },
                             'condition': [
                                 {
+                                    'name': 'backend-articles-condition',
+                                    'statement': 'req.url ~ "^/articles"',
+                                    'type': 'REQUEST',
+                                },
+                                {
                                     'name': 'condition-503',
                                     'statement': 'beresp.status == 503',
                                     'type': 'CACHE',

--- a/src/tests/test_buildercore_terraform.py
+++ b/src/tests/test_buildercore_terraform.py
@@ -59,14 +59,14 @@ class TestBuildercoreTerraform(base.BaseCase):
                             'domain': [{
                                 'name': 'prod--cdn-of-www.example.org'
                             }],
-                            'backend': {
+                            'backend': [{
                                 'address': 'prod--www.example.org',
                                 'name': 'project-with-fastly-minimal--prod',
                                 'port': 443,
                                 'use_ssl': True,
                                 'ssl_cert_hostname': 'prod--www.example.org',
                                 'ssl_check_cert': True,
-                            },
+                            }],
                             'request_setting': {
                                 'name': 'default',
                                 'force_ssl': True,
@@ -128,15 +128,27 @@ class TestBuildercoreTerraform(base.BaseCase):
                                     'name': 'future.example.org'
                                 },
                             ],
-                            'backend': {
-                                'address': 'prod--www.example.org',
-                                'name': 'project-with-fastly-complex--prod',
-                                'port': 443,
-                                'use_ssl': True,
-                                'ssl_cert_hostname': 'prod--www.example.org',
-                                'ssl_check_cert': True,
-                                'healthcheck': 'default',
-                            },
+                            'backend': [
+                                {
+                                    'address': 'defaultdummy3.example.org',
+                                    'name': 'default',
+                                    'port': 443,
+                                    'use_ssl': True,
+                                    'ssl_cert_hostname': 'defaultdummy3.example.org',
+                                    'ssl_check_cert': True,
+                                    'healthcheck': 'default',
+                                },
+                                {
+                                    'address': 'prod--defaultdummy3.example.org',
+                                    'name': 'articles',
+                                    'port': 443,
+                                    'use_ssl': True,
+                                    'ssl_cert_hostname': 'prod--defaultdummy3.example.org',
+                                    'ssl_check_cert': True,
+                                    'request_condition': 'backend-articles-condition',
+                                    'healthcheck': 'default',
+                                }
+                            ],
                             'request_setting': {
                                 'name': 'default',
                                 'force_ssl': True,


### PR DESCRIPTION
Theory: use a default and a custom backend, adding a `request_condition` to select a particular pattern like `articles/` for the custom one.