### PR TITLE
CDN path for digest images

### DIFF
--- a/projects/elife.yaml
+++ b/projects/elife.yaml
@@ -738,9 +738,9 @@ generic-cdn:
                 articles:
                     hostname: "{instance}-elife-published.s3.amazonaws.com"
                     condition: req.url ~ "^/articles/"
-                digest:
+                digests:
                     hostname: "{instance}-elife-published.s3.amazonaws.com"
-                    condition: req.url ~ "^/digest/"
+                    condition: req.url ~ "^/digests/"
             default-ttl: 86400 # seconds
             vcl:
                 - "original-host"

--- a/projects/elife.yaml
+++ b/projects/elife.yaml
@@ -738,6 +738,9 @@ generic-cdn:
                 articles:
                     hostname: "{instance}-elife-published.s3.amazonaws.com"
                     condition: req.url ~ "^/articles/"
+                digest:
+                    hostname: "{instance}-elife-published.s3.amazonaws.com"
+                    condition: req.url ~ "^/digest/"
             default-ttl: 86400 # seconds
             vcl:
                 - "original-host"


### PR DESCRIPTION
Making a stab at the CDN configuration described in https://github.com/elifesciences/digest-parser/issues/18.