### PR TITLE
Feature: reduces the logging noise from boto3 and botocore

### DIFF
--- a/src/buildercore/core.py
+++ b/src/buildercore/core.py
@@ -19,7 +19,8 @@ import logging
 from kids.cache import cache as cached
 
 LOG = logging.getLogger(__name__)
-boto3.set_stream_logger(name='botocore', level=logging.INFO)
+boto3.set_stream_logger(name='botocore', level=logging.WARN)
+boto3.set_stream_logger(name='boto3', level=logging.WARN)
 
 class DeprecationException(Exception):
     pass


### PR DESCRIPTION
Example output of me attempting to stop a stopped instance:

```
$ ./bldr stop:gitter--1
2018-06-06 17:35:42,027 botocore.credentials [INFO] Found credentials in shared credentials file: ~/.aws/credentials
INFO - botocore.credentials - Found credentials in shared credentials file: ~/.aws/credentials
2018-06-06 17:35:42,140 boto3.resources.collection [INFO] Calling paginated ec2:describe_instances with {'Filters': [{'Values': ['gitter--1'], 'Name': 'tag:aws:cloudformation:stack-name'}]}
INFO - boto3.resources.collection - Calling paginated ec2:describe_instances with {'Filters': [{'Values': ['gitter--1'], 'Name': 'tag:aws:cloudformation:stack-name'}]}
2018-06-06 17:35:42,142 botocore.vendored.requests.packages.urllib3.connectionpool [INFO] Starting new HTTPS connection (1): ec2.us-east-1.amazonaws.com
INFO - botocore.vendored.requests.packages.urllib3.connectionpool - Starting new HTTPS connection (1): ec2.us-east-1.amazonaws.com
INFO - buildercore.lifecycle - Current states: EC2 {'i-02ad953d80306e8cd': 'stopped'}, RDS {}
INFO - buildercore.lifecycle - Selected for stopping: EC2 [], RDS []
INFO - decorators - func:'stop' args:[('gitter--1',), {}] took: 1.3153 sec

Done.
```

and afterwards:

```
$ ./bldr stop:gitter--1
INFO - buildercore.lifecycle - Current states: EC2 {'i-02ad953d80306e8cd': 'stopped'}, RDS {}
INFO - buildercore.lifecycle - Selected for stopping: EC2 [], RDS []
INFO - decorators - func:'stop' args:[('gitter--1',), {}] took: 1.3773 sec
```

what do you think? 

I personally think there is too much output at the moment and if we prune back some of this noise we can look at more important output and improve or drop the severity of those messages.