### PR TITLE
ELPP-3524 Fastly configuration for elifesciences.org

### DIFF
--- a/projects/elife.yaml
+++ b/projects/elife.yaml
@@ -508,6 +508,25 @@ journal:
                             - Referer
                         cookies:
                             - journal
+            fastly:
+                subdomains:
+                    - "{instance}--fastly-journal"
+                #healthcheck:
+                #    path: /ping-fastly
+                #    check-interval: 30000
+                #    timeout: 2000
+                #errors:
+                #    # always prod for simplicity
+                #    url: https://prod-elife-error-pages.s3.amazonaws.com/
+                #    codes:
+                #        503: "5xx.html"
+                vcl:
+                    - "original-host"
+                    - "strip-non-journal-cookies"
+                gcslogging:
+                    bucket: "{instance}-elife-fastly"
+                    path: "journal--{instance}/"
+                    period: 600
         prod:
             description: prod environment for journal. ELB on top of multiple EC2 instances
             ec2:

--- a/projects/elife.yaml
+++ b/projects/elife.yaml
@@ -511,15 +511,15 @@ journal:
             fastly:
                 subdomains:
                     - "{instance}--fastly-journal"
-                #healthcheck:
-                #    path: /ping-fastly
-                #    check-interval: 30000
-                #    timeout: 2000
-                #errors:
-                #    # always prod for simplicity
-                #    url: https://prod-elife-error-pages.s3.amazonaws.com/
-                #    codes:
-                #        503: "5xx.html"
+                healthcheck:
+                    path: /ping-fastly
+                    check-interval: 30000
+                    timeout: 2000
+                errors:
+                    # always prod for simplicity
+                    url: https://prod-elife-error-pages.s3.amazonaws.com/
+                    codes:
+                        503: "5xx.html"
                 vcl:
                     - "original-host"
                     - "strip-non-journal-cookies"

--- a/projects/elife.yaml
+++ b/projects/elife.yaml
@@ -515,11 +515,11 @@ journal:
                     path: /ping-fastly
                     check-interval: 30000
                     timeout: 2000
-                errors:
-                    # always prod for simplicity
-                    url: https://prod-elife-error-pages.s3.amazonaws.com/
-                    codes:
-                        503: "5xx.html"
+                #errors:
+                #    # always prod for simplicity
+                #    url: https://prod-elife-error-pages.s3.amazonaws.com/
+                #    codes:
+                #        503: "5xx.html"
                 vcl:
                     - "original-host"
                     - "strip-non-journal-cookies"

--- a/projects/elife.yaml
+++ b/projects/elife.yaml
@@ -134,6 +134,11 @@ defaults:
             default-ttl: 3600 # Fastly default, in seconds
             dns:
                 cname: u2.shared.global.fastly.net
+                a:
+                    - 151.101.2.217
+                    - 151.101.66.217
+                    - 151.101.130.217
+                    - 151.101.194.217
             gcslogging: false
             healthcheck: false
             errors: false

--- a/src/buildercore/fastly.py
+++ b/src/buildercore/fastly.py
@@ -95,4 +95,10 @@ VCL_SNIPPETS = {
         type='recv',
         hook='after'
     ),
+    'strip-non-journal-cookies': FastlyVCLSnippet(
+        name='strip-non-journal-cookies',
+        content=_read_vcl_file('strip-non-journal-cookies.vcl'),
+        type='recv',
+        hook='after'
+    ),
 }

--- a/src/buildercore/fastly/vcl/strip-non-journal-cookies.vcl
+++ b/src/buildercore/fastly/vcl/strip-non-journal-cookies.vcl
@@ -1,0 +1,7 @@
+declare local var.journal_cookie STRING;
+set var.journal_cookie = req.http.Cookie:journal;
+if (var.journal_cookie != "") {
+    set req.http.Cookie = "journal=" var.journal_cookie ";";
+} else {
+    unset req.http.Cookie;
+}

--- a/src/buildercore/trop.py
+++ b/src/buildercore/trop.py
@@ -51,9 +51,6 @@ ELASTICACHE_PARAMETER_GROUP_TITLE = 'ElastiCacheParameterGroup'
 
 KEYPAIR = "KeyName"
 
-FASTLY_GLOBAL = 'nonssl.global.fastly.net.'
-FASTLY_SSL = 'u2.shared.global.fastly.net'
-
 def _read_script(script_filename):
     path = join(config.SCRIPTS_PATH, script_filename)
     with open(path, 'r') as fp:
@@ -391,7 +388,7 @@ def external_dns_fastly(context):
     ensure(isinstance(context['domain'], str), "A 'domain' must be specified for CNAMEs to be built: %s" % context)
 
     # may be used to point to TLS servers
-    cname = context['fastly']['dns'].get('cname', FASTLY_GLOBAL)
+    cname = context['fastly']['dns']['cname']
 
     def entry(hostname, i):
         if _is_domain_2nd_level(hostname):

--- a/src/buildercore/trop.py
+++ b/src/buildercore/trop.py
@@ -402,16 +402,16 @@ def external_dns_fastly(context):
                 ResourceRecords=ip_addresses,
             )
             raise ConfigurationError("2nd-level domains aliases are not supported yet by builder. See https://docs.fastly.com/guides/basic-configuration/using-fastly-with-apex-domains")
-        else:
-            cname = context['fastly']['dns']['cname']
-            return route53.RecordSetType(
-                R53_FASTLY_TITLE % (i + 1), # expecting more than one entry (aliases), so numbering them immediately
-                HostedZoneName=hostedzone,
-                Name=hostname,
-                Type="CNAME",
-                TTL="60",
-                ResourceRecords=[cname],
-            )
+
+        cname = context['fastly']['dns']['cname']
+        return route53.RecordSetType(
+            R53_FASTLY_TITLE % (i + 1), # expecting more than one entry (aliases), so numbering them immediately
+            HostedZoneName=hostedzone,
+            Name=hostname,
+            Type="CNAME",
+            TTL="60",
+            ResourceRecords=[cname],
+        )
     return [entry(hostname, i) for i, hostname in enumerate(context['fastly']['subdomains'])]
 
 #

--- a/src/buildercore/trop.py
+++ b/src/buildercore/trop.py
@@ -389,7 +389,6 @@ def external_dns_fastly(context):
 
     # may be used to point to TLS servers
 
-
     def entry(hostname, i):
         hostedzone = context['domain'] + "."
         if _is_domain_2nd_level(hostname):

--- a/src/tests/fixtures/projects/dummy-project.yaml
+++ b/src/tests/fixtures/projects/dummy-project.yaml
@@ -97,6 +97,9 @@ defaults:
             subdomains-without-dns: []
             dns:
                 cname: something.fastly.net
+                a:
+                    - 127.0.0.1
+                    - 127.0.0.2
             default-ttl: 3600 # seconds
             gcslogging: false
             healthcheck: false
@@ -336,6 +339,7 @@ project-with-fastly-complex:
             subdomains:
                 - "{instance}--cdn1-of-www"
                 - "{instance}--cdn2-of-www"
+                - ""
             subdomains-without-dns:
                 - "future"
             default-ttl: 86400

--- a/src/tests/test_buildercore_terraform.py
+++ b/src/tests/test_buildercore_terraform.py
@@ -146,6 +146,9 @@ class TestBuildercoreTerraform(base.BaseCase):
                                     'name': 'prod--cdn2-of-www.example.org'
                                 },
                                 {
+                                    'name': 'example.org'
+                                },
+                                {
                                     'name': 'future.example.org'
                                 },
                             ],

--- a/src/tests/test_buildercore_trop.py
+++ b/src/tests/test_buildercore_trop.py
@@ -822,6 +822,49 @@ class TestBuildercoreTrop(base.BaseCase):
             data['Resources']['CloudFrontCDN']['Properties']['DistributionConfig']['CustomErrorResponses']
         )
 
+    def test_fastly_template_contains_only_dns(self):
+        extra = {
+            'stackname': 'project-with-fastly-complex--prod',
+        }
+        context = cfngen.build_context('project-with-fastly-complex', **extra)
+        cfn_template = trop.render(context)
+        data = self._parse_json(cfn_template)
+        self.assertTrue('FastlyDNS1' in list(data['Resources'].keys()))
+        self.assertEqual(
+            {
+                'HostedZoneName': 'example.org.',
+                'Name': 'prod--cdn1-of-www.example.org',
+                'ResourceRecords': ['something.fastly.net'],
+                'TTL': '60',
+                'Type': 'CNAME',
+            },
+            data['Resources']['FastlyDNS1']['Properties']
+        )
+
+        self.assertTrue('FastlyDNS2' in list(data['Resources'].keys()))
+        self.assertEqual(
+            {
+                'HostedZoneName': 'example.org.',
+                'Name': 'prod--cdn2-of-www.example.org',
+                'ResourceRecords': ['something.fastly.net'],
+                'TTL': '60',
+                'Type': 'CNAME',
+            },
+            data['Resources']['FastlyDNS2']['Properties']
+        )
+
+        self.assertTrue('FastlyDNS3' in list(data['Resources'].keys()))
+        self.assertEqual(
+            {
+                'HostedZoneName': 'example.org.',
+                'Name': 'example.org',
+                'ResourceRecords': ['127.0.0.1', '127.0.0.2'],
+                'TTL': '60',
+                'Type': 'A',
+            },
+            data['Resources']['FastlyDNS3']['Properties']
+        )
+
     def test_elasticache_redis_template(self):
         extra = {
             'stackname': 'project-with-elasticache-redis--prod',


### PR DESCRIPTION
First stage:

- subdomain mapped with CNAME but support for A is provided (will be needed for 2nd-level domains like `elifesciences.org`)
- health check (hits nginx through the load balancer)
- some VCL to strip all cookies but `journal`, emulating CloudFront's whitelist
- usual `gcslogging`

More will follow on the error-pages, fundamentally they don't work in all use cases now so the implementation has to be rewritten with MoreCustomVCL(TM).