### PR TITLE
ELPP-3393 Lower Fastly healthchecks interval

### DIFF
--- a/projects/elife.yaml
+++ b/projects/elife.yaml
@@ -484,7 +484,7 @@ journal:
                     - "{instance}--fastly-journal"
                 healthcheck:
                     path: /ping-fastly
-                    check-interval: 30000
+                    check-interval: 10000
                     timeout: 2000
                 errors:
                     # always prod for simplicity
@@ -541,7 +541,7 @@ journal:
                     - "{instance}--fastly-journal"
                 healthcheck:
                     path: /ping-fastly
-                    check-interval: 30000
+                    check-interval: 10000
                     timeout: 2000
                 errors:
                     # always prod for simplicity
@@ -612,7 +612,7 @@ journal:
                     - "elifejournal.org"
                 healthcheck:
                     path: /ping-fastly
-                    check-interval: 30000
+                    check-interval: 10000
                     timeout: 2000
                 errors:
                     # always prod for simplicity
@@ -1618,7 +1618,7 @@ iiif:
                 period: 600
             healthcheck:
                 path: /ping-fastly
-                check-interval: 30000
+                check-interval: 10000
                 timeout: 2000
             surrogate-keys:
                 article-id-versioned:

--- a/projects/elife.yaml
+++ b/projects/elife.yaml
@@ -366,7 +366,7 @@ api-gateway:
                 - "{instance}--cdn-gateway"
             healthcheck:
                 path: /ping-fastly
-                check-interval: 30000
+                check-interval: 10000
                 timeout: 2000
             vcl:
                 - "original-host"


### PR DESCRIPTION
Only applying to `api-gateway--end2end` for now, but it seems given the time for the DNS changes to propagate, the CDN should be more responsive to start routing traffic.

https://elifesciences.slack.com/archives/C5VTPCH08/p1528818653000110