### PR TITLE
ELPP-3693 Use tasks.create_ami from Jenkins

### DIFF
--- a/scripts/clean-stack-for-ami.sh
+++ b/scripts/clean-stack-for-ami.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-# runs as ROOT on ALL AWS MINIONS directly after stack creation and before AMI 
+# runs as ROOT before AMI creation
 # creation
 
 set -e # everything must pass
@@ -7,12 +7,11 @@ set -u # no unbound variables
 set -xv  # output the scripts and interpolated steps
 
 if command -v salt-minion > /dev/null; then
-    # salt is installed, probably using an AMI or creating an AMI
-    # https://docs.saltstack.com/en/latest/ref/modules/all/salt.modules.saltutil.html#salt.modules.saltutil.clear_cache
+    # salt is installed
     systemctl stop salt-minion 2> /dev/null || service salt-minion stop
 fi
 
-# remove leftover files from AMIs
+# remove credentials and stack-specific files
 rm -rf \
     /etc/cfn-info.json \
     /etc/salt/pki/minion/* \
@@ -23,3 +22,7 @@ rm -rf \
     /etc/certificates/* \
     /root/events.log \
     /var/cache/salt/minion
+
+# commit memory buffers to disk to avoid partly written files
+# since AMIs are essentially snapshots of the root volume
+sync

--- a/src/buildercore/bakery.py
+++ b/src/buildercore/bakery.py
@@ -10,13 +10,13 @@ def ami_name(stackname):
     return "%s.%s" % (core.project_name_from_stackname(stackname), utils.ymd())
 
 @core.requires_active_stack
-def create_ami(stackname):
+def create_ami(stackname, name=None):
     "creates an AMI from the running stack"
     with core.stack_conn(stackname, username=config.BOOTSTRAP_USER):
         bootstrap.prep_ec2_instance()
     ec2 = core.find_ec2_instances(stackname)[0]
     kwargs = {
-        'Name': ami_name(stackname),
+        'Name': ami_name(stackname) if name is None else name,
         'NoReboot': True,
         #'DryRun': True
     }

--- a/src/buildercore/bakery.py
+++ b/src/buildercore/bakery.py
@@ -23,5 +23,8 @@ def create_ami(stackname, name=None):
     # http://boto3.readthedocs.io/en/latest/reference/services/ec2.html#EC2.Instance.create_image
     ami = ec2.create_image(**kwargs)
     # http://boto3.readthedocs.io/en/latest/reference/services/ec2.html#EC2.Image
-    ami.wait_until_exists()
+    ami.wait_until_exists(Filters=[{
+        'Name': 'state',
+        'Values': ['available'],
+    }])
     return str(ami.id) # this should be used to update the stack templates

--- a/src/buildercore/bakery.py
+++ b/src/buildercore/bakery.py
@@ -16,7 +16,7 @@ def create_ami(stackname, name=None):
         bootstrap.clean_stack_for_ami()
     ec2 = core.find_ec2_instances(stackname)[0]
     kwargs = {
-        'Name': ami_name(stackname) if name is None else name,
+        'Name': name or ami_name(stackname),
         'NoReboot': True,
         #'DryRun': True
     }

--- a/src/buildercore/bakery.py
+++ b/src/buildercore/bakery.py
@@ -13,7 +13,7 @@ def ami_name(stackname):
 def create_ami(stackname, name=None):
     "creates an AMI from the running stack"
     with core.stack_conn(stackname, username=config.BOOTSTRAP_USER):
-        bootstrap.prep_ec2_instance()
+        bootstrap.clean_stack_for_ami()
     ec2 = core.find_ec2_instances(stackname)[0]
     kwargs = {
         'Name': ami_name(stackname) if name is None else name,

--- a/src/buildercore/bootstrap.py
+++ b/src/buildercore/bootstrap.py
@@ -59,9 +59,8 @@ def run_script(script_filename, *script_params, **environment_variables):
     LOG.info("Executed script %s in %2.4f seconds", script_filename, (end - start).total_seconds())
     return retval
 
-def prep_ec2_instance():
-    """called after stack creation and before AMI creation"""
-    return run_script("prep-stack.sh")
+def clean_stack_for_ami():
+    return run_script("clean-stack-for-ami.sh")
 
 
 #

--- a/src/buildercore/config.py
+++ b/src/buildercore/config.py
@@ -106,6 +106,7 @@ logging.getLogger('paramiko.transport').setLevel(logging.ERROR)
 # like ec2 instance keypairs
 BUILDER_BUCKET = 'elife-builder'
 BUILDER_REGION = 'us-east-1'
+BUILDER_NON_INTERACTIVE = 'BUILDER_NON_INTERACTIVE' in os.environ and os.environ['BUILDER_NON_INTERACTIVE']
 KEYPAIR_PREFIX = 'keypairs/'
 CONTEXT_PREFIX = 'contexts/'
 

--- a/src/buildercore/trop.py
+++ b/src/buildercore/trop.py
@@ -187,7 +187,7 @@ def ec2instance(context, node):
     else:
         subnet_id = lu('project.aws.redundant-subnet-id')
 
-    clean_server = _read_script('.clean-server.sh.fragment') # this file duplicates scripts/prep-stack.sh
+    clean_server = _read_script('.clean-server.sh.fragment')
     project_ec2 = {
         "ImageId": lu('project.aws.ec2.ami'),
         "InstanceType": context['ec2']['type'], # t2.small, m1.medium, etc

--- a/src/tasks.py
+++ b/src/tasks.py
@@ -19,7 +19,6 @@ def create_ami(stackname, name=None):
     confirm(msg)
 
     amiid = bakery.create_ami(stackname, name)
-    errcho('AWS has created AMI with id:')
     print(amiid)
     errcho('update project file with new ami %s. these changes must be merged and committed manually' % amiid)
 

--- a/src/tasks.py
+++ b/src/tasks.py
@@ -5,7 +5,7 @@ better off in their own module. This module really is for stuff
 that has no home."""
 from buildercore import core, bootstrap
 from fabric.api import local, task
-from fabric.contrib.console import confirm
+from utils import confirm, errcho
 from decorators import requires_aws_stack, debugtask
 from buildercore import bakery
 from buildercore.core import stack_conn
@@ -13,15 +13,15 @@ from buildercore.context_handler import load_context
 
 @task
 @requires_aws_stack
-def create_ami(stackname):
+def create_ami(stackname, name=None):
     pname = core.project_name_from_stackname(stackname)
-    msg = "this will create a new AMI for the project %r. Continue?" % pname
-    if not confirm(msg, default=False):
-        print('doing nothing')
-        return
-    amiid = bakery.create_ami(stackname)
-    print('AWS has created AMI with id', amiid)
-    print('update project file with new ami %s. these changes must be merged and committed manually' % amiid)
+    msg = "this will create a new AMI for the project %r" % pname
+    confirm(msg)
+
+    amiid = bakery.create_ami(stackname, name)
+    errcho('AWS has created AMI with id:')
+    print(amiid)
+    errcho('update project file with new ami %s. these changes must be merged and committed manually' % amiid)
 
 #
 #

--- a/src/utils.py
+++ b/src/utils.py
@@ -94,8 +94,8 @@ def uin(param, default=0xDEADBEEF):
 
 
 def confirm(message):
-    print(message)
-    print('press Enter to confirm (ctrl-c to quit)')
+    errcho(message)
+    errcho('press Enter to confirm (ctrl-c to quit)')
     get_input('')
 
 def walk_nested_struct(val, fn):

--- a/src/utils.py
+++ b/src/utils.py
@@ -1,8 +1,11 @@
+import logging
 import os, sys
 from buildercore import config
 from buildercore.utils import second, last, gtpy2
 from fabric.api import local
 from buildercore import core
+
+LOG = logging.getLogger(__name__)
 
 # totally is assigned :(
 # pylint: disable=global-variable-not-assigned
@@ -96,7 +99,7 @@ def uin(param, default=0xDEADBEEF):
 
 def confirm(message):
     if config.BUILDER_NON_INTERACTIVE:
-        errcho('Non-interactive mode, confirming automatically')
+        LOG.info('Non-interactive mode, confirming automatically')
         return
 
     errcho(message)

--- a/src/utils.py
+++ b/src/utils.py
@@ -1,4 +1,5 @@
 import os, sys
+from buildercore import config
 from buildercore.utils import second, last, gtpy2
 from fabric.api import local
 from buildercore import core
@@ -94,6 +95,10 @@ def uin(param, default=0xDEADBEEF):
 
 
 def confirm(message):
+    if config.BUILDER_NON_INTERACTIVE:
+        errcho('Non-interactive mode, confirming automatically')
+        return
+
     errcho(message)
     errcho('press Enter to confirm (ctrl-c to quit)')
     get_input('')


### PR DESCRIPTION
Minimal extensions to make the task usable from an automated build that updates the AMI for the `containers` stack:

- fixes a bug with uncommitted files that are sometimes lost in the AMI
- put AMI ID output on a single line
- put most of the messages on stderr
- allow non-interactive confirmation through environment variable
- wait until AMI is `available`, it may be `pending` for a while
- allow a custom name to avoid clashes on `containers.2018-06-20` when running a build more than once in a day