### PR TITLE
ELPP-3624 CloudFormation vs Terraform follow up

### DIFF
--- a/src/buildercore/bootstrap.py
+++ b/src/buildercore/bootstrap.py
@@ -336,33 +336,6 @@ def master_data(region):
 def master(region, key):
     return master_data(region)[key]
 
-#
-# bootstrap stack
-#
-
-# TODO: consider moving to cloudformation.py
-def update_template(stackname, template):
-    parameters = []
-    pdata = project_data_for_stackname(stackname)
-    if pdata['aws']['ec2']:
-        parameters.append({'ParameterKey': 'KeyName', 'ParameterValue': stackname})
-    try:
-        conn = core.describe_stack(stackname)
-        conn.update(TemplateBody=json.dumps(template), Parameters=parameters)
-    except botocore.exceptions.ClientError as ex:
-        # ex.response ll: {'ResponseMetadata': {'RetryAttempts': 0, 'HTTPStatusCode': 400, 'RequestId': 'dc28fd8f-4456-11e8-8851-d9346a742012', 'HTTPHeaders': {'x-amzn-requestid': 'dc28fd8f-4456-11e8-8851-d9346a742012', 'date': 'Fri, 20 Apr 2018 04:54:08 GMT', 'content-length': '288', 'content-type': 'text/xml', 'connection': 'close'}}, 'Error': {'Message': 'No updates are to be performed.', 'Code': 'ValidationError', 'Type': 'Sender'}}
-        if ex.response['Error']['Message'] == 'No updates are to be performed.':
-            LOG.info(str(ex), extra={'response': ex.response})
-            return
-        raise
-
-    def stack_is_updating():
-        return not core.stack_is(stackname, ['UPDATE_COMPLETE'], terminal_states=['UPDATE_ROLLBACK_COMPLETE'])
-
-    waiting = "waiting for template of %s to be updated" % stackname
-    done = "template of %s is in state UPDATE_COMPLETE" % stackname
-    call_while(stack_is_updating, interval=2, timeout=7200, update_msg=waiting, done_msg=done)
-
 @core.requires_active_stack
 def template_info(stackname):
     "returns some useful information about the given stackname as a map"

--- a/src/buildercore/bootstrap.py
+++ b/src/buildercore/bootstrap.py
@@ -11,7 +11,7 @@ from datetime import datetime
 from . import utils, config, bvars, core, context_handler, project, cloudformation, terraform, sns as snsmod
 from .context_handler import only_if as updates
 from .core import stack_pem, stack_all_ec2_nodes, project_data_for_stackname, stack_conn
-from .utils import first, call_while, ensure, subdict, yaml_dumps, lmap, fab_get, fab_put, fab_put_data
+from .utils import first, ensure, subdict, yaml_dumps, lmap, fab_get, fab_put, fab_put_data
 from .lifecycle import delete_dns
 from .config import BOOTSTRAP_USER
 from fabric.api import sudo, show

--- a/src/buildercore/bootstrap.py
+++ b/src/buildercore/bootstrap.py
@@ -380,7 +380,6 @@ def update_stack(stackname, service_list=None, **kwargs):
     """updates the given stack. if a list of services are provided (s3, ec2, sqs, etc)
     then only those services will be updated"""
     # TODO: partition away at least ec2
-    # TODO: partition away also terraform
     # Has too many responsibilities:
     #    - ec2: deploys
     #    - s3, sqs, ...: infrastructure updates
@@ -388,7 +387,6 @@ def update_stack(stackname, service_list=None, **kwargs):
         ('ec2', update_ec2_stack),
         ('s3', update_s3_stack),
         ('sqs', update_sqs_stack),
-        ('terraform', terraform.update)
     ])
     service_list = service_list or service_update_fns.keys()
     ensure(utils.iterable(service_list), "cannot iterate over given service list %r" % service_list)

--- a/src/buildercore/cfngen.py
+++ b/src/buildercore/cfngen.py
@@ -445,7 +445,7 @@ class Delta(namedtuple('Delta', ['plus', 'edit', 'minus', 'terraform'])):
         )
 
     @property
-    def non_empty(self):
+    def cloudformation_non_empty(self):
         return any([
             self.plus['Resources'],
             self.plus['Outputs'],
@@ -453,7 +453,6 @@ class Delta(namedtuple('Delta', ['plus', 'edit', 'minus', 'terraform'])):
             self.edit['Outputs'],
             self.minus['Resources'],
             self.minus['Outputs'],
-            self.terraform
         ])
 _empty_cloudformation_dictionary = {'Resources': {}, 'Outputs': {}}
 Delta.__new__.__defaults__ = (_empty_cloudformation_dictionary, _empty_cloudformation_dictionary, _empty_cloudformation_dictionary, None)

--- a/src/buildercore/cfngen.py
+++ b/src/buildercore/cfngen.py
@@ -551,28 +551,12 @@ def template_delta(context):
 def merge_delta(stackname, delta):
     """Merges the new resources in delta in the local copy of the Cloudformation  template"""
     template = cloudformation.read_template(stackname)
-    apply_delta(template, delta)
+    cloudformation.apply_delta(template, delta)
     # TODO: possibly pre-write the cloudformation template
     # the source of truth can always be redownloaded from the CloudFormation API
     write_cloudformation_template(stackname, json.dumps(template))
     # nothing to do on Terraform as the plan file is already there
     return template
-
-def apply_delta(template, delta):
-    for component in delta.plus:
-        ensure(component in ["Resources", "Outputs"], "Template component %s not recognized" % component)
-        data = template.get(component, {})
-        data.update(delta.plus[component])
-        template[component] = data
-    for component in delta.edit:
-        ensure(component in ["Resources", "Outputs"], "Template component %s not recognized" % component)
-        data = template.get(component, {})
-        data.update(delta.edit[component])
-        template[component] = data
-    for component in delta.minus:
-        ensure(component in ["Resources", "Outputs"], "Template component %s not recognized" % component)
-        for title in delta.minus[component]:
-            del template[component][title]
 
 def _current_cloudformation_template(stackname):
     "retrieves a template from the CloudFormation API, using it as the source of truth"

--- a/src/buildercore/cfngen.py
+++ b/src/buildercore/cfngen.py
@@ -325,17 +325,6 @@ def choose_alt_config(stackname):
         # instance_id exactly matches an alternative config. use that.
         return instance_id
 
-#
-#
-#
-
-# TODO: move to cloudformation.py
-def write_cloudformation_template(stackname, contents):
-    "writes a json version of the python cloudformation template to the stacks directory"
-    output_fname = os.path.join(STACK_DIR, stackname + ".json")
-    open(output_fname, 'w').write(contents)
-    return output_fname
-
 # TODO: prefer this single dispatch function for handling creation of template files
 def write_template(stackname, contents):
     "writes any provider templates and returns a list of paths to templates"
@@ -404,7 +393,7 @@ def generate_stack(pname, **more_context):
     stackname = context['stackname']
 
     context_handler.write_context(stackname, context)
-    cloudformation_template_file = write_cloudformation_template(stackname, cloudformation_template)
+    cloudformation_template_file = cloudformation.write_template(stackname, cloudformation_template)
     terraform_template_file = terraform.write_template(stackname, terraform_template)
     return context, cloudformation_template_file, terraform_template_file
 
@@ -555,7 +544,7 @@ def merge_delta(stackname, delta):
     cloudformation.apply_delta(template, delta.cloudformation)
     # TODO: possibly pre-write the cloudformation template
     # the source of truth can always be redownloaded from the CloudFormation API
-    write_cloudformation_template(stackname, json.dumps(template))
+    cloudformation.write_template(stackname, json.dumps(template))
     # nothing to do on Terraform as the plan file is already there
     return template
 
@@ -571,7 +560,7 @@ def _current_cloudformation_template(stackname):
         raise
 
 def download_cloudformation_template(stackname):
-    write_cloudformation_template(stackname, json.dumps(_current_cloudformation_template(stackname)))
+    cloudformation.write_template(stackname, json.dumps(_current_cloudformation_template(stackname)))
 
 def regenerate_stack(stackname, **more_context):
     current_context = context_handler.load_context(stackname)

--- a/src/buildercore/cfngen.py
+++ b/src/buildercore/cfngen.py
@@ -403,6 +403,7 @@ EC2_NOT_UPDATABLE_PROPERTIES = ['ImageId', 'Tags', 'UserData']
 # * what to add
 # * what to modify
 # * what to remove
+# TODO: remove (plus, edit, minus) delegating to self.cloudformation instead
 class Delta(namedtuple('Delta', ['plus', 'edit', 'minus', 'cloudformation', 'terraform'])):
     @classmethod
     def from_cloudformation_and_terraform(cls, cloud_formation_delta, terraform_delta):

--- a/src/buildercore/cfngen.py
+++ b/src/buildercore/cfngen.py
@@ -22,7 +22,6 @@ import botocore
 import netaddr
 from . import utils, cloudformation, terraform, core, project, context_handler
 from .utils import ensure, lmap
-from .config import STACK_DIR
 
 LOG = logging.getLogger(__name__)
 

--- a/src/buildercore/cfngen.py
+++ b/src/buildercore/cfngen.py
@@ -344,17 +344,6 @@ def write_template(stackname, contents):
     # return [cfn, tfm]
     pass
 
-# TODO: move implementation to cloudformation.py
-# TODO: perhaps add terraform support?
-def read_template(stackname):
-    "returns the contents of a cloudformation template as a python data structure"
-    output_fname = os.path.join(STACK_DIR, stackname + ".json")
-    return json.load(open(output_fname, 'r'))
-
-#
-#
-#
-
 def more_validation(json_template_str):
     "local cloudformation template checks. complements the validation AWS does"
     try:
@@ -461,7 +450,7 @@ def template_delta(context):
     """given an already existing template, regenerates it and produces a delta containing only the new resources.
 
     Some the existing resources are treated as immutable and not put in the delta. Most that support non-destructive updates like CloudFront are instead included"""
-    old_template = read_template(context['stackname'])
+    old_template = cloudformation.read_template(context['stackname'])
     template = json.loads(cloudformation.render_template(context))
     new_terraform_template_file = terraform.EMPTY_TEMPLATE
     if context['fastly']:
@@ -561,7 +550,7 @@ def template_delta(context):
 
 def merge_delta(stackname, delta):
     """Merges the new resources in delta in the local copy of the Cloudformation  template"""
-    template = read_template(stackname)
+    template = cloudformation.read_template(stackname)
     apply_delta(template, delta)
     # TODO: possibly pre-write the cloudformation template
     # the source of truth can always be redownloaded from the CloudFormation API

--- a/src/buildercore/cfngen.py
+++ b/src/buildercore/cfngen.py
@@ -325,14 +325,6 @@ def choose_alt_config(stackname):
         # instance_id exactly matches an alternative config. use that.
         return instance_id
 
-# TODO: prefer this single dispatch function for handling creation of template files
-def write_template(stackname, contents):
-    "writes any provider templates and returns a list of paths to templates"
-    # cfn = cloudformation.write_template(stackname, contents)
-    # tfm = terraform.write_template(stackname, contents)
-    # return [cfn, tfm]
-    pass
-
 def more_validation(json_template_str):
     "local cloudformation template checks. complements the validation AWS does"
     try:

--- a/src/buildercore/cfngen.py
+++ b/src/buildercore/cfngen.py
@@ -538,16 +538,6 @@ def template_delta(context):
         terraform.generate_delta(context, new_terraform_template_file)
     )
 
-def merge_delta(stackname, delta):
-    """Merges the new resources in delta in the local copy of the Cloudformation  template"""
-    template = cloudformation.read_template(stackname)
-    cloudformation.apply_delta(template, delta.cloudformation)
-    # TODO: possibly pre-write the cloudformation template
-    # the source of truth can always be redownloaded from the CloudFormation API
-    cloudformation.write_template(stackname, json.dumps(template))
-    # nothing to do on Terraform as the plan file is already there
-    return template
-
 def _current_cloudformation_template(stackname):
     "retrieves a template from the CloudFormation API, using it as the source of truth"
     cfn = core.boto_conn(stackname, 'cloudformation', client=True)

--- a/src/buildercore/cfngen.py
+++ b/src/buildercore/cfngen.py
@@ -434,9 +434,6 @@ def template_delta(context):
     Some the existing resources are treated as immutable and not put in the delta. Most that support non-destructive updates like CloudFront are instead included"""
     old_template = cloudformation.read_template(context['stackname'])
     template = json.loads(cloudformation.render_template(context))
-    new_terraform_template_file = terraform.EMPTY_TEMPLATE
-    if context['fastly']:
-        new_terraform_template_file = terraform.render(context)
 
     def _related_to_ec2(output):
         if 'Value' in output:
@@ -527,7 +524,7 @@ def template_delta(context):
                 'Outputs': delta_minus_outputs,
             }
         ),
-        terraform.generate_delta(context, new_terraform_template_file)
+        terraform.generate_delta(context)
     )
 
 def _current_cloudformation_template(stackname):

--- a/src/buildercore/cloudformation.py
+++ b/src/buildercore/cloudformation.py
@@ -169,7 +169,7 @@ def update_template(stackname, delta):
 
 def _update_template(stackname, template):
     parameters = []
-    pdata = project_data_for_stackname(stackname)
+    pdata = core.project_data_for_stackname(stackname)
     if pdata['aws']['ec2']:
         parameters.append({'ParameterKey': 'KeyName', 'ParameterValue': stackname})
     try:

--- a/src/buildercore/cloudformation.py
+++ b/src/buildercore/cloudformation.py
@@ -123,6 +123,14 @@ def _wait_until_in_progress(stackname):
     ensure(final_stack.stack_status in core.ACTIVE_CFN_STATUS,
            "Failed to create stack: %s.\nEvents: %s" % (final_stack.stack_status, pformat(events)))
 
+def read_template(stackname):
+    "returns the contents of a cloudformation template as a python data structure"
+    output_fname = os.path.join(config.STACK_DIR, stackname + ".json")
+    return json.load(open(output_fname, 'r'))
+
+def update_template(stackname, delta):
+    pass
+
 def destroy(stackname, context):
     stack_body = core.stack_json(stackname)
     if json.loads(stack_body) == EMPTY_TEMPLATE:

--- a/src/buildercore/cloudformation.py
+++ b/src/buildercore/cloudformation.py
@@ -48,6 +48,8 @@ class CloudFormationDelta(namedtuple('Delta', ['plus', 'edit', 'minus'])):
             self.minus['Resources'],
             self.minus['Outputs'],
         ])
+_empty_cloudformation_dictionary = {'Resources': {}, 'Outputs': {}}
+CloudFormationDelta.__new__.__defaults__ = (_empty_cloudformation_dictionary, _empty_cloudformation_dictionary, _empty_cloudformation_dictionary)
 
 EMPTY_TEMPLATE = {'Resources': {}}
 
@@ -161,7 +163,7 @@ def write_template(stackname, contents):
 
 def update_template(stackname, delta):
     if delta.non_empty:
-        new_template = _merge_delta(stackname, delta.cloudformation)
+        new_template = _merge_delta(stackname, delta)
         _update_template(stackname, new_template)
     else:
         # attempting to apply an empty change set would result in an error

--- a/src/buildercore/cloudformation.py
+++ b/src/buildercore/cloudformation.py
@@ -160,7 +160,12 @@ def write_template(stackname, contents):
     return output_fname
 
 def update_template(stackname, delta):
-    pass
+    if delta.cloudformation_non_empty:
+        new_template = merge_delta(stackname, delta)
+        _update_template(stackname, new_template)
+    else:
+        # attempting to apply an empty change set would result in an error
+        LOG.info("Nothing to update on CloudFormation")
 
 def _update_template(stackname, template):
     parameters = []

--- a/src/buildercore/cloudformation.py
+++ b/src/buildercore/cloudformation.py
@@ -144,10 +144,10 @@ def apply_delta(template, delta):
         for title in delta.minus[component]:
             del template[component][title]
 _
-def merge_delta(stackname, delta):
+def _merge_delta(stackname, delta):
     """Merges the new resources in delta in the local copy of the Cloudformation  template"""
     template = read_template(stackname)
-    apply_delta(template, delta.cloudformation)
+    apply_delta(template, delta)
     # TODO: possibly pre-write the cloudformation template
     # the source of truth can always be redownloaded from the CloudFormation API
     write_template(stackname, json.dumps(template))
@@ -160,8 +160,8 @@ def write_template(stackname, contents):
     return output_fname
 
 def update_template(stackname, delta):
-    if delta.cloudformation_non_empty:
-        new_template = merge_delta(stackname, delta)
+    if delta.non_empty:
+        new_template = _merge_delta(stackname, delta.cloudformation)
         _update_template(stackname, new_template)
     else:
         # attempting to apply an empty change set would result in an error

--- a/src/buildercore/cloudformation.py
+++ b/src/buildercore/cloudformation.py
@@ -128,6 +128,22 @@ def read_template(stackname):
     output_fname = os.path.join(config.STACK_DIR, stackname + ".json")
     return json.load(open(output_fname, 'r'))
 
+def apply_delta(template, delta):
+    for component in delta.plus:
+        ensure(component in ["Resources", "Outputs"], "Template component %s not recognized" % component)
+        data = template.get(component, {})
+        data.update(delta.plus[component])
+        template[component] = data
+    for component in delta.edit:
+        ensure(component in ["Resources", "Outputs"], "Template component %s not recognized" % component)
+        data = template.get(component, {})
+        data.update(delta.edit[component])
+        template[component] = data
+    for component in delta.minus:
+        ensure(component in ["Resources", "Outputs"], "Template component %s not recognized" % component)
+        for title in delta.minus[component]:
+            del template[component][title]
+
 def update_template(stackname, delta):
     pass
 

--- a/src/buildercore/cloudformation.py
+++ b/src/buildercore/cloudformation.py
@@ -143,6 +143,15 @@ def apply_delta(template, delta):
         ensure(component in ["Resources", "Outputs"], "Template component %s not recognized" % component)
         for title in delta.minus[component]:
             del template[component][title]
+_
+def merge_delta(stackname, delta):
+    """Merges the new resources in delta in the local copy of the Cloudformation  template"""
+    template = read_template(stackname)
+    apply_delta(template, delta.cloudformation)
+    # TODO: possibly pre-write the cloudformation template
+    # the source of truth can always be redownloaded from the CloudFormation API
+    write_template(stackname, json.dumps(template))
+    return template
 
 def write_template(stackname, contents):
     "writes a json version of the python cloudformation template to the stacks directory"

--- a/src/buildercore/cloudformation.py
+++ b/src/buildercore/cloudformation.py
@@ -143,7 +143,7 @@ def apply_delta(template, delta):
         ensure(component in ["Resources", "Outputs"], "Template component %s not recognized" % component)
         for title in delta.minus[component]:
             del template[component][title]
-_
+
 def _merge_delta(stackname, delta):
     """Merges the new resources in delta in the local copy of the Cloudformation  template"""
     template = read_template(stackname)

--- a/src/buildercore/cloudformation.py
+++ b/src/buildercore/cloudformation.py
@@ -144,6 +144,12 @@ def apply_delta(template, delta):
         for title in delta.minus[component]:
             del template[component][title]
 
+def write_template(stackname, contents):
+    "writes a json version of the python cloudformation template to the stacks directory"
+    output_fname = os.path.join(config.STACK_DIR, stackname + ".json")
+    open(output_fname, 'w').write(contents)
+    return output_fname
+
 def update_template(stackname, delta):
     pass
 

--- a/src/buildercore/terraform.py
+++ b/src/buildercore/terraform.py
@@ -6,7 +6,7 @@ import re
 import shutil
 from python_terraform import Terraform, IsFlagged, IsNotFlagged
 from .config import BUILDER_BUCKET, BUILDER_REGION, TERRAFORM_DIR, ConfigurationError
-from .context_handler import only_if
+from .context_handler import only_if, load_context
 from .utils import ensure, mkdir_p, http_responses
 from . import fastly
 
@@ -406,6 +406,10 @@ def init(stackname, context):
         }))
     terraform.init(input=False, capture_output=False, raise_on_error=True)
     return terraform
+
+def update_template(stackname):
+    context = load_context(stackname)
+    update(stackname, context)
 
 @only_if('fastly', 'gcs')
 def update(stackname, context):

--- a/src/cfn.py
+++ b/src/cfn.py
@@ -91,7 +91,7 @@ def update_infrastructure(stackname):
 
     context_handler.write_context(stackname, context)
 
-    cloudformation.update_template(stackname, delta)
+    cloudformation.update_template(stackname, delta.cloudformation)
 
     # Fastly via Terraform
     if context.get('fastly', {}):

--- a/src/cfn.py
+++ b/src/cfn.py
@@ -99,7 +99,7 @@ def update_infrastructure(stackname):
     # TODO: move to cloudformation module?
     # bootstrap.update_stack(stackname, service_list=['cloudformation'])?
     if delta.cloudformation_non_empty:
-        new_template = cfngen.merge_delta(stackname, delta)
+        new_template = cloudformation.merge_delta(stackname, delta)
         bootstrap.update_template(stackname, new_template)
     else:
         # attempting to apply an empty change set would result in an error

--- a/src/cfn.py
+++ b/src/cfn.py
@@ -96,7 +96,7 @@ def update_infrastructure(stackname):
 
     # TODO: move to cloudformation module?
     # bootstrap.update_stack(stackname, service_list=['cloudformation'])?
-    if delta.non_empty:
+    if delta.cloudformation_non_empty:
         new_template = cfngen.merge_delta(stackname, delta)
         bootstrap.update_template(stackname, new_template)
     else:

--- a/src/cfn.py
+++ b/src/cfn.py
@@ -91,14 +91,7 @@ def update_infrastructure(stackname):
 
     context_handler.write_context(stackname, context)
 
-    # TODO: move to cloudformation module?
-    # bootstrap.update_stack(stackname, service_list=['cloudformation'])?
-    if delta.cloudformation_non_empty:
-        new_template = cloudformation.merge_delta(stackname, delta)
-        cloudformation._update_template(stackname, new_template)
-    else:
-        # attempting to apply an empty change set would result in an error
-        LOG.info("Nothing to update on CloudFormation")
+    cloudformation.update_template(stackname, delta)
 
     # Fastly via Terraform
     if context.get('fastly', {}):

--- a/src/cfn.py
+++ b/src/cfn.py
@@ -8,6 +8,8 @@ from fabric.contrib import files
 import utils, buildvars
 from decorators import requires_project, requires_aws_stack, echo_output, setdefault, debugtask, timeit
 from buildercore import core, cfngen, utils as core_utils, bootstrap, project, checks, lifecycle as core_lifecycle, context_handler
+# potentially remove to go through buildercore.bootstrap?
+from buildercore import cloudformation, terraform
 from buildercore.concurrency import concurrency_for
 from buildercore.core import stack_conn, stack_pem, stack_all_ec2_nodes, tags2dict
 from buildercore.decorators import PredicateException

--- a/src/cfn.py
+++ b/src/cfn.py
@@ -92,10 +92,7 @@ def update_infrastructure(stackname):
     context_handler.write_context(stackname, context)
 
     cloudformation.update_template(stackname, delta.cloudformation)
-
-    # Fastly via Terraform
-    if context.get('fastly', {}):
-        bootstrap.update_stack(stackname, service_list=['terraform'])
+    terraform.update_template(stackname)
 
     # TODO: move inside bootstrap.update_stack
     # EC2

--- a/src/cfn.py
+++ b/src/cfn.py
@@ -62,11 +62,6 @@ def update(stackname, autostart="0", concurrency='serial'):
     return bootstrap.update_stack(stackname, service_list=['ec2'], concurrency=concurrency)
 
 @task
-def update_template(stackname):
-    print('This task has been renamed to update_infrastructure.')
-    exit(1)
-
-@task
 @timeit
 def update_infrastructure(stackname):
     """Limited update of the Cloudformation template and/or Terraform template.
@@ -100,7 +95,7 @@ def update_infrastructure(stackname):
     # bootstrap.update_stack(stackname, service_list=['cloudformation'])?
     if delta.cloudformation_non_empty:
         new_template = cloudformation.merge_delta(stackname, delta)
-        bootstrap.update_template(stackname, new_template)
+        cloudformation._update_template(stackname, new_template)
     else:
         # attempting to apply an empty change set would result in an error
         LOG.info("Nothing to update on CloudFormation")

--- a/src/integration_tests/test_with_instance.py
+++ b/src/integration_tests/test_with_instance.py
@@ -89,7 +89,7 @@ class One(base.BaseCase):
         bootstrap.setup_ec2(self.stackname, self.context)
 
     # TODO: transform this into a cloudformation module test
-    #def test_bootstrap_update_template_no_updates(self):
+    # def test_bootstrap_update_template_no_updates(self):
     #    "a template with no changes can be updated with no problems"
     #    bootstrap.update_template(self.stackname, json.load(open(self.cfn_template, 'r')))
 

--- a/src/integration_tests/test_with_instance.py
+++ b/src/integration_tests/test_with_instance.py
@@ -88,9 +88,10 @@ class One(base.BaseCase):
         cloudformation._wait_until_in_progress(self.stackname)
         bootstrap.setup_ec2(self.stackname, self.context)
 
-    def test_bootstrap_update_template_no_updates(self):
-        "a template with no changes can be updated with no problems"
-        bootstrap.update_template(self.stackname, json.load(open(self.cfn_template, 'r')))
+    # TODO: transform this into a cloudformation module test
+    #def test_bootstrap_update_template_no_updates(self):
+    #    "a template with no changes can be updated with no problems"
+    #    bootstrap.update_template(self.stackname, json.load(open(self.cfn_template, 'r')))
 
     def test_bootstrap_run_script(self):
         with core.stack_conn(self.stackname, username=BOOTSTRAP_USER):

--- a/src/integration_tests/test_with_instance.py
+++ b/src/integration_tests/test_with_instance.py
@@ -88,11 +88,6 @@ class One(base.BaseCase):
         cloudformation._wait_until_in_progress(self.stackname)
         bootstrap.setup_ec2(self.stackname, self.context)
 
-    # TODO: transform this into a cloudformation module test
-    # def test_bootstrap_update_template_no_updates(self):
-    #    "a template with no changes can be updated with no problems"
-    #    bootstrap.update_template(self.stackname, json.load(open(self.cfn_template, 'r')))
-
     def test_bootstrap_run_script(self):
         with core.stack_conn(self.stackname, username=BOOTSTRAP_USER):
             bootstrap.run_script('test.sh')

--- a/src/tests/test_buildercore_cfngen.py
+++ b/src/tests/test_buildercore_cfngen.py
@@ -173,5 +173,5 @@ class TestUpdates(base.BaseCase):
         if not in_memory:
             context_handler.write_context(stackname, context)
             template = cloudformation.render_template(context)
-            cfngen.write_cloudformation_template(stackname, template)
+            cloudformation.write_template(stackname, template)
         return context

--- a/src/tests/test_buildercore_cfngen.py
+++ b/src/tests/test_buildercore_cfngen.py
@@ -166,26 +166,6 @@ class TestUpdates(base.BaseCase):
         self.assertEqual(list(delta_minus['Resources'].keys()), ['CnameDNS1'])
         self.assertEqual(list(delta_minus['Outputs'].keys()), [])
 
-    def test_apply_delta_may_add_edit_and_remove_resources(self):
-        template = {
-            'Resources': {
-                'A': 1,
-                'B': 2,
-                'C': 3,
-            }
-        }
-        cloudformation.apply_delta(template, cloudformation.CloudFormationDelta({'Resources': {'D': 4}}, {'Resources': {'C': 30}}, {'Resources': {'B': 2}}))
-        self.assertEqual(template, {'Resources': {'A': 1, 'C': 30, 'D': 4}})
-
-    def test_apply_delta_may_add_components_which_werent_there(self):
-        template = {
-            'Resources': {
-                'A': 1,
-            }
-        }
-        cloudformation.apply_delta(template, cloudformation.CloudFormationDelta({'Outputs': {'B': 2}}, {}, {}))
-        self.assertEqual(template, {'Resources': {'A': 1}, 'Outputs': {'B': 2}})
-
     def _base_context(self, project_name='dummy1', in_memory=False, existing_context=None):
         environment_name = base.generate_environment_name()
         stackname = '%s--%s' % (project_name, environment_name)

--- a/src/tests/test_buildercore_cfngen.py
+++ b/src/tests/test_buildercore_cfngen.py
@@ -174,7 +174,7 @@ class TestUpdates(base.BaseCase):
                 'C': 3,
             }
         }
-        cfngen.apply_delta(template, cfngen.Delta({'Resources': {'D': 4}}, {'Resources': {'C': 30}}, {'Resources': {'B': 2}}))
+        cloudformation.apply_delta(template, cfngen.Delta({'Resources': {'D': 4}}, {'Resources': {'C': 30}}, {'Resources': {'B': 2}}))
         self.assertEqual(template, {'Resources': {'A': 1, 'C': 30, 'D': 4}})
 
     def test_apply_delta_may_add_components_which_werent_there(self):
@@ -183,7 +183,7 @@ class TestUpdates(base.BaseCase):
                 'A': 1,
             }
         }
-        cfngen.apply_delta(template, cfngen.Delta({'Outputs': {'B': 2}}, {}, {}))
+        cloudformation.apply_delta(template, cfngen.Delta({'Outputs': {'B': 2}}, {}, {}))
         self.assertEqual(template, {'Resources': {'A': 1}, 'Outputs': {'B': 2}})
 
     def _base_context(self, project_name='dummy1', in_memory=False, existing_context=None):

--- a/src/tests/test_buildercore_cfngen.py
+++ b/src/tests/test_buildercore_cfngen.py
@@ -34,7 +34,7 @@ class TestBuildContext(base.BaseCase):
 class TestUpdates(base.BaseCase):
     def test_empty_template_delta(self):
         context = self._base_context()
-        (delta_plus, delta_edit, delta_minus, new_terraform_template_file) = cfngen.template_delta(context)
+        (delta_plus, delta_edit, delta_minus, cloudformation_delta, new_terraform_template_file) = cfngen.template_delta(context)
         self.assertEqual(delta_plus, {'Outputs': {}, 'Resources': {}})
 
     def test_template_delta_includes_cloudfront(self):
@@ -56,13 +56,13 @@ class TestUpdates(base.BaseCase):
             "default-ttl": 300,
             "logging": False,
         }
-        (delta_plus, delta_edit, delta_minus, new_terraform_template_file) = cfngen.template_delta(context)
+        (delta_plus, delta_edit, delta_minus, cloudformation_delta, new_terraform_template_file) = cfngen.template_delta(context)
         self.assertCountEqual(list(delta_plus['Resources'].keys()), ['CloudFrontCDN', 'CloudFrontCDNDNS1', 'ExtDNS'])
         self.assertEqual(list(delta_plus['Outputs'].keys()), ['DomainName'])
 
     def test_template_delta_does_not_include_cloudfront_if_there_are_no_modifications(self):
         context = self._base_context('project-with-cloudfront-minimal')
-        (delta_plus, delta_edit, delta_minus, new_terraform_template_file) = cfngen.template_delta(context)
+        (delta_plus, delta_edit, delta_minus, cloudformation_delta, new_terraform_template_file) = cfngen.template_delta(context)
         self.assertEqual(list(delta_plus['Resources'].keys()), [])
         self.assertEqual(list(delta_plus['Outputs'].keys()), [])
 
@@ -70,7 +70,7 @@ class TestUpdates(base.BaseCase):
         "we do not want to mess with running VMs"
         context = self._base_context()
         context['ec2']['cluster_size'] = 2
-        (delta_plus, delta_edit, delta_minus, new_terraform_template_file) = cfngen.template_delta(context)
+        (delta_plus, delta_edit, delta_minus, cloudformation_delta, new_terraform_template_file) = cfngen.template_delta(context)
         self.assertEqual(list(delta_plus['Resources'].keys()), [])
         self.assertEqual(list(delta_plus['Outputs'].keys()), [])
 
@@ -78,7 +78,7 @@ class TestUpdates(base.BaseCase):
         "we accept to reboot VMs if an instance type change is requested"
         context = self._base_context()
         context['ec2']['type'] = 't2.xlarge'
-        (delta_plus, delta_edit, delta_minus, new_terraform_template_file) = cfngen.template_delta(context)
+        (delta_plus, delta_edit, delta_minus, cloudformation_delta, new_terraform_template_file) = cfngen.template_delta(context)
         self.assertEqual(list(delta_edit['Resources'].keys()), ['EC2Instance1'])
         self.assertEqual(list(delta_edit['Outputs'].keys()), [])
 
@@ -86,7 +86,7 @@ class TestUpdates(base.BaseCase):
         "we don't want random reboot or recreations of instances"
         context = self._base_context()
         context['ec2']['ami'] = 'ami-1234567'
-        (delta_plus, delta_edit, delta_minus, new_terraform_template_file) = cfngen.template_delta(context)
+        (delta_plus, delta_edit, delta_minus, cloudformation_delta, new_terraform_template_file) = cfngen.template_delta(context)
         self.assertEqual(list(delta_plus['Resources'].keys()), [])
         self.assertEqual(list(delta_plus['Outputs'].keys()), [])
 
@@ -94,7 +94,7 @@ class TestUpdates(base.BaseCase):
         "it's useful to open and close ports"
         context = self._base_context()
         context['project']['aws']['ports'] = [110]
-        (delta_plus, delta_edit, delta_minus, new_terraform_template_file) = cfngen.template_delta(context)
+        (delta_plus, delta_edit, delta_minus, cloudformation_delta, new_terraform_template_file) = cfngen.template_delta(context)
         self.assertEqual(list(delta_edit['Resources'].keys()), ['StackSecurityGroup'])
         self.assertEqual(list(delta_edit['Outputs'].keys()), [])
 
@@ -102,7 +102,7 @@ class TestUpdates(base.BaseCase):
         "we want to update RDS instances in place to avoid data loss"
         context = self._base_context('dummy2')
         context['project']['aws']['rds']['multi-az'] = True
-        (delta_plus, delta_edit, delta_minus, new_terraform_template_file) = cfngen.template_delta(context)
+        (delta_plus, delta_edit, delta_minus, cloudformation_delta, new_terraform_template_file) = cfngen.template_delta(context)
         self.assertEqual(list(delta_edit['Resources'].keys()), ['AttachedDB'])
         self.assertEqual(delta_edit['Resources']['AttachedDB']['Properties']['MultiAZ'], 'true')
         self.assertEqual(list(delta_edit['Outputs'].keys()), [])
@@ -111,7 +111,7 @@ class TestUpdates(base.BaseCase):
         "we don't want to update RDS instances more than necessary, since it takes time and may cause reboots or replacements"
         context = self._base_context('dummy2')
         updated_context = self._base_context('dummy2', in_memory=False, existing_context=context)
-        (delta_plus, delta_edit, delta_minus, new_terraform_template_file) = cfngen.template_delta(updated_context)
+        (delta_plus, delta_edit, delta_minus, cloudformation_delta, new_terraform_template_file) = cfngen.template_delta(updated_context)
         self.assertEqual(list(delta_plus['Resources'].keys()), [])
         self.assertEqual(list(delta_minus['Resources'].keys()), [])
         self.assertEqual(list(delta_plus['Outputs'].keys()), [])
@@ -123,7 +123,7 @@ class TestUpdates(base.BaseCase):
         context['cloudfront']['subdomains'] = [
             "custom-subdomain.example.org"
         ]
-        (delta_plus, delta_edit, delta_minus, new_terraform_template_file) = cfngen.template_delta(context)
+        (delta_plus, delta_edit, delta_minus, cloudformation_delta, new_terraform_template_file) = cfngen.template_delta(context)
         self.assertCountEqual(list(delta_edit['Resources'].keys()), ['CloudFrontCDN', 'CloudFrontCDNDNS1'])
         self.assertEqual(delta_edit['Resources']['CloudFrontCDNDNS1']['Properties']['Name'], 'custom-subdomain.example.org.')
         self.assertEqual(list(delta_edit['Outputs'].keys()), [])
@@ -132,7 +132,7 @@ class TestUpdates(base.BaseCase):
         "we want to update ELBs in place given how long it takes to recreate them"
         context = self._base_context('project-with-cluster')
         context['elb']['healthcheck']['protocol'] = 'tcp'
-        (delta_plus, delta_edit, delta_minus, new_terraform_template_file) = cfngen.template_delta(context)
+        (delta_plus, delta_edit, delta_minus, cloudformation_delta, new_terraform_template_file) = cfngen.template_delta(context)
         self.assertEqual(list(delta_edit['Resources'].keys()), ['ElasticLoadBalancer'])
         self.assertEqual(delta_edit['Resources']['ElasticLoadBalancer']['Properties']['HealthCheck']['Target'], 'TCP:80')
         self.assertEqual(list(delta_edit['Outputs'].keys()), [])
@@ -142,7 +142,7 @@ class TestUpdates(base.BaseCase):
         context = self._base_context('project-with-cluster')
         context['elb']['protocol'] = 'https'
         context['elb']['certificate'] = 'DUMMY_CERTIFICATE'
-        (delta_plus, delta_edit, delta_minus, new_terraform_template_file) = cfngen.template_delta(context)
+        (delta_plus, delta_edit, delta_minus, cloudformation_delta, new_terraform_template_file) = cfngen.template_delta(context)
         self.assertCountEqual(list(delta_edit['Resources'].keys()), ['ElasticLoadBalancer', 'ELBSecurityGroup'])
         self.assertEqual(list(delta_edit['Outputs'].keys()), [])
 
@@ -153,7 +153,7 @@ class TestUpdates(base.BaseCase):
             'size': 10,
             'device': '/dev/sdh',
         }
-        (delta_plus, delta_edit, delta_minus, new_terraform_template_file) = cfngen.template_delta(context)
+        (delta_plus, delta_edit, delta_minus, cloudformation_delta, new_terraform_template_file) = cfngen.template_delta(context)
         self.assertCountEqual(list(delta_plus['Resources'].keys()), ['MountPoint1', 'ExtraStorage1'])
         self.assertEqual(delta_plus['Resources']['ExtraStorage1']['Properties']['Size'], '10')
         self.assertEqual(delta_plus['Resources']['MountPoint1']['Properties']['Device'], '/dev/sdh')
@@ -162,7 +162,7 @@ class TestUpdates(base.BaseCase):
     def test_template_delta_includes_removal_of_subdomains(self):
         context = self._base_context('dummy2')
         context['subdomains'] = []
-        (delta_plus, delta_edit, delta_minus, new_terraform_template_file) = cfngen.template_delta(context)
+        (delta_plus, delta_edit, delta_minus, cloudformation_delta, new_terraform_template_file) = cfngen.template_delta(context)
         self.assertEqual(list(delta_minus['Resources'].keys()), ['CnameDNS1'])
         self.assertEqual(list(delta_minus['Outputs'].keys()), [])
 
@@ -174,7 +174,7 @@ class TestUpdates(base.BaseCase):
                 'C': 3,
             }
         }
-        cloudformation.apply_delta(template, cfngen.Delta({'Resources': {'D': 4}}, {'Resources': {'C': 30}}, {'Resources': {'B': 2}}))
+        cloudformation.apply_delta(template, cloudformation.CloudFormationDelta({'Resources': {'D': 4}}, {'Resources': {'C': 30}}, {'Resources': {'B': 2}}))
         self.assertEqual(template, {'Resources': {'A': 1, 'C': 30, 'D': 4}})
 
     def test_apply_delta_may_add_components_which_werent_there(self):
@@ -183,7 +183,7 @@ class TestUpdates(base.BaseCase):
                 'A': 1,
             }
         }
-        cloudformation.apply_delta(template, cfngen.Delta({'Outputs': {'B': 2}}, {}, {}))
+        cloudformation.apply_delta(template, cloudformation.CloudFormationDelta({'Outputs': {'B': 2}}, {}, {}))
         self.assertEqual(template, {'Resources': {'A': 1}, 'Outputs': {'B': 2}})
 
     def _base_context(self, project_name='dummy1', in_memory=False, existing_context=None):

--- a/src/tests/test_buildercore_cloudformation.py
+++ b/src/tests/test_buildercore_cloudformation.py
@@ -17,6 +17,10 @@ class StackCreationContextManager(base.BaseCase):
                 'CreateStack'
             )
 
+class StackUpdate(base.BaseCase):
+    def test_no_updates(self):
+        cloudformation.update_template('dummy1--test', cloudformation.CloudFormationDelta())
+
 class ApplyDelta(base.BaseCase):
     def test_apply_delta_may_add_edit_and_remove_resources(self):
         template = {

--- a/src/tests/test_buildercore_cloudformation.py
+++ b/src/tests/test_buildercore_cloudformation.py
@@ -16,3 +16,25 @@ class StackCreationContextManager(base.BaseCase):
                 },
                 'CreateStack'
             )
+
+class ApplyDelta(base.BaseCase):
+    def test_apply_delta_may_add_edit_and_remove_resources(self):
+        template = {
+            'Resources': {
+                'A': 1,
+                'B': 2,
+                'C': 3,
+            }
+        }
+        cloudformation.apply_delta(template, cloudformation.CloudFormationDelta({'Resources': {'D': 4}}, {'Resources': {'C': 30}}, {'Resources': {'B': 2}}))
+        self.assertEqual(template, {'Resources': {'A': 1, 'C': 30, 'D': 4}})
+
+    def test_apply_delta_may_add_components_which_werent_there(self):
+        template = {
+            'Resources': {
+                'A': 1,
+            }
+        }
+        cloudformation.apply_delta(template, cloudformation.CloudFormationDelta({'Outputs': {'B': 2}}, {}, {}))
+        self.assertEqual(template, {'Resources': {'A': 1}, 'Outputs': {'B': 2}})
+

--- a/src/tests/test_buildercore_cloudformation.py
+++ b/src/tests/test_buildercore_cloudformation.py
@@ -37,4 +37,3 @@ class ApplyDelta(base.BaseCase):
         }
         cloudformation.apply_delta(template, cloudformation.CloudFormationDelta({'Outputs': {'B': 2}}, {}, {}))
         self.assertEqual(template, {'Resources': {'A': 1}, 'Outputs': {'B': 2}})
-

--- a/src/tests/test_buildercore_terraform.py
+++ b/src/tests/test_buildercore_terraform.py
@@ -38,8 +38,7 @@ class TestBuildercoreTerraform(base.BaseCase):
         stackname = 'project-with-fastly-minimal--prod'
         context = cfngen.build_context('project-with-fastly-minimal', stackname=stackname)
         terraform.init(stackname, context)
-        new_identical_template = terraform.render(context)
-        delta = terraform.generate_delta(context, new_identical_template)
+        delta = terraform.generate_delta(context)
         self.assertEqual(delta, terraform.TerraformDelta('Plan output: ...'))
 
     def test_fastly_template_minimal(self):


### PR DESCRIPTION
Strictly separates more of the `update_infrastructure` process into `cloudformation` and `terraform` modules. Carries on the emptying out of `cfngen` from CloudFormation or Terraform concerns. The end result is also that `cfn` becomes simpler as `cloudformation` and `terraform` get uniform interfaces (similar function names and arguments).