### PR TITLE
ELPP-3393 Add ELB to journal--continuumtest

### DIFF
--- a/projects/elife.yaml
+++ b/projects/elife.yaml
@@ -501,6 +501,13 @@ journal:
                 engine: redis
                 type: cache.t2.micro
                 clusters: 2
+            elb:
+                stickiness:
+                    type: cookie
+                    cookie-name: journal
+                protocol:
+                    - https
+                    - http
             cloudfront:
                 subdomains:
                     - "{instance}--cdn-journal"


### PR DESCRIPTION
Identical to prod, and removes some headaches for integrating with CDNs in multiple environments: one fewer configuration to deal with