### PR TITLE
ELPP-3693 Add resources for EC2 dynamic creation in Jenkins

### DIFF
--- a/projects/elife.yaml
+++ b/projects/elife.yaml
@@ -47,6 +47,8 @@ defaults:
             masterless: false
             # optional: pin a master server for all new instances of a project
             master_ip: 10.0.2.198
+            # optional: specify `ports` to be opened
+            security-group: {}
         region: us-east-1
         vpc-id: vpc-78a2071d  # vpc-id + subnet-id are peculiar to AWS account + region
         subnet-id: subnet-1d4eb46a # elife-public-subnet, us-east-1d

--- a/projects/elife.yaml
+++ b/projects/elife.yaml
@@ -1095,6 +1095,9 @@ containers:
     aws-alt:
         jenkins-plugin-ami:
             ext: false
+            ec2:
+                root:
+                    size: 20 # GB
     vagrant:
         box: ubuntu/trusty64 # Ubuntu 14.04, deprecated
         ram: 1024

--- a/projects/elife.yaml
+++ b/projects/elife.yaml
@@ -1089,6 +1089,7 @@ elife-libraries:
         ram: 1024
 
 containers:
+    description: run any Docker-based workload
     subdomain: containers
     formula-repo: https://github.com/elifesciences/containers-formula
     aws:
@@ -1099,6 +1100,9 @@ containers:
             size: 100 # GB
             type: gp2
     aws-alt:
+        # AMIs created from here used in
+        # https://alfred.elifesciences.org/configure
+        # `Cloud` section
         jenkins-plugin-ami:
             ext: false
             ec2:
@@ -1138,12 +1142,12 @@ elife-alfred:
 # used in https://alfred.elifesciences.org/configure
 # `Cloud` section
 elife-alfred-nodes:
+    description: supports dynamic creation of EC2 instances from Jenkins
     domain: false
     intdomain: false
     aws:
         ec2:
-            cluster-size: 0 # will be created automatically
-                            # by the Jenkins EC2 plugin
+            cluster-size: 0
             security-group:
                 ports:
                     - 22

--- a/projects/elife.yaml
+++ b/projects/elife.yaml
@@ -1104,11 +1104,6 @@ containers:
             ec2:
                 root:
                     size: 20 # GB
-        jenkins-plugin-test:
-            ext: false
-            ec2:
-                root:
-                    size: 20 # GB
     vagrant:
         box: ubuntu/trusty64 # Ubuntu 14.04, deprecated
         ram: 1024

--- a/projects/elife.yaml
+++ b/projects/elife.yaml
@@ -1126,6 +1126,18 @@ elife-alfred:
         ports:
             1433: 80
 
+elife-alfred-nodes:
+    domain: false
+    intdomain: false
+    aws:
+        ec2:
+            cluster-size: 0 # will be created automatically
+            security-group:
+                # preferred to aws.ports for this use case?
+                ports:
+                    - 22
+            
+
 api-dummy:
     subdomain: api-dummy
     repo: https://github.com/elifesciences/api-dummy

--- a/projects/elife.yaml
+++ b/projects/elife.yaml
@@ -1104,6 +1104,11 @@ containers:
             ec2:
                 root:
                     size: 20 # GB
+        jenkins-plugin-test:
+            ext: false
+            ec2:
+                root:
+                    size: 20 # GB
     vagrant:
         box: ubuntu/trusty64 # Ubuntu 14.04, deprecated
         ram: 1024

--- a/projects/elife.yaml
+++ b/projects/elife.yaml
@@ -1140,14 +1140,16 @@ elife-alfred:
         ports:
             1433: 80
 
+# used in https://alfred.elifesciences.org/configure
+# `Cloud` section
 elife-alfred-nodes:
     domain: false
     intdomain: false
     aws:
         ec2:
             cluster-size: 0 # will be created automatically
+                            # by the Jenkins EC2 plugin
             security-group:
-                # preferred to aws.ports for this use case?
                 ports:
                     - 22
             

--- a/projects/elife.yaml
+++ b/projects/elife.yaml
@@ -1093,12 +1093,8 @@ containers:
             size: 100 # GB
             type: gp2
     aws-alt:
-        ckeditor-inline:
-            ports:
-                - 22
-                - 80
-            ext:
-                size: 10
+        jenkins-plugin-ami:
+            ext: false
     vagrant:
         box: ubuntu/trusty64 # Ubuntu 14.04, deprecated
         ram: 1024

--- a/src/buildercore/bootstrap.py
+++ b/src/buildercore/bootstrap.py
@@ -87,6 +87,10 @@ def create_stack(stackname):
 
 @updates('ec2')
 def setup_ec2(stackname, context):
+    if context['ec2']['cluster-size'] == 0:
+        LOG.info('No EC2 instances configured to be provisioned')
+        return
+
     def _setup_ec2_node():
         def is_resourcing():
             try:
@@ -446,7 +450,7 @@ def upload_master_configuration(master_stack, master_configuration_data):
 
 @updates('ec2')
 @core.requires_active_stack
-def update_ec2_stack(stackname, ctx, concurrency=None, formula_revisions=None, **kwargs):
+def update_ec2_stack(stackname, context, concurrency=None, formula_revisions=None, **kwargs):
     """installs/updates the ec2 instance attached to the specified stackname.
 
     Once AWS has finished creating an EC2 instance for us, we need to install
@@ -454,7 +458,7 @@ def update_ec2_stack(stackname, ctx, concurrency=None, formula_revisions=None, *
     script that can be downloaded from the web and then very conveniently
     installs it's own dependencies. Once Salt is installed we give it an ID
     (the given `stackname`), the address of the master server """
-    pdata = ctx['project']
+    pdata = context['project']
     # backward compatibility: old instances may not have 'ec2' key
     # consider it true if missing, as newer stacks e.g. bus--prod
     # would have it explicitly set to False
@@ -469,6 +473,10 @@ def update_ec2_stack(stackname, ctx, concurrency=None, formula_revisions=None, *
     # and refresh their context then remove this check
     if ec2 is True:
         ec2 = default_ec2
+
+    if context['ec2']['cluster-size'] == 0:
+        LOG.info('No EC2 instances configured to be updated')
+        return
 
     region = pdata['aws']['region']
     is_master = core.is_master_server_stack(stackname)

--- a/src/buildercore/bootstrap.py
+++ b/src/buildercore/bootstrap.py
@@ -87,6 +87,7 @@ def create_stack(stackname):
 
 @updates('ec2')
 def setup_ec2(stackname, context):
+    # TODO: I don't think this check is needed, can we create a elife-alfred-nodes stack without it? If so, remove
     if context['ec2']['cluster-size'] == 0:
         LOG.info('No EC2 instances configured to be provisioned')
         return
@@ -474,6 +475,7 @@ def update_ec2_stack(stackname, context, concurrency=None, formula_revisions=Non
     if ec2 is True:
         ec2 = default_ec2
 
+    # TODO: can we fall back to an empty for loop rather than checking this? Test by creating elife-alfred-nodes stacks
     if context['ec2']['cluster-size'] == 0:
         LOG.info('No EC2 instances configured to be updated')
         return

--- a/src/buildercore/bootstrap.py
+++ b/src/buildercore/bootstrap.py
@@ -87,11 +87,6 @@ def create_stack(stackname):
 
 @updates('ec2')
 def setup_ec2(stackname, context):
-    # TODO: I don't think this check is needed, can we create a elife-alfred-nodes stack without it? If so, remove
-    if context['ec2']['cluster-size'] == 0:
-        LOG.info('No EC2 instances configured to be provisioned')
-        return
-
     def _setup_ec2_node():
         def is_resourcing():
             try:
@@ -474,11 +469,6 @@ def update_ec2_stack(stackname, context, concurrency=None, formula_revisions=Non
     # and refresh their context then remove this check
     if ec2 is True:
         ec2 = default_ec2
-
-    # TODO: can we fall back to an empty for loop rather than checking this? Test by creating elife-alfred-nodes stacks
-    if context['ec2']['cluster-size'] == 0:
-        LOG.info('No EC2 instances configured to be updated')
-        return
 
     region = pdata['aws']['region']
     is_master = core.is_master_server_stack(stackname)

--- a/src/buildercore/cfngen.py
+++ b/src/buildercore/cfngen.py
@@ -482,8 +482,7 @@ def template_delta(context):
         if 'Type' in title_in_old:
             if title_in_old['Type'] == 'AWS::EC2::Instance':
                 for property_name in EC2_NOT_UPDATABLE_PROPERTIES:
-                    title_in_old['Properties'][property_name] = None
-                    title_in_new['Properties'][property_name] = None
+                    title_in_new['Properties'][property_name] = title_in_old['Properties'][property_name]
         return title_in_old != title_in_new
 
     def legacy_title(title):

--- a/src/buildercore/core.py
+++ b/src/buildercore/core.py
@@ -298,6 +298,10 @@ def stack_all_ec2_nodes(stackname, workfn, username=config.DEPLOY_USER, concurre
         'nodes': nodes
     })
 
+    if not public_ips:
+        LOG.info("No EC2 nodes to execute on")
+        return
+
     LOG.info("Executing on ec2 nodes (%s), concurrency %s", public_ips, concurrency)
 
     ensure(all(public_ips.values()), "Public ips are not valid: %s" % public_ips, NoPublicIps)
@@ -470,7 +474,7 @@ class NoRunningInstances(Exception):
 # TODO: misleading name, this returns a list of raw boto3 EC2.Instance data
 def stack_data(stackname, ensure_single_instance=False):
     try:
-        ec2_instances = find_ec2_instances(stackname)
+        ec2_instances = find_ec2_instances(stackname, allow_empty=True)
         if len(ec2_instances) > 1 and ensure_single_instance:
             raise RuntimeError("talking to multiple EC2 instances is not supported for this task yet: %r" % stackname)
         return [ec2.meta.data for ec2 in ec2_instances]

--- a/src/buildercore/trop.py
+++ b/src/buildercore/trop.py
@@ -70,6 +70,10 @@ def ingress(port, end_port=None, protocol='tcp', cidr='0.0.0.0/0'):
 def complex_ingress(port, struct):
     if struct == True:
         return ingress(port)
+    if isinstance(struct, int):
+        struct = {
+            'guest': struct,
+        }
     default_end_port = port
     default_cidr_ip = '0.0.0.0/0'
     default_protocol = 'tcp'

--- a/src/buildercore/trop.py
+++ b/src/buildercore/trop.py
@@ -101,7 +101,7 @@ def ec2_security(context):
                     ports_map[p] = True
                 elif isinstance(p, OrderedDict):
                     ensure(len(p) == 1, "Port can only be defined as a single dictionary")
-                    ports_map[p.keys()[0]] = p.values()[0]
+                    ports_map[p.keys()[0]] = list(p.values())[0]
                 else:
                     raise ValueError("Invalid port definition: %s" % p)
             return ports_map

--- a/src/buildercore/trop.py
+++ b/src/buildercore/trop.py
@@ -17,7 +17,7 @@ from .config import ConfigurationError
 from troposphere import GetAtt, Output, Ref, Template, ec2, rds, sns, sqs, Base64, route53, Parameter, Tags
 from troposphere import s3, cloudfront, elasticloadbalancing as elb, elasticache
 from functools import partial
-from .utils import first, ensure, subdict, lmap, isstr
+from .utils import ensure, subdict, lmap, isstr
 import logging
 
 LOG = logging.getLogger(__name__)
@@ -90,7 +90,7 @@ def security_group(group_id, vpc_id, ingress_structs, description=""):
 def ec2_security(context):
     def _convert_to_dictionary(ports):
         if isinstance(ports, list):
-            ports_map = {} 
+            ports_map = {}
             for p in ports:
                 if isinstance(p, int):
                     ports_map[p] = True

--- a/src/buildercore/trop.py
+++ b/src/buildercore/trop.py
@@ -68,7 +68,7 @@ class Ingress():
                         ports_map[p] = {}
                     elif isinstance(p, dict):
                         ensure(len(p) == 1, "Single port definition cannot contain more than one value")
-                        from_port = p.keys()[0]
+                        from_port = list(p.keys())[0]
                         configuration = list(p.values())[0]
                         ports_map[from_port] = configuration
                     else:

--- a/src/buildercore/trop.py
+++ b/src/buildercore/trop.py
@@ -67,6 +67,7 @@ def ingress(port, end_port=None, protocol='tcp', cidr='0.0.0.0/0'):
         'CidrIp': cidr
     })
 
+# TODO: extract a class into another module to deal with all the cases
 def complex_ingress(port, struct):
     if struct == True:
         return ingress(port)
@@ -220,6 +221,7 @@ echo %s > /etc/build-vars.json.b64
 %s""" % (buildvars_serialization, clean_server)),
     }
 
+    # TODO: extract in private method?
     if context['ec2'].get('root'):
         project_ec2['BlockDeviceMappings'] = [{
             'DeviceName': '/dev/sda1',

--- a/src/buildercore/trop.py
+++ b/src/buildercore/trop.py
@@ -91,13 +91,20 @@ def security_group(group_id, vpc_id, ingress_structs, description=""):
     })
 
 def ec2_security(context):
-    ensure('ports' in context['project']['aws'],
-           "Missing `ports` configuration in `aws` for '%s'" % context['stackname'])
+    ports = context['project']['aws'].get('ports', {})
+    security_group_ports = context['ec2']['security-group'].get('ports', {})
+    if isinstance(security_group_ports, list):
+        security_group_ports = {p:True for p in security_group_ports}
+    ports.update(security_group_ports)
+
+    #ports.update(context['ec2']['security-group'].get('ports', {}))
+    ensure(len(ports) > 0,
+           "Empty `ports` configuration in `aws` for '%s'" % context['stackname'])
 
     return security_group(
         SECURITY_GROUP_TITLE,
         context['project']['aws']['vpc-id'],
-        context['project']['aws']['ports']
+        ports
     ) # list of strings or dicts
 
 def rds_security(context):

--- a/src/buildercore/trop.py
+++ b/src/buildercore/trop.py
@@ -85,6 +85,23 @@ def complex_ingress(port, struct):
         'cidr': struct.get('cidr-ip', default_cidr_ip),
     })
 
+class Ingress():
+    @classmethod
+    def build(cls, ports):
+        return Ingress(ports)
+
+    def __init__(self, ports):
+        self._ports = ports
+
+    def to_troposphere(self):
+        return [ec2.SecurityGroupRule(**{
+            'FromPort': port,
+            'ToPort': port,
+            'IpProtocol': 'tcp',
+            'CidrIp': '0.0.0.0/0'
+        }) for port in self._ports]
+
+
 def security_group(group_id, vpc_id, ingress_structs, description=""):
     return ec2.SecurityGroup(group_id, **{
         'GroupDescription': description or 'security group',

--- a/src/buildercore/trop.py
+++ b/src/buildercore/trop.py
@@ -94,13 +94,22 @@ class Ingress():
                 for p in ports:
                     if isinstance(p, int):
                         ports_map[p] = {}
-                    elif isinstance(p, OrderedDict):
-                        ensure(len(p) == 1, "Port can only be defined as a single dictionary")
-                        ports_map[p.keys()[0]] = list(p.values())[0]
                     else:
                         raise ValueError("Invalid port definition: %s" % p)
-                return ports_map
-            return ports
+            elif isinstance(ports, OrderedDict):
+                ports_map = OrderedDict()
+                for p, configuration in ports.items():
+                    if isinstance(configuration, int):
+                        ports_map[p] = {'guest':configuration}
+                    elif isinstance(configuration, OrderedDict):
+                        ports_map[p] = configuration
+                    else:
+                        raise ValueError("Invalid port definition: %s => %s" % (p, configuration))
+            else:
+                raise ValueError("Invalid ports definition: %s" % ports)
+
+            return ports_map
+
         return Ingress(_convert_to_dictionary(ports))
 
     def __init__(self, ports):

--- a/src/buildercore/trop.py
+++ b/src/buildercore/trop.py
@@ -105,9 +105,6 @@ def ec2_security(context):
     security_group_ports = _convert_to_dictionary(context['ec2']['security-group'].get('ports', {}))
     ports.update(security_group_ports)
 
-    ensure(len(ports) > 0,
-           "Empty `ports` configuration in `aws` for '%s'" % context['stackname'])
-
     return security_group(
         SECURITY_GROUP_TITLE,
         context['project']['aws']['vpc-id'],

--- a/src/buildercore/trop.py
+++ b/src/buildercore/trop.py
@@ -218,6 +218,15 @@ echo %s > /etc/build-vars.json.b64
 
 %s""" % (buildvars_serialization, clean_server)),
     }
+
+    if context['ec2'].get('root'):
+        project_ec2['BlockDeviceMappings'] = [{
+            'DeviceName': '/dev/sda1',
+            'Ebs': {
+                'VolumeSize': context['ec2']['root']['size'],
+                'VolumeType': context['ec2']['root'].get('type', 'standard'),
+            }
+        }]
     return ec2.Instance(EC2_TITLE_NODE % node, **project_ec2)
 
 def rdsdbparams(context, template):

--- a/src/buildercore/trop.py
+++ b/src/buildercore/trop.py
@@ -96,11 +96,14 @@ class Ingress():
                         ports_map[p] = {}
                     else:
                         raise ValueError("Invalid port definition: %s" % p)
-            elif isinstance(ports, OrderedDict):
+            elif isinstance(ports, dict):
                 ports_map = OrderedDict()
                 for p, configuration in ports.items():
-                    if isinstance(configuration, int):
-                        ports_map[p] = {'guest':configuration}
+                    if isinstance(configuration, bool):
+                        # temporary
+                        ports_map[p] = {}
+                    elif isinstance(configuration, int):
+                        ports_map[p] = {'guest': configuration}
                     elif isinstance(configuration, OrderedDict):
                         ports_map[p] = configuration
                     else:
@@ -125,10 +128,13 @@ class Ingress():
 
 
 def security_group(group_id, vpc_id, ingress_structs, description=""):
+    if not isinstance(ingress_structs, Ingress):
+        ingress_structs = Ingress.build(ingress_structs)
     return ec2.SecurityGroup(group_id, **{
         'GroupDescription': description or 'security group',
         'VpcId': vpc_id,
-        'SecurityGroupIngress': [complex_ingress(port, definition) for port, definition in ingress_structs.items()],
+        #'SecurityGroupIngress': [complex_ingress(port, definition) for port, definition in ingress_structs.items()],
+        'SecurityGroupIngress': ingress_structs.to_troposphere(),
     })
 
 def ec2_security(context):

--- a/src/integration_tests/test_validation.py
+++ b/src/integration_tests/test_validation.py
@@ -1,6 +1,6 @@
 import pytest
 from tests import base
-from buildercore import cfngen, project
+from buildercore import cfngen
 import logging
 LOG = logging.getLogger(__name__)
 
@@ -8,11 +8,15 @@ logging.disable(logging.NOTSET) # re-enables logging during integration testing
 
 # Depends on talking to AWS.
 
-class TestValidationFixtures(base.BaseCase):
-    def test_validation(self):
+class TestValidationFixtures():
+    @classmethod
+    def setup_class(cls):
+        base.switch_in_test_settings()
+
+    @pytest.mark.parametrize("project_name", base.test_projects())
+    def test_validation(self, project_name):
         "dummy projects and their alternative configurations pass validation"
-        for pname in project.aws_projects().keys():
-            cfngen.validate_project(pname)
+        cfngen.validate_project(project_name)
 
 class TestValidationElife():
     @classmethod
@@ -25,7 +29,7 @@ class TestValidationElife():
     def teardown_class(cls):
         base.switch_in_test_settings()
 
-    @pytest.mark.parametrize("project_name", project.aws_projects().keys())
+    @pytest.mark.parametrize("project_name", base.elife_projects())
     def test_validation_elife_projects(self, project_name, filter_project_name):
         "elife projects (and their alternative configurations) that come with the builder pass validation"
         if filter_project_name:

--- a/src/tests/base.py
+++ b/src/tests/base.py
@@ -31,6 +31,9 @@ def switch_out_test_settings():
     project.project_map.cache_clear()
     imp.reload(config)
 
+def test_projects():
+    switch_in_test_settings()
+    return project.aws_projects().keys()
 
 class BaseCase(TestCase):
     maxDiff = None

--- a/src/tests/base.py
+++ b/src/tests/base.py
@@ -35,6 +35,10 @@ def test_projects():
     switch_in_test_settings()
     return project.aws_projects().keys()
 
+def elife_projects():
+    switch_out_test_settings()
+    return project.aws_projects().keys()
+
 class BaseCase(TestCase):
     maxDiff = None
 

--- a/src/tests/fixtures/dummy1-project.json
+++ b/src/tests/fixtures/dummy1-project.json
@@ -17,6 +17,7 @@
             "dns-internal": false, 
             "suppressed": [], 
             "overrides": {}, 
+            "security-group": {},
             "ami": "ami-9eaa1cf6",
             "master_ip": "10.0.2.42"
         }, 

--- a/src/tests/fixtures/dummy2-project.json
+++ b/src/tests/fixtures/dummy2-project.json
@@ -17,6 +17,7 @@
             "dns-internal": false, 
             "suppressed": [], 
             "overrides": {}, 
+            "security-group": {},
             "ami": "ami-111111",
             "master_ip": "10.0.2.42"
         }, 
@@ -67,6 +68,7 @@
                 "dns-internal": false, 
                 "suppressed": [], 
                 "overrides": {}, 
+                "security-group": {},
                 "ami": "ami-9eaa1cf6",
                 "master_ip": "10.0.2.42"
             }, 
@@ -117,6 +119,7 @@
                 "dns-internal": false, 
                 "suppressed": [], 
                 "overrides": {}, 
+                "security-group": {},
                 "ami": "ami-22222",
                 "master_ip": "10.0.2.42"
             }, 

--- a/src/tests/fixtures/dummy3-project.json
+++ b/src/tests/fixtures/dummy3-project.json
@@ -17,6 +17,7 @@
             "dns-internal": false, 
             "suppressed": [], 
             "overrides": {}, 
+            "security-group": {},
             "ami": "ami-111111",
             "master_ip": "10.0.2.42"
         }, 
@@ -45,6 +46,7 @@
                 "dns-internal": false, 
                 "suppressed": [], 
                 "overrides": {}, 
+                "security-group": {},
                 "ami": "ami-9eaa1cf6",
                 "master_ip": "10.0.2.42"
             }, 
@@ -73,6 +75,7 @@
                 "dns-internal": false, 
                 "suppressed": [], 
                 "overrides": {}, 
+                "security-group": {},
                 "ami": "ami-111111",
                 "master_ip": "10.0.2.42"
             }, 
@@ -118,6 +121,7 @@
                 "dns-internal": false, 
                 "suppressed": [], 
                 "overrides": {}, 
+                "security-group": {},
                 "ami": "ami-111111",
                 "master_ip": "10.0.2.42"
             }, 

--- a/src/tests/fixtures/projects/dummy-project.yaml
+++ b/src/tests/fixtures/projects/dummy-project.yaml
@@ -31,6 +31,7 @@ defaults:
             # find more here: http://cloud-images.ubuntu.com/releases/
             ami: ami-9eaa1cf6  # Ubuntu 14.04
             master_ip: 10.0.2.42
+            security-group: {}
         type: t2.small
         region: us-east-1
         vpc-id: vpc-78a2071d  # vpc-id + subnet-id are peculiar to AWS account + region

--- a/src/tests/fixtures/projects/dummy-project.yaml
+++ b/src/tests/fixtures/projects/dummy-project.yaml
@@ -378,6 +378,13 @@ project-with-fastly-gcs:
                 bucket: my-bucket
                 path: my-project/
                 period: 1800
+                    
+project-with-ec2-custom-root:
+    repo: ssh://git@github.com/elifesciences/dummy3
+    aws:
+        ec2:
+            root:
+                size: 20 # GB
 
 project-with-cluster:
     repo: ssh://git@github.com/elifesciences/dummy3

--- a/src/tests/fixtures/projects/dummy-project.yaml
+++ b/src/tests/fixtures/projects/dummy-project.yaml
@@ -428,6 +428,17 @@ project-with-cluster-overrides:
         elb: 
             protocol: http
 
+project-with-cluster-empty:
+    repo: ssh://git@github.com/elifesciences/dummy3
+    subdomain: project-with-cluster
+    intdomain: false
+    aws:
+        ec2:
+            cluster-size: 0
+            security-group:
+                ports:
+                    - 22
+
 project-with-stickiness:
     repo: ssh://git@github.com/elifesciences/dummy3
     subdomain: project-with-cluster

--- a/src/tests/fixtures/projects/dummy-project2.yaml
+++ b/src/tests/fixtures/projects/dummy-project2.yaml
@@ -26,6 +26,7 @@ defaults:
             # find more here: http://cloud-images.ubuntu.com/releases/
             ami: ami-9eaa1cf6  # Ubuntu 14.04
             master_ip: 192.168.1.254
+            security-group: {}
         type: t2.small
         region: us-east-1
         vpc-id: vpc-0a0a0a0a  # vpc-id + subnet-id are peculiar to AWS account + region

--- a/src/tests/test_buildercore_cfngen.py
+++ b/src/tests/test_buildercore_cfngen.py
@@ -1,14 +1,16 @@
+import pytest
 from . import base
 from buildercore import core, cfngen, project, context_handler, cloudformation
 
 import logging
 LOG = logging.getLogger(__name__)
 
-class TestBuildercoreCfngen(base.BaseCase):
-    def test_rendering(self):
-        for pname in project.aws_projects().keys():
-            LOG.info('rendering %s', pname)
-            cfngen.quick_render(pname)
+class TestBuildercoreCfngen():
+    # note: this requires pytest, but provides great introspection
+    # on which project_name is failing
+    @pytest.mark.parametrize("project_name", project.aws_projects().keys())
+    def test_quick_rendering(self, project_name):
+        cfngen.quick_render(project_name)
 
 class TestBuildContext(base.BaseCase):
     def test_existing_alt_config(self):

--- a/src/tests/test_buildercore_cfngen.py
+++ b/src/tests/test_buildercore_cfngen.py
@@ -1,6 +1,6 @@
 import pytest
 from . import base
-from buildercore import core, cfngen, project, context_handler, cloudformation
+from buildercore import core, cfngen, context_handler, cloudformation
 
 import logging
 LOG = logging.getLogger(__name__)

--- a/src/tests/test_buildercore_cfngen.py
+++ b/src/tests/test_buildercore_cfngen.py
@@ -8,7 +8,7 @@ LOG = logging.getLogger(__name__)
 class TestBuildercoreCfngen():
     # note: this requires pytest, but provides great introspection
     # on which project_name is failing
-    @pytest.mark.parametrize("project_name", project.aws_projects().keys())
+    @pytest.mark.parametrize("project_name", base.test_projects())
     def test_quick_rendering(self, project_name):
         cfngen.quick_render(project_name)
 

--- a/src/tests/test_buildercore_fastly.py
+++ b/src/tests/test_buildercore_fastly.py
@@ -1,4 +1,4 @@
-from buildercore.terraform import fastly
+from buildercore import fastly
 from . import base
 
 class TestFastlyCustomVCL(base.BaseCase):

--- a/src/tests/test_buildercore_project.py
+++ b/src/tests/test_buildercore_project.py
@@ -10,7 +10,9 @@ ALL_PROJECTS = [
     'just-some-sns', 'project-with-sqs', 'project-with-s3',
     'project-with-ext', 'project-with-cloudfront', 'project-with-cloudfront-minimal',
     'project-with-cloudfront-error-pages', 'project-with-cloudfront-origins', 'project-with-fastly-minimal', 'project-with-fastly-complex', 'project-with-fastly-gcs',
-    'project-with-cluster', 'project-with-cluster-suppressed', 'project-with-cluster-overrides', 'project-with-stickiness', 'project-with-multiple-elb-listeners',
+    'project-with-ec2-custom-root',
+    'project-with-cluster', 'project-with-cluster-suppressed', 'project-with-cluster-overrides', 'project-with-cluster-empty',
+    'project-with-stickiness', 'project-with-multiple-elb-listeners',
     'project-with-cluster-integration-tests', 'project-with-db-params', 'project-with-rds-only', 'project-with-elasticache-redis', 'project-with-multiple-elasticaches', 'project-with-fully-overridden-elasticaches',
     'project-on-gcp',
 ]

--- a/src/tests/test_buildercore_trop.py
+++ b/src/tests/test_buildercore_trop.py
@@ -1,3 +1,4 @@
+from collections import OrderedDict
 import json  # , yaml
 import os
 from os.path import join
@@ -1158,6 +1159,36 @@ class TestIngress(base.BaseCase):
                     'FromPort': 80,
                     'CidrIp': '0.0.0.0/0',
                     'IpProtocol': 'tcp',
+                },
+            ]
+        )
+
+    def test_accepts_ports_defining_custom_rules(self):
+        simple_ingress = trop.Ingress.build(OrderedDict([
+            (80, OrderedDict([
+                ('guest', 8080),
+                ('cidr-ip', '10.0.0.0/0'),
+            ])),
+            (10000, OrderedDict([
+                ('guest', 10000),
+                ('protocol', 'udp'),
+                ('cidr-ip', '0.0.0.0/0'),
+            ]))
+        ]))
+        self.assertEqual(
+            self._dump_to_list_of_rules(simple_ingress),
+            [
+                {
+                    'ToPort': 8080,
+                    'FromPort': 80,
+                    'CidrIp': '10.0.0.0/0',
+                    'IpProtocol': 'tcp',
+                },
+                {
+                    'ToPort': 10000,
+                    'FromPort': 10000,
+                    'CidrIp': '0.0.0.0/0',
+                    'IpProtocol': 'udp',
                 },
             ]
         )

--- a/src/tests/test_buildercore_trop.py
+++ b/src/tests/test_buildercore_trop.py
@@ -337,7 +337,7 @@ class TestBuildercoreTrop(base.BaseCase):
         cfn_template = trop.render(context)
         data = self._parse_json(cfn_template)
         resources = data['Resources']
-        self.assertEqual(resources.keys(), ['StackSecurityGroup'])
+        self.assertEqual(list(resources.keys()), ['StackSecurityGroup'])
         security_group = resources['StackSecurityGroup']['Properties']
         self.assertEqual(
             security_group,

--- a/src/tests/test_buildercore_trop.py
+++ b/src/tests/test_buildercore_trop.py
@@ -137,6 +137,27 @@ class TestBuildercoreTrop(base.BaseCase):
             data['Resources']['MountPoint1']['Properties']
         )
 
+    def test_root_volume_size_template(self):
+        extra = {
+            'stackname': 'project-with-ec2-custom-root--prod',
+        }
+        context = cfngen.build_context('project-with-ec2-custom-root', **extra)
+        cfn_template = trop.render(context)
+        data = self._parse_json(cfn_template)
+        ec2 = data['Resources']['EC2Instance1']['Properties']
+        self.assertIn('BlockDeviceMappings', ec2)
+        self.assertEqual(
+            ec2['BlockDeviceMappings'],
+            [
+                {
+                    'DeviceName': '/dev/sda1',
+                    'Ebs': {
+                        'VolumeSize': 20,
+                    },
+                },
+            ]
+        )
+
     def test_clustered_template(self):
         extra = {
             'stackname': 'project-with-cluster--prod',

--- a/src/tests/test_buildercore_trop.py
+++ b/src/tests/test_buildercore_trop.py
@@ -1140,3 +1140,29 @@ class TestBuildercoreTrop(base.BaseCase):
         data = self._parse_json(trop.render(context))
         self.assertEqual(context['rds']['deletion-policy'], "Delete")
         self.assertEqual(data['Resources']['AttachedDB']['DeletionPolicy'], 'Delete')
+
+class TestIngress(base.BaseCase):
+    def test_accepts_a_list_of_ports(self):
+        simple_ingress = trop.Ingress.build([22, 80])
+        self.assertEqual(
+            self._dump_to_list_of_rules(simple_ingress),
+            [
+                {
+                    'ToPort': 22,
+                    'FromPort': 22,
+                    'CidrIp': '0.0.0.0/0',
+                    'IpProtocol': 'tcp',
+                },
+                {
+                    'ToPort': 80,
+                    'FromPort': 80,
+                    'CidrIp': '0.0.0.0/0',
+                    'IpProtocol': 'tcp',
+                },
+            ]
+        )
+
+    def _dump_to_list_of_rules(self, ingress):
+        return [r.to_dict() for r in ingress.to_troposphere()]
+
+

--- a/src/tests/test_buildercore_trop.py
+++ b/src/tests/test_buildercore_trop.py
@@ -153,6 +153,7 @@ class TestBuildercoreTrop(base.BaseCase):
                     'DeviceName': '/dev/sda1',
                     'Ebs': {
                         'VolumeSize': 20,
+                        'VolumeType': 'standard',
                     },
                 },
             ]

--- a/src/tests/test_buildercore_trop.py
+++ b/src/tests/test_buildercore_trop.py
@@ -306,6 +306,35 @@ class TestBuildercoreTrop(base.BaseCase):
             ]
         )
 
+    def test_clustered_template_empty(self):
+        extra = {
+            'stackname': 'project-with-cluster-empty--prod',
+        }
+        context = cfngen.build_context('project-with-cluster-empty', **extra)
+        cfn_template = trop.render(context)
+        data = self._parse_json(cfn_template)
+        #resources = data['Resources']
+        #self.assertNotIn('EC2Instance1', list(resources.keys()))
+        #self.assertIn('EC2Instance2', list(resources.keys()))
+        #self.assertIn('EC2Instance3', list(resources.keys()))
+        #self.assertNotIn('ExtraStorage1', list(resources.keys()))
+        #self.assertIn('ExtraStorage2', list(resources.keys()))
+        #self.assertIn('ExtraStorage3', list(resources.keys()))
+
+        #self.assertIn('ElasticLoadBalancer', list(resources.keys()))
+        #elb = resources['ElasticLoadBalancer']['Properties']
+        #self.assertEqual(
+        #    elb['Instances'],
+        #    [
+        #        {
+        #            'Ref': 'EC2Instance2',
+        #        },
+        #        {
+        #            'Ref': 'EC2Instance3',
+        #        }
+        #    ]
+        #)
+
     def test_clustered_template_with_node_overrides(self):
         extra = {
             'stackname': 'project-with-cluster-overrides--prod',

--- a/src/tests/test_buildercore_trop.py
+++ b/src/tests/test_buildercore_trop.py
@@ -313,27 +313,22 @@ class TestBuildercoreTrop(base.BaseCase):
         context = cfngen.build_context('project-with-cluster-empty', **extra)
         cfn_template = trop.render(context)
         data = self._parse_json(cfn_template)
-        #resources = data['Resources']
-        #self.assertNotIn('EC2Instance1', list(resources.keys()))
-        #self.assertIn('EC2Instance2', list(resources.keys()))
-        #self.assertIn('EC2Instance3', list(resources.keys()))
-        #self.assertNotIn('ExtraStorage1', list(resources.keys()))
-        #self.assertIn('ExtraStorage2', list(resources.keys()))
-        #self.assertIn('ExtraStorage3', list(resources.keys()))
-
-        #self.assertIn('ElasticLoadBalancer', list(resources.keys()))
-        #elb = resources['ElasticLoadBalancer']['Properties']
-        #self.assertEqual(
-        #    elb['Instances'],
-        #    [
-        #        {
-        #            'Ref': 'EC2Instance2',
-        #        },
-        #        {
-        #            'Ref': 'EC2Instance3',
-        #        }
-        #    ]
-        #)
+        resources = data['Resources']
+        self.assertEqual(resources.keys(), ['StackSecurityGroup'])
+        security_group = resources['StackSecurityGroup']['Properties']
+        self.assertEqual(
+            security_group,
+            {
+                'GroupDescription': 'security group',
+                'SecurityGroupIngress': [{
+                    'CidrIp': '0.0.0.0/0',
+                    'FromPort': 22,
+                    'ToPort': 22,
+                    'IpProtocol': 'tcp',
+                }],
+                'VpcId': 'vpc-78a2071d',
+            }
+        )
 
     def test_clustered_template_with_node_overrides(self):
         extra = {

--- a/src/tests/test_buildercore_trop.py
+++ b/src/tests/test_buildercore_trop.py
@@ -1163,6 +1163,22 @@ class TestIngress(base.BaseCase):
             ]
         )
 
+    def test_accepts_remapped_ports(self):
+        simple_ingress = trop.Ingress.build(OrderedDict([
+            (80, 8080),
+        ]))
+        self.assertEqual(
+            self._dump_to_list_of_rules(simple_ingress),
+            [
+                {
+                    'ToPort': 8080,
+                    'FromPort': 80,
+                    'CidrIp': '0.0.0.0/0',
+                    'IpProtocol': 'tcp',
+                },
+            ]
+        )
+
     def test_accepts_ports_defining_custom_rules(self):
         simple_ingress = trop.Ingress.build(OrderedDict([
             (80, OrderedDict([


### PR DESCRIPTION
EC2 instances dynamically created by Jenkins shouldn't be snowflakes, so these projects capture them with configuration as code.

## Features

- specify `ports` inside `aws.ec2.security-group`, continuing to push EC2-related configuration inside the `ec2` section but functionally equivalent to the existing `aws.ports`
- specify a custom size for the `/` root volume, as `aws.ec2.root.size` (possibly also `aws.ec2.root.type` in the future, same structure as `aws.ext`)

## `elife-alfred-nodes`

This project is an empty EC2 clusters, providing a security group which the instances created by Jenkins will use. Implicitly it also provides other inherited configuration to Jenkins: the VPC and the subnet the instances should be attached to.

## `containers--...`

This is the first kind of Jenkins node that can be dynamically created. Pretty much any container-related build can run on this node. The original stack is only needed to create an AMI, Jenkins than instantiates the AMI.