### PR TITLE
Integration test stability

### DIFF
--- a/docs/testing.md
+++ b/docs/testing.md
@@ -46,3 +46,11 @@ or:
 or:
 
     PYTHONPATH=src green tests.test_buildercore_trop.TestBuildercoreTrop.test_method_name
+
+## Filter single integration tests
+
+Some integration tests run through all the defined projects for regression testing. To filter only a single project, for example to reproduce a failure, you can run:
+
+```
+pytest src/integration_tests/test_validation.py::TestValidationElife --filter-project-name=generic-cdn
+```

--- a/src/conftest.py
+++ b/src/conftest.py
@@ -2,9 +2,9 @@ import pytest
 
 def pytest_addoption(parser):
     parser.addoption("--filter-project-name",
-            action="store",
-            default=None,
-            help="pass a project name to filter a test file to run only tests related to it")
+                     action="store",
+                     default=None,
+                     help="pass a project name to filter a test file to run only tests related to it")
 
 @pytest.fixture
 def filter_project_name(request):

--- a/src/conftest.py
+++ b/src/conftest.py
@@ -1,0 +1,11 @@
+import pytest
+
+def pytest_addoption(parser):
+    parser.addoption("--filter-project-name",
+            action="store",
+            default=None,
+            help="pass a project name to filter a test file to run only tests related to it")
+
+@pytest.fixture
+def filter_project_name(request):
+    return request.config.getoption('--filter-project-name')

--- a/src/integration_tests/test_validation.py
+++ b/src/integration_tests/test_validation.py
@@ -23,8 +23,11 @@ class TestValidationElife():
     def tearDown(self):
         base.switch_in_test_settings()
 
-    @pytest.mark.parametrize("pname", project.aws_projects().keys())
-    def test_validation_elife_projects(self, pname):
+    @pytest.mark.parametrize("project_name", project.aws_projects().keys())
+    def test_validation_elife_projects(self, project_name, filter_project_name):
         "elife projects (and their alternative configurations) that come with the builder pass validation"
+        if filter_project_name:
+            if project_name != filter_project_name:
+                pytest.skip("Filtered out through filter_project_name")
 
-        cfngen.validate_project(pname)
+        cfngen.validate_project(project_name)

--- a/src/integration_tests/test_validation.py
+++ b/src/integration_tests/test_validation.py
@@ -15,12 +15,14 @@ class TestValidationFixtures(base.BaseCase):
             cfngen.validate_project(pname)
 
 class TestValidationElife():
-    def setUp(self):
+    @classmethod
+    def setup_class(cls):
         # HERE BE DRAGONS
         # resets the testing config.SETTINGS_FILE we set in the base.BaseCase class
         base.switch_out_test_settings()
 
-    def tearDown(self):
+    @classmethod
+    def teardown_class(cls):
         base.switch_in_test_settings()
 
     @pytest.mark.parametrize("project_name", project.aws_projects().keys())

--- a/src/integration_tests/test_validation.py
+++ b/src/integration_tests/test_validation.py
@@ -1,3 +1,4 @@
+import pytest
 from tests import base
 from buildercore import cfngen, project
 import logging
@@ -7,27 +8,23 @@ logging.disable(logging.NOTSET) # re-enables logging during integration testing
 
 # Depends on talking to AWS.
 
-class TestValidation(base.BaseCase):
-
+class TestValidationFixtures(base.BaseCase):
     def test_validation(self):
         "dummy projects and their alternative configurations pass validation"
         for pname in project.aws_projects().keys():
             cfngen.validate_project(pname)
 
-    def test_validation_elife_projects(self):
-        "elife projects (and their alternative configurations) that come with the builder pass validation"
-
+class TestValidationElife():
+    def setUp(self):
         # HERE BE DRAGONS
         # resets the testing config.SETTINGS_FILE we set in the base.BaseCase class
-        self.switch_out_test_settings()
+        base.switch_out_test_settings()
 
-        for pname in project.aws_projects().keys():
-            # TODO: subTest doesn't work very well here because there's no way to filter a single pname when re-running after a failure
-            # a solution like
-            # https://github.com/elifesciences/elife-spectrum/blob/master/spectrum/test_article.py#L15-L19
-            # could help, but require to run tests with pytest only
-            with self.subTest(pname):
-                cfngen.validate_project(pname)
+    def tearDown(self):
+        base.switch_in_test_settings()
 
-        # todo: does this need to live in a try: ... finally: ... ?
-        self.switch_in_test_settings()
+    @pytest.mark.parametrize("pname", project.aws_projects().keys())
+    def test_validation_elife_projects(self, pname):
+        "elife projects (and their alternative configurations) that come with the builder pass validation"
+
+        cfngen.validate_project(pname)

--- a/src/integration_tests/test_with_instance.py
+++ b/src/integration_tests/test_with_instance.py
@@ -20,6 +20,7 @@ class One(base.BaseCase):
     @classmethod
     def setUpClass(self): # cls, not self
         super(One, self).setUpClass()
+        base.switch_in_test_settings()
 
         # to re-use an existing stack, ensure self.reuse_existing_stack is True
         # this will read the instance name from a temporary file (if it exists) and

--- a/src/integration_tests/test_with_many_nodes.py
+++ b/src/integration_tests/test_with_many_nodes.py
@@ -22,6 +22,7 @@ class One(base.BaseCase):
     @classmethod
     def setUpClass(self): # cls, not self
         super(One, self).setUpClass()
+        base.switch_in_test_settings()
 
         # to re-use an existing stack, ensure self.reuse_existing_stack is True
         # this will read the instance name from a temporary file (if it exists) and

--- a/src/tests/base.py
+++ b/src/tests/base.py
@@ -38,6 +38,7 @@ class BaseCase(TestCase):
     def __init__(self, *args, **kwargs):
         super(BaseCase, self).__init__(*args, **kwargs)
         switch_in_test_settings()
+        self.fixtures_dir = fixtures_dir
 
     # TODO: python2 warning
     def assertCountEqual(self, *args):

--- a/src/tests/base.py
+++ b/src/tests/base.py
@@ -22,11 +22,11 @@ this_dir = os.path.realpath(os.path.dirname(__file__))
 fixtures_dir = join(this_dir, 'fixtures')
 
 def switch_in_test_settings(new_settings='dummy-settings.yaml'):
-    config.SETTINGS_FILE = join(self.fixtures_dir, new_settings)
+    config.SETTINGS_FILE = join(fixtures_dir, new_settings)
     project.project_map.cache_clear()
     config.app.cache_clear()
 
-def switch_out_test_settings(self):
+def switch_out_test_settings():
     # clear any caches and reload the config module
     project.project_map.cache_clear()
     imp.reload(config)

--- a/src/tests/base.py
+++ b/src/tests/base.py
@@ -18,14 +18,26 @@ def generate_environment_name():
     now = datetime.utcnow().strftime("%Y%m%d%H%M%S")
     return "-".join([who, now, str(randint(1, 1000000))]) # ll: luke-20180420022437-51631
 
+this_dir = os.path.realpath(os.path.dirname(__file__))
+fixtures_dir = join(this_dir, 'fixtures')
+
+def switch_in_test_settings(new_settings='dummy-settings.yaml'):
+    config.SETTINGS_FILE = join(self.fixtures_dir, new_settings)
+    project.project_map.cache_clear()
+    config.app.cache_clear()
+
+def switch_out_test_settings(self):
+    # clear any caches and reload the config module
+    project.project_map.cache_clear()
+    imp.reload(config)
+
+
 class BaseCase(TestCase):
     maxDiff = None
-    this_dir = os.path.realpath(os.path.dirname(__file__))
-    fixtures_dir = join(this_dir, 'fixtures')
 
     def __init__(self, *args, **kwargs):
         super(BaseCase, self).__init__(*args, **kwargs)
-        self.switch_in_test_settings()
+        switch_in_test_settings()
 
     # TODO: python2 warning
     def assertCountEqual(self, *args):
@@ -34,17 +46,6 @@ class BaseCase(TestCase):
             self.assertItemsEqual(*args)
         else:
             parent.assertCountEqual(*args)
-
-    def switch_in_test_settings(self, new_settings='dummy-settings.yaml'):
-        self.original_settings_file = config.SETTINGS_FILE
-        config.SETTINGS_FILE = join(self.fixtures_dir, new_settings)
-        project.project_map.cache_clear()
-        config.app.cache_clear()
-
-    def switch_out_test_settings(self):
-        # clear any caches and reload the config module
-        project.project_map.cache_clear()
-        imp.reload(config)
 
     # pyline: disable=invalid-name
 

--- a/src/tests/test_buildercore_core.py
+++ b/src/tests/test_buildercore_core.py
@@ -134,7 +134,7 @@ class SimpleCases(base.BaseCase):
         self.assertEqual(core.find_region(), "us-east-1")
 
     def test_find_region_when_more_than_one_is_available(self):
-        self.switch_in_test_settings('dummy-settings-multiple-regions.yaml')
+        base.switch_in_test_settings('dummy-settings-multiple-regions.yaml')
         try:
             core.find_region()
             self.fail("Shouldn't be able to choose a region")


### PR DESCRIPTION
- Switch in test settings in recent integration tests. Allows them to run in isolation, found out after a failure of `test_validation` made them all fail because it wasn't switching back to the test settings
- Separate `TestValidationElife` to its own class
- `TestValidationElife` runs 43 separate tests rather than a single one
- `TestValidationElife` can filter one of the 43 separate tests rather than always running all of them

Last two features require `pytest`, but greatly help in debugging these cases.

Started from a build where there was one single project problem (`generic-cdn` `aws-alt` validation failures), and that produced this test result:
<img src="https://screenshotscdn.firefoxusercontent.com/images/d8973de9-021f-45df-a046-5796d447075e.png" />