### PR TITLE
ELPP-3665 Add conditions to surrogate keys

### DIFF
--- a/src/buildercore/terraform.py
+++ b/src/buildercore/terraform.py
@@ -223,12 +223,21 @@ def render(context):
                 ensure(match is not None, "Regex %s does not match sample %s" % (surrogate['url'], sample))
                 sample_actual = match.expand(surrogate['value'])
                 ensure(sample_actual == sample['expected'], "Incorrect generated surrogate key `%s` for sample %s" % (sample_actual, sample))
+
+            cache_condition = {
+                'name': 'condition-surrogate-%s' % name,
+                'statement': 'req.url ~ "%s"' % surrogate['url'],
+                'type': 'CACHE',
+            }
+            conditions.append(cache_condition)
             headers.append({
                 'name': 'surrogate-keys %s' % name,
                 'destination': "http.surrogate-key",
                 'source': 'regsub(req.url, "%s", "%s")' % (surrogate['url'], surrogate['value']),
                 'type': 'cache',
                 'action': 'set',
+                'ignore_if_set': True,
+                'cache_condition': cache_condition['name'],
             })
 
     if conditions:

--- a/src/tests/test_buildercore_terraform.py
+++ b/src/tests/test_buildercore_terraform.py
@@ -205,6 +205,11 @@ class TestBuildercoreTerraform(base.BaseCase):
                                     'statement': 'beresp.status == 503',
                                     'type': 'CACHE',
                                 },
+                                {
+                                    'name': 'condition-surrogate-article-id',
+                                    'statement': 'req.url ~ "^/articles/(\\d+)/(.+)$"',
+                                    'type': 'CACHE',
+                                },
                             ],
                             'response_object': [
                                 {
@@ -234,6 +239,8 @@ class TestBuildercoreTerraform(base.BaseCase):
                                     'action': 'set',
                                     'source': 'regsub(req.url, "^/articles/(\\d+)/(.+)$", "article/\\1")',
                                     'destination': 'http.surrogate-key',
+                                    'ignore_if_set': True,
+                                    'cache_condition': 'condition-surrogate-article-id',
                                 },
                             ],
                             'force_destroy': True,


### PR DESCRIPTION
Whenever multiple possible surrogate keys are defined, they need not to interact with each other. Therefore, add a condition so that only one header declaration can be used on a particular response