### PR TITLE
Allow ensure_destroyed idempotence

### DIFF
--- a/src/buildercore/bootstrap.py
+++ b/src/buildercore/bootstrap.py
@@ -565,6 +565,9 @@ def remove_all_orphaned_keys(master_stackname):
             sudo("rm -f /etc/salt/pki/master/minions/%s" % fname)
 
 def destroy(stackname):
+    # TODO: if context does not exist anymore on S3,
+    # we could exit idempotently
+
     context = context_handler.load_context(stackname)
     terraform.destroy(stackname, context)
     cloudformation.destroy(stackname, context)
@@ -572,4 +575,6 @@ def destroy(stackname):
     # don't do this. requires master server access and would prevent regular users deleting stacks
     # remove_minion_key(stackname)
     delete_dns(stackname)
+
+    context_handler.delete_context(stackname)
     LOG.info("stack %r deleted", stackname)

--- a/src/buildercore/context_handler.py
+++ b/src/buildercore/context_handler.py
@@ -46,10 +46,19 @@ def write_context_to_s3(stackname):
     key = s3_context_key(stackname)
     s3.write(key, open(path, 'rb'), overwrite=True)
 
+def delete_context(stackname):
+    delete_context_locally(stackname)
+    delete_context_from_s3(stackname)
+
 @if_enabled('write-context-to-s3', silent=True)
 def delete_context_from_s3(stackname):
     key = s3_context_key(stackname)
     return s3.delete(key)
+
+def delete_context_locally(stackname):
+    path = local_context_file(stackname)
+    if os.path.exists(path):
+        os.unlink(path)
 
 @if_enabled('write-context-to-s3', silent=True)
 def download_from_s3(stackname, refresh=False):

--- a/src/tests/test_buildercore_context_handler.py
+++ b/src/tests/test_buildercore_context_handler.py
@@ -4,7 +4,7 @@ from buildercore import cfngen, context_handler
 
 class TestBuildercoreContext(base.BaseCase):
     def setUp(self):
-        print(context_handler.delete_context_from_s3('dummy1--prod'))
+        context_handler.delete_context_from_s3('dummy1--prod')
 
     def test_storing_a_context_on_s3_and_retrieving_it_from_a_new_client(self):
         stackname = 'dummy1--prod'


### PR DESCRIPTION
Streamlines the destroy behavior to be:
- destroy CloudFormation/Terraform
- destroy leftover resources such as DNS
- finally destroy the context, both locally and from S3

The context is the first thing we check for idempotence: if it's
missing, we are sure everything has already been deleted.

https://github.com/elifesciences/journal-formula/pull/62 had some
problems to be solved with this change.