### PR TITLE
Cleanup buckets after elife-alfred-formula builds

### DIFF
--- a/projects/elife.yaml
+++ b/projects/elife.yaml
@@ -1112,6 +1112,10 @@ elife-alfred:
             "{instance}-elife-alfred":
                 deletion-policy: retain
     aws-alt:
+        standalone:
+            s3:
+                "{instance}-elife-alfred":
+                    deletion-policy: delete
         prod:
             subdomains:
                 - alfred


### PR DESCRIPTION
They should be retained for the production environment, but not for throwaway masterless stacks