### PR TITLE
ELPP-3524 journal--prod test on Fastly, with new implementation of Fastly error pages

### DIFF
--- a/projects/elife.yaml
+++ b/projects/elife.yaml
@@ -519,7 +519,7 @@ journal:
                     # always prod for simplicity
                     url: https://prod-elife-error-pages.s3.amazonaws.com/
                     codes:
-                        503: "5xx.html"
+                        503: "503.html"
                 vcl:
                     - "original-host"
                     - "strip-non-journal-cookies"
@@ -590,7 +590,7 @@ journal:
                     # always prod for simplicity
                     url: https://prod-elife-error-pages.s3.amazonaws.com/
                     codes:
-                        503: "5xx.html"
+                        503: "503.html"
                 vcl:
                     - "original-host"
                     - "strip-non-journal-cookies"

--- a/projects/elife.yaml
+++ b/projects/elife.yaml
@@ -515,11 +515,11 @@ journal:
                     path: /ping-fastly
                     check-interval: 30000
                     timeout: 2000
-                #errors:
-                #    # always prod for simplicity
-                #    url: https://prod-elife-error-pages.s3.amazonaws.com/
-                #    codes:
-                #        503: "5xx.html"
+                errors:
+                    # always prod for simplicity
+                    url: https://prod-elife-error-pages.s3.amazonaws.com/
+                    codes:
+                        503: "5xx.html"
                 vcl:
                     - "original-host"
                     - "strip-non-journal-cookies"

--- a/projects/elife.yaml
+++ b/projects/elife.yaml
@@ -578,6 +578,26 @@ journal:
                             - journal
                 logging:
                     bucket: elife-cloudfront-logs
+            fastly:
+                subdomains:
+                    - "{instance}--fastly-journal"
+                    - "elifejournal.org"
+                healthcheck:
+                    path: /ping-fastly
+                    check-interval: 30000
+                    timeout: 2000
+                errors:
+                    # always prod for simplicity
+                    url: https://prod-elife-error-pages.s3.amazonaws.com/
+                    codes:
+                        503: "5xx.html"
+                vcl:
+                    - "original-host"
+                    - "strip-non-journal-cookies"
+                gcslogging:
+                    bucket: "{instance}-elife-fastly"
+                    path: "journal--{instance}/"
+                    period: 600
     vagrant:
         box: ubuntu/trusty64 # Ubuntu 14.04, deprecated
         ram: 4096

--- a/src/buildercore/fastly.py
+++ b/src/buildercore/fastly.py
@@ -46,13 +46,7 @@ class FastlyVCL:
             raise FastlyCustomVCLGenerationError("Cannot match %s into main VCL template:\n\n%s" % (lookup, str(self)))
         return section_start
 
-class FastlyVCLSnippet(namedtuple('FastlyVCLSnippet', ['name', 'content', 'type', 'hook'])):
-    """VCL snippets that can be used to augment the default VCL
-
-    Due to Terraform limitations we are unable to pass these directly to the Fastly API, and have to build a whole VCL ourselves.
-
-    Terminology for fields comes from https://docs.fastly.com/api/config#snippet"""
-
+class FastlyVCLInclusion(namedtuple('FastlyVCLInclusion', ['name', 'type', 'hook'])):
     def insert_include(self, main_vcl):
         return main_vcl.insert(
             self.type,
@@ -64,10 +58,20 @@ class FastlyVCLSnippet(namedtuple('FastlyVCLSnippet', ['name', 'content', 'type'
             ]
         )
 
+
+class FastlyVCLSnippet(namedtuple('FastlyVCLSnippet', ['name', 'content', 'type', 'hook'])):
+    """VCL snippets that can be used to augment the default VCL
+
+    Due to Terraform limitations we are unable to pass these directly to the Fastly API, and have to build a whole VCL ourselves.
+
+    Terminology for fields comes from https://docs.fastly.com/api/config#snippet"""
+
+    def as_inclusion(self):
+        return FastlyVCLInclusion(self.name, self.type, self.hook)
+
 class FastlyVCLTemplate(namedtuple('FastlyVCLTemplate', ['name', 'content', 'type', 'hook'])):
-    def as_snippet(self, name):
-        # TODO: self.content should not be there
-        return FastlyVCLSnippet(name, self.content, self.type, self.hook)
+    def as_inclusion(self, name):
+        return FastlyVCLInclusion(name, self.type, self.hook)
 
 class FastlyCustomVCLGenerationError(Exception):
     pass

--- a/src/buildercore/fastly.py
+++ b/src/buildercore/fastly.py
@@ -64,6 +64,11 @@ class FastlyVCLSnippet(namedtuple('FastlyVCLSnippet', ['name', 'content', 'type'
             ]
         )
 
+class FastlyVCLTemplate(FastlyVCLSnippet):
+    def as_snippet(self, name):
+        # TODO: self.content should not be there
+        return FastlyVCLSnippet(name, self.content, self.type, self.hook)
+
 class FastlyCustomVCLGenerationError(Exception):
     pass
 
@@ -104,7 +109,7 @@ VCL_SNIPPETS = {
 }
 
 VCL_TEMPLATES = {
-    'error-page': FastlyVCLSnippet(
+    'error-page': FastlyVCLTemplate(
         name='error-page',
         content=_read_vcl_file('error-page.vcl.tpl'),
         type='error',

--- a/src/buildercore/fastly.py
+++ b/src/buildercore/fastly.py
@@ -64,8 +64,7 @@ class FastlyVCLSnippet(namedtuple('FastlyVCLSnippet', ['name', 'content', 'type'
             ]
         )
 
-# TODO: may not need extension?
-class FastlyVCLTemplate(FastlyVCLSnippet):
+class FastlyVCLTemplate(namedtuple('FastlyVCLTemplate', ['name', 'content', 'type', 'hook'])):
     def as_snippet(self, name):
         # TODO: self.content should not be there
         return FastlyVCLSnippet(name, self.content, self.type, self.hook)

--- a/src/buildercore/fastly.py
+++ b/src/buildercore/fastly.py
@@ -64,6 +64,7 @@ class FastlyVCLSnippet(namedtuple('FastlyVCLSnippet', ['name', 'content', 'type'
             ]
         )
 
+# TODO: may not need extension?
 class FastlyVCLTemplate(FastlyVCLSnippet):
     def as_snippet(self, name):
         # TODO: self.content should not be there

--- a/src/buildercore/fastly.py
+++ b/src/buildercore/fastly.py
@@ -102,3 +102,12 @@ VCL_SNIPPETS = {
         hook='after'
     ),
 }
+
+VCL_TEMPLATES = {
+    'error-page': FastlyVCLSnippet(
+        name='error-page',
+        content=_read_vcl_file('error-page.vcl.tpl'),
+        type='error',
+        hook='after'
+    ),
+}

--- a/src/buildercore/fastly/vcl/error-page.vcl.tpl
+++ b/src/buildercore/fastly/vcl/error-page.vcl.tpl
@@ -1,0 +1,7 @@
+# not to be used directly as a VCL snippet
+
+if (obj.status == ${code}) {
+   set obj.http.Content-Type = "text/html; charset=us-ascii";
+      synthetic {"${synthetic_response}"};
+     return(deliver);
+}

--- a/src/buildercore/fastly/vcl/error-page.vcl.tpl
+++ b/src/buildercore/fastly/vcl/error-page.vcl.tpl
@@ -1,5 +1,3 @@
-# not to be used directly as a VCL snippet
-
 if (obj.status == ${code}) {
    set obj.http.Content-Type = "text/html; charset=us-ascii";
       synthetic {"${synthetic_response}"};

--- a/src/buildercore/terraform.py
+++ b/src/buildercore/terraform.py
@@ -193,7 +193,7 @@ def render_fastly(context):
                     }
                 },
             }
-            vcl_templated_snippets[name] = error_vcl_template.as_snippet(name)
+            vcl_templated_snippets[name] = error_vcl_template.as_inclusion(name)
 
     if context['fastly']['gcslogging']:
         gcslogging = context['fastly']['gcslogging']
@@ -229,7 +229,7 @@ def render_fastly(context):
         tf_file['resource'][RESOURCE_TYPE_FASTLY][RESOURCE_NAME_FASTLY]['vcl'].extend([
             {
                 'name': snippet_name,
-                'content': '${data.template_file.%s.rendered}' % name,
+                'content': '${data.template_file.%s.rendered}' % snippet_name,
             } for snippet_name in vcl_templated_snippets
         ])
 
@@ -237,7 +237,7 @@ def render_fastly(context):
         linked_main_vcl = fastly.MAIN_VCL_TEMPLATE
         for name in vcl_constant_snippets:
             snippet = fastly.VCL_SNIPPETS[name]
-            linked_main_vcl = snippet.insert_include(linked_main_vcl)
+            linked_main_vcl = snippet.as_inclusion().insert_include(linked_main_vcl)
         for name in vcl_templated_snippets:
             linked_main_vcl = vcl_templated_snippets[name].insert_include(linked_main_vcl)
 

--- a/src/buildercore/terraform.py
+++ b/src/buildercore/terraform.py
@@ -235,11 +235,9 @@ def render_fastly(context):
 
         # main
         linked_main_vcl = fastly.MAIN_VCL_TEMPLATE
-        for name in vcl_constant_snippets:
-            snippet = fastly.VCL_SNIPPETS[name]
-            linked_main_vcl = snippet.as_inclusion().insert_include(linked_main_vcl)
-        for name in vcl_templated_snippets:
-            linked_main_vcl = vcl_templated_snippets[name].insert_include(linked_main_vcl)
+        inclusions = [fastly.VCL_SNIPPETS[name].as_inclusion() for name in vcl_constant_snippets] + vcl_templated_snippets.values()
+        for i in inclusions:
+            linked_main_vcl = i.insert_include(linked_main_vcl)
 
         tf_file['resource'][RESOURCE_TYPE_FASTLY][RESOURCE_NAME_FASTLY]['vcl'].append({
             'name': FASTLY_MAIN_VCL_KEY,

--- a/src/buildercore/terraform.py
+++ b/src/buildercore/terraform.py
@@ -96,6 +96,7 @@ def render_fastly(context):
     request_settings = []
     headers = []
     data = {}
+    vcl_constant_snippets = context['fastly']['vcl']
     vcl_templated_snippets = {}
 
     if context['fastly']['backends']:
@@ -214,9 +215,8 @@ def render_fastly(context):
             }
         }
 
-    if context['fastly']['vcl'] or vcl_templated_snippets:
-        # snippets
-        vcl_constant_snippets = context['fastly']['vcl']
+    if vcl_constant_snippets or vcl_templated_snippets:
+        # constant snippets
         tf_file['resource'][RESOURCE_TYPE_FASTLY][RESOURCE_NAME_FASTLY]['vcl'] = [
             {
                 'name': snippet_name,
@@ -224,7 +224,7 @@ def render_fastly(context):
             } for snippet_name in vcl_constant_snippets
         ]
 
-        # templates
+        # templated snippets
         tf_file['resource'][RESOURCE_TYPE_FASTLY][RESOURCE_NAME_FASTLY]['vcl'].extend([
             {
                 'name': snippet_name,
@@ -233,7 +233,6 @@ def render_fastly(context):
         ])
 
         # main
-
         linked_main_vcl = fastly.MAIN_VCL_TEMPLATE
         for name in vcl_constant_snippets:
             snippet = fastly.VCL_SNIPPETS[name]

--- a/src/buildercore/terraform.py
+++ b/src/buildercore/terraform.py
@@ -170,10 +170,11 @@ def render_fastly(context):
             b['healthcheck'] = 'default'
 
     if context['fastly']['errors']:
-        error_vcl_template = _generate_vcl_file(
+        error_vcl_template = fastly.VCL_TEMPLATES['error-page']
+        error_vcl_template_file = _generate_vcl_file(
             context['stackname'],
-            fastly.VCL_TEMPLATES['error-page'].content,
-            fastly.VCL_TEMPLATES['error-page'].name,
+            error_vcl_template.content,
+            error_vcl_template.name,
             extension='vcl.tpl'
         )
         errors = context['fastly']['errors']
@@ -185,14 +186,14 @@ def render_fastly(context):
             name = 'error-page-vcl-%d' % code
             data['template_file'] = {
                 name: {
-                    'template': error_vcl_template,
+                    'template': error_vcl_template_file,
                     'vars': {
                         'code': '%d' % code,
                         'synthetic_response': '${data.http.error-page-%s.body}' % code,
                     }
                 },
             }
-            vcl_templated_snippets[name] = fastly.VCL_TEMPLATES['error-page'].as_snippet(name)
+            vcl_templated_snippets[name] = error_vcl_template.as_snippet(name)
 
     if context['fastly']['gcslogging']:
         gcslogging = context['fastly']['gcslogging']

--- a/src/buildercore/terraform.py
+++ b/src/buildercore/terraform.py
@@ -212,7 +212,7 @@ def render_fastly(context):
 
         # main
         linked_main_vcl = fastly.MAIN_VCL_TEMPLATE
-        inclusions = [fastly.VCL_SNIPPETS[name].as_inclusion() for name in vcl_constant_snippets] + vcl_templated_snippets.values()
+        inclusions = [fastly.VCL_SNIPPETS[name].as_inclusion() for name in vcl_constant_snippets] + list(vcl_templated_snippets.values())
         for i in inclusions:
             linked_main_vcl = i.insert_include(linked_main_vcl)
 

--- a/src/buildercore/terraform.py
+++ b/src/buildercore/terraform.py
@@ -19,6 +19,7 @@ RESOURCE_NAME_FASTLY = 'fastly-cdn'
 
 DATA_TYPE_VAULT_GENERIC_SECRET = 'vault_generic_secret'
 DATA_TYPE_HTTP = 'http'
+DATE_TYPE_TEMPLATE = 'template_file'
 DATA_NAME_VAULT_GCS_LOGGING = 'fastly-gcs-logging'
 DATA_NAME_VAULT_FASTLY_API_KEY = 'fastly'
 
@@ -184,11 +185,11 @@ def render_fastly(context):
                 'url': '%s%s' % (errors['url'], path),
             }
             name = 'error-page-vcl-%d' % code
-            data['template_file'] = {
+            data[DATE_TYPE_TEMPLATE] = {
                 name: {
                     'template': error_vcl_template_file,
                     'vars': {
-                        'code': '%d' % code,
+                        'code': code,
                         'synthetic_response': '${data.http.error-page-%s.body}' % code,
                     }
                 },

--- a/src/buildercore/trop.py
+++ b/src/buildercore/trop.py
@@ -390,8 +390,8 @@ def external_dns_fastly(context):
     # may be used to point to TLS servers
 
     def entry(hostname, i):
-        hostedzone = context['domain'] + "."
         if _is_domain_2nd_level(hostname):
+            hostedzone = hostname + "."
             ip_addresses = context['fastly']['dns']['a']
             return route53.RecordSetType(
                 R53_FASTLY_TITLE % (i + 1), # expecting more than one entry (aliases), so numbering them immediately
@@ -403,6 +403,7 @@ def external_dns_fastly(context):
             )
             raise ConfigurationError("2nd-level domains aliases are not supported yet by builder. See https://docs.fastly.com/guides/basic-configuration/using-fastly-with-apex-domains")
 
+        hostedzone = context['domain'] + "."
         cname = context['fastly']['dns']['cname']
         return route53.RecordSetType(
             R53_FASTLY_TITLE % (i + 1), # expecting more than one entry (aliases), so numbering them immediately

--- a/src/tests/fixtures/projects/dummy-project.yaml
+++ b/src/tests/fixtures/projects/dummy-project.yaml
@@ -340,6 +340,7 @@ project-with-fastly-complex:
                 - "{instance}--cdn1-of-www"
                 - "{instance}--cdn2-of-www"
                 - ""
+                - "anotherdomain.org"
             subdomains-without-dns:
                 - "future"
             default-ttl: 86400

--- a/src/tests/test_buildercore_fastly.py
+++ b/src/tests/test_buildercore_fastly.py
@@ -63,7 +63,6 @@ sub vcl_fetch {
   }
 }
 """)
-        print(snippet.insert_include(original_main_vcl))
         self.assertEqual(
             snippet.insert_include(original_main_vcl),
             expected_main_vcl

--- a/src/tests/test_buildercore_fastly.py
+++ b/src/tests/test_buildercore_fastly.py
@@ -3,9 +3,8 @@ from . import base
 
 class TestFastlyCustomVCL(base.BaseCase):
     def test_inserts_snippets_through_include_statements(self):
-        snippet = fastly.FastlyVCLSnippet(
+        snippet = fastly.FastlyVCLInclusion(
             name='do-some-magic',
-            content='...',
             type='fetch',
             hook='after'
         )
@@ -37,9 +36,8 @@ sub vcl_fetch {
         )
 
     def test_snippets_can_be_included_even_before_fastly_macros(self):
-        snippet = fastly.FastlyVCLSnippet(
+        snippet = fastly.FastlyVCLInclusion(
             name='do-some-magic',
-            content='...',
             type='fetch',
             hook='before'
         )
@@ -72,9 +70,8 @@ sub vcl_fetch {
         )
 
     def test_stops_generation_if_an_inclusion_section_cannot_be_found(self):
-        snippet = fastly.FastlyVCLSnippet(
+        snippet = fastly.FastlyVCLInclusion(
             name='do-some-magic',
-            content='...',
             type='hit',
             hook='after'
         )

--- a/src/tests/test_buildercore_terraform.py
+++ b/src/tests/test_buildercore_terraform.py
@@ -158,6 +158,9 @@ class TestBuildercoreTerraform(base.BaseCase):
                                     'name': 'example.org'
                                 },
                                 {
+                                    'name': 'anotherdomain.org'
+                                },
+                                {
                                     'name': 'future.example.org'
                                 },
                             ],

--- a/src/tests/test_buildercore_terraform.py
+++ b/src/tests/test_buildercore_terraform.py
@@ -242,6 +242,10 @@ class TestBuildercoreTerraform(base.BaseCase):
                                     'content': '${file("gzip-by-content-type-suffix.vcl")}',
                                 },
                                 {
+                                    'name': 'error-page-vcl-503',
+                                    'content': '${data.template_file.error-page-vcl-503.rendered}',
+                                },
+                                {
                                     'name': 'main',
                                     'content': '${file("main.vcl")}',
                                     'main': True,

--- a/src/tests/test_buildercore_terraform.py
+++ b/src/tests/test_buildercore_terraform.py
@@ -132,6 +132,15 @@ class TestBuildercoreTerraform(base.BaseCase):
                             'url': 'https://example.com/'
                         },
                     },
+                    'template_file': {
+                        'error-page-vcl-503': {
+                            'template': '${file("error-page.vcl.tpl")}',
+                            'vars': {
+                                'code': '503',
+                                'synthetic_response': '${data.http.error-page-503.body}',
+                            },
+                        },
+                    },
                 },
                 'resource': {
                     'fastly_service_v1': {
@@ -222,24 +231,9 @@ class TestBuildercoreTerraform(base.BaseCase):
                                     'type': 'REQUEST',
                                 },
                                 {
-                                    'name': 'condition-503',
-                                    'statement': 'beresp.status == 503',
-                                    'type': 'CACHE',
-                                },
-                                {
                                     'name': 'condition-surrogate-article-id',
                                     'statement': 'req.url ~ "^/articles/(\\d+)/(.+)$"',
                                     'type': 'CACHE',
-                                },
-                            ],
-                            'response_object': [
-                                {
-                                    'name': 'error-503',
-                                    'status': 503,
-                                    'response': 'Service Unavailable',
-                                    'content': '${data.http.error-page-503.body}',
-                                    'content_type': 'text/html; charset=us-ascii',
-                                    'cache_condition': 'condition-503',
                                 },
                             ],
                             'vcl': [

--- a/src/tests/test_buildercore_terraform.py
+++ b/src/tests/test_buildercore_terraform.py
@@ -136,7 +136,7 @@ class TestBuildercoreTerraform(base.BaseCase):
                         'error-page-vcl-503': {
                             'template': '${file("error-page.vcl.tpl")}',
                             'vars': {
-                                'code': '503',
+                                'code': 503,
                                 'synthetic_response': '${data.http.error-page-503.body}',
                             },
                         },

--- a/src/tests/test_buildercore_trop.py
+++ b/src/tests/test_buildercore_trop.py
@@ -865,6 +865,18 @@ class TestBuildercoreTrop(base.BaseCase):
             data['Resources']['FastlyDNS3']['Properties']
         )
 
+        self.assertTrue('FastlyDNS4' in list(data['Resources'].keys()))
+        self.assertEqual(
+            {
+                'HostedZoneName': 'anotherdomain.org.',
+                'Name': 'anotherdomain.org',
+                'ResourceRecords': ['127.0.0.1', '127.0.0.2'],
+                'TTL': '60',
+                'Type': 'A',
+            },
+            data['Resources']['FastlyDNS4']['Properties']
+        )
+
     def test_elasticache_redis_template(self):
         extra = {
             'stackname': 'project-with-elasticache-redis--prod',


### PR DESCRIPTION
## Test Fastly on 2nd-level domain

We use `elifejournal.org` already added to our Fastly TLS certificates. The DNS is different from the CNAME used for domains such as `cdn.elifesciences.org`, we configure A records instead.

## Error pages

The previous implementation overwrote all 503 errors, but didn't work when the origin was down. With the magic of Terraform and custom VCL we:

1. Download the `error-pages--prod` HTML as a Terraform data source
2. Put it into a template that becomes the VCL snippet `error-page-vcl-503` which is another, derived Terraform data source.
3. Include that template into the main VCL, along with any other VCL snippet we were interested in.

Incredibly, the whole pipeline works and generates a VCL that not only has correct syntax but also served the synthetic response when the origin is unreachable (easily tested by stopping nginx).