### PR TITLE
ELPP-3665 Define surrogate keys for iiif

### DIFF
--- a/projects/elife.yaml
+++ b/projects/elife.yaml
@@ -773,21 +773,21 @@ generic-cdn:
             surrogate-keys:
                 article-assets:
                     url: "^/articles/([0-9]+)/elife-([0-9]+)-([a-z0-9]+)-v([0-9]+)\\.(.+)$"
-                    value: "articles/\\1 article/\\1 article/\\1/version/\\4"
+                    value: "articles/\\1 article/\\1 article/\\1v\\4"
                     samples:
                         article-asset:
                             path: /articles/10627/elife-10627-fig1-v1.tif
-                            expected: "articles/10627 article/10627 article/10627/version/1"
+                            expected: "articles/10627 article/10627 article/10627v1"
                         # legacy, not supported: /articles/10627/elife-10627-fig1-v1-download.jpg
                         # legacy, not supported: /articles/10627/elife-10627-fig1-v1-972w.jpg
 
                 article-pdf-xml:
                     url: "^/articles/([0-9]+)/elife-([0-9]+)-v([0-9]+)\\.(.+)$"
-                    value: "articles/\\1 article/\\1 article/\\1/version/\\3"
+                    value: "articles/\\1 article/\\1 article/\\1v\\3"
                     samples:
                         article-pdf:
                             path: /articles/10627/elife-10627-v1.pdf
-                            expected: "articles/10627 article/10627 article/10627/version/1"
+                            expected: "articles/10627 article/10627 article/10627v1"
     aws-alt:
         # have to specify this because otherwise configuration such as `fresh` inherited from defaults won't see the ec2: false in `aws:` and test_validation.py will fail for all of them?
         fresh:

--- a/projects/elife.yaml
+++ b/projects/elife.yaml
@@ -771,9 +771,12 @@ generic-cdn:
                     condition: req.url ~ "^/articles/"
             default-ttl: 86400 # seconds
             surrogate-keys:
-                article-id:
+                article-id-legacy:
                     url: "^/articles/([0-9]+)/(.+)$"
                     value: "articles/\\1"
+                article-id:
+                    url: "^/articles/([0-9]+)/(.+)$"
+                    value: "article/\\1"
     aws-alt:
         # have to specify this because otherwise configuration such as `fresh` inherited from defaults won't see the ec2: false in `aws:` and test_validation.py will fail for all of them?
         fresh:

--- a/projects/elife.yaml
+++ b/projects/elife.yaml
@@ -771,9 +771,23 @@ generic-cdn:
                     condition: req.url ~ "^/articles/"
             default-ttl: 86400 # seconds
             surrogate-keys:
-                article-id:
-                    url: "^/articles/([0-9]+)/(.+)$"
-                    value: "articles/\\1 article/\\1"
+                article-assets:
+                    url: "^/articles/([0-9]+)/elife-([0-9]+)-([a-z0-9]+)-v([0-9]+)\\.(.+)$"
+                    value: "articles/\\1 article/\\1 article/\\1/version/\\4"
+                    samples:
+                        article-asset:
+                            path: /articles/10627/elife-10627-fig1-v1.tif
+                            expected: "articles/10627 article/10627 article/10627/version/1"
+                        # legacy, not supported: /articles/10627/elife-10627-fig1-v1-download.jpg
+                        # legacy, not supported: /articles/10627/elife-10627-fig1-v1-972w.jpg
+
+                article-pdf-xml:
+                    url: "^/articles/([0-9]+)/elife-([0-9]+)-v([0-9]+)\\.(.+)$"
+                    value: "articles/\\1 article/\\1 article/\\1/version/\\3"
+                    samples:
+                        article-pdf:
+                            path: /articles/10627/elife-10627-v1.pdf
+                            expected: "articles/10627 article/10627 article/10627/version/1"
     aws-alt:
         # have to specify this because otherwise configuration such as `fresh` inherited from defaults won't see the ec2: false in `aws:` and test_validation.py will fail for all of them?
         fresh:

--- a/projects/elife.yaml
+++ b/projects/elife.yaml
@@ -788,6 +788,13 @@ generic-cdn:
                         article-pdf:
                             path: /articles/10627/elife-10627-v1.pdf
                             expected: "articles/10627 article/10627 article/10627v1"
+                article-unversioned:
+                    url: "^/articles/([0-9]+)/elife-([0-9]+)-video([0-9]+)\\.(.+)$"
+                    value: "articles/\\1 article/\\1/videos"
+                    samples:
+                        article-video-or-still:
+                            path: /articles/34773/elife-34773-video2.mp4
+                            expected: "articles/34773 article/34773/videos"
     aws-alt:
         # have to specify this because otherwise configuration such as `fresh` inherited from defaults won't see the ec2: false in `aws:` and test_validation.py will fail for all of them?
         fresh:

--- a/projects/elife.yaml
+++ b/projects/elife.yaml
@@ -1558,9 +1558,21 @@ iiif:
                 check-interval: 30000
                 timeout: 2000
             surrogate-keys:
-                article-id-version:
+                article-id-versioned:
                     url: "^/lax:([0-9]+)/elife-([0-9]+)-([a-z0-9]+)-v([0-9]+)\\.(.+)$"
-                    value: "article/\\1 article/\\1/version/\\4"
+                    value: "article/\\1 article/\\1v\\4"
+                    samples:
+                        figure:
+                            path: /lax:10627/elife-10627-fig1-v1.tif/full/1500,/0/default.jpg
+                            expected: "article/10627 article/10627v1"
+
+                article-id-unversioned:
+                    url: "^/lax:([0-9]+)/elife-([0-9]+)-video([0-9]+)\\.(.+)$"
+                    value: "article/\\1 article/\\1/videos"
+                    samples:
+                        video-still:
+                            path: /lax:34773/elife-34773-video2.jpg/full/639,/0/default.jpg
+                            expected: "article/34773 article/34773/videos"
     aws-alt:
         standalone:
             # for now a copy of standalone1404

--- a/projects/elife.yaml
+++ b/projects/elife.yaml
@@ -771,12 +771,9 @@ generic-cdn:
                     condition: req.url ~ "^/articles/"
             default-ttl: 86400 # seconds
             surrogate-keys:
-                article-id-legacy:
-                    url: "^/articles/([0-9]+)/(.+)$"
-                    value: "articles/\\1"
                 article-id:
                     url: "^/articles/([0-9]+)/(.+)$"
-                    value: "article/\\1"
+                    value: "articles/\\1 article/\\1"
     aws-alt:
         # have to specify this because otherwise configuration such as `fresh` inherited from defaults won't see the ec2: false in `aws:` and test_validation.py will fail for all of them?
         fresh:
@@ -1547,12 +1544,9 @@ iiif:
                 check-interval: 30000
                 timeout: 2000
             surrogate-keys:
-                article-id:
-                    url: "^/lax:([0-9]+)/(.+)$"
-                    value: "article/\\1"
                 article-id-version:
                     url: "^/lax:([0-9]+)/elife-([0-9]+)-([a-z0-9]+)-v([0-9]+)\\.(.+)$"
-                    value: "article/\\1/version/\\4"
+                    value: "article/\\1 article/\\1/version/\\4"
     aws-alt:
         standalone:
             # for now a copy of standalone1404

--- a/projects/elife.yaml
+++ b/projects/elife.yaml
@@ -1539,6 +1539,13 @@ iiif:
             - 22
             - 80
             - 443
+        fastly:
+            subdomains:
+                - "{instance}--cdn-iiif"
+            healthcheck:
+                path: /ping-fastly
+                check-interval: 30000
+                timeout: 2000
     aws-alt:
         standalone:
             # for now a copy of standalone1404
@@ -1547,6 +1554,7 @@ iiif:
             ec2:
                 ami: ami-92002785 # Ubuntu 14.04, deprecated
                 masterless: true
+            fastly: false
         # for testing new versions
         ci:
             ports:
@@ -1570,6 +1578,7 @@ iiif:
                     - https
                 healthcheck:
                     path: /
+            fastly: false
         end2end:
             ports:
                 - 22
@@ -1585,13 +1594,6 @@ iiif:
                     - https
                 healthcheck:
                     path: /
-            fastly:
-                subdomains:
-                    - "{instance}--cdn-iiif"
-                healthcheck:
-                    path: /ping-fastly
-                    check-interval: 30000
-                    timeout: 2000
         # manual tests
         continuumtest:
             ports:
@@ -1605,13 +1607,6 @@ iiif:
                     - https
                 healthcheck:
                     path: /
-            fastly:
-                subdomains:
-                    - "{instance}--cdn-iiif"
-                healthcheck:
-                    path: /ping-fastly
-                    check-interval: 30000
-                    timeout: 2000
         prod:
             ports:
                 - 22
@@ -1630,10 +1625,6 @@ iiif:
                 subdomains:
                     - "{instance}--cdn-iiif"
                     - iiif
-                healthcheck:
-                    path: /ping-fastly
-                    check-interval: 30000
-                    timeout: 2000
     vagrant:
         box: ubuntu/trusty64 # Ubuntu 14.04, deprecated
         ports:

--- a/projects/elife.yaml
+++ b/projects/elife.yaml
@@ -1546,6 +1546,13 @@ iiif:
                 path: /ping-fastly
                 check-interval: 30000
                 timeout: 2000
+            surrogate-keys:
+                article-id:
+                    url: "^/lax:([0-9]+)/(.+)$"
+                    value: "article/\\1"
+                article-id-version:
+                    url: "^/lax:([0-9]+)/elife-([0-9]+)-([a-z0-9]+)-v([0-9]+)\\.(.+)$"
+                    value: "article/\\1/version/\\4"
     aws-alt:
         standalone:
             # for now a copy of standalone1404

--- a/src/buildercore/cfngen.py
+++ b/src/buildercore/cfngen.py
@@ -260,7 +260,7 @@ def build_context_fastly(context, parameterize):
         b['hostname'] = parameterize(b['hostname'])
         return b
 
-    if 'fastly' in context['project']['aws']:
+    if 'fastly' in context['project']['aws'] and context['project']['aws']['fastly']:
         backends = context['project']['aws']['fastly'].get('backends', OrderedDict({}))
         context['fastly'] = {
             'backends': OrderedDict([(n, _parameterize_hostname(b)) for n, b in backends.items()]),

--- a/src/buildercore/cfngen.py
+++ b/src/buildercore/cfngen.py
@@ -260,7 +260,7 @@ def build_context_fastly(context, parameterize):
         b['hostname'] = parameterize(b['hostname'])
         return b
 
-    if 'fastly' in context['project']['aws'] and context['project']['aws']['fastly']:
+    if context['project']['aws'].get('fastly'):
         backends = context['project']['aws']['fastly'].get('backends', OrderedDict({}))
         context['fastly'] = {
             'backends': OrderedDict([(n, _parameterize_hostname(b)) for n, b in backends.items()]),

--- a/src/buildercore/terraform.py
+++ b/src/buildercore/terraform.py
@@ -217,8 +217,12 @@ def render(context):
 
     if context['fastly']['surrogate-keys']:
         for name, surrogate in context['fastly']['surrogate-keys'].items():
-            surrogate['url']
-            surrogate['value']
+            for sample_name, sample in surrogate.get('samples', {}).items():
+                # check sample['url'] parsed leads to sample['value']
+                match = re.match(surrogate['url'], sample['path'])
+                ensure(match is not None, "Regex %s does not match sample %s" % (surrogate['url'], sample))
+                sample_actual = match.expand(surrogate['value'])
+                ensure(sample_actual == sample['expected'], "Incorrect generated surrogate key `%s` for sample %s" % (sample_actual, sample))
             headers.append({
                 'name': 'surrogate-keys %s' % name,
                 'destination': "http.surrogate-key",

--- a/src/tests/fixtures/projects/dummy-project.yaml
+++ b/src/tests/fixtures/projects/dummy-project.yaml
@@ -351,12 +351,13 @@ project-with-fastly-complex:
                 - "gzip-by-content-type-suffix"
             surrogate-keys:
                 article-id:
+                    # TODO: rename to path
                     url: "^/articles/(\\d+)/(.+)$"
                     value: "article/\\1"
                     samples:
                         article-pdf:
-                            url: /articles/10627/elife-10627-v1.pdf
-                            value: article/10627
+                            path: /articles/10627/elife-10627-v1.pdf
+                            expected: article/10627
 
 project-with-fastly-gcs:
     repo: ssh://git@github.com/elifesciences/dummy3

--- a/src/tests/fixtures/projects/dummy-project.yaml
+++ b/src/tests/fixtures/projects/dummy-project.yaml
@@ -352,7 +352,11 @@ project-with-fastly-complex:
             surrogate-keys:
                 article-id:
                     url: "^/articles/(\\d+)/(.+)$"
-                    value: "articles/\\1"
+                    value: "article/\\1"
+                    samples:
+                        article-pdf:
+                            url: /articles/10627/elife-10627-v1.pdf
+                            value: article/10627
 
 project-with-fastly-gcs:
     repo: ssh://git@github.com/elifesciences/dummy3

--- a/src/tests/test_buildercore_terraform.py
+++ b/src/tests/test_buildercore_terraform.py
@@ -232,7 +232,7 @@ class TestBuildercoreTerraform(base.BaseCase):
                                     'name': 'surrogate-keys article-id',
                                     'type': 'cache',
                                     'action': 'set',
-                                    'source': 'regsub(req.url, "^/articles/(\\d+)/(.+)$", "articles/\\1")',
+                                    'source': 'regsub(req.url, "^/articles/(\\d+)/(.+)$", "article/\\1")',
                                     'destination': 'http.surrogate-key',
                                 },
                             ],


### PR DESCRIPTION
Also refine them for generic-cdn. Will allow the bot to invalidate a single article or a single version.