### PR TITLE
ELPP-3693 Remove upload of owner private key

### DIFF
--- a/src/buildercore/bootstrap.py
+++ b/src/buildercore/bootstrap.py
@@ -478,13 +478,6 @@ def update_ec2_stack(stackname, context, concurrency=None, formula_revisions=Non
         master_builder_key = download_master_builder_key(stackname)
 
     def _update_ec2_node():
-        # upload private key if not present remotely
-        if not files.exists("/root/.ssh/id_rsa", use_sudo=True):
-            # if it also doesn't exist on the filesystem, die horribly.
-            # regular updates shouldn't have to deal with this.
-            pem = stack_pem(stackname, die_if_doesnt_exist=True)
-            fab_put(pem, "/root/.ssh/id_rsa", use_sudo=True)
-
         # write out environment config (/etc/cfn-info.json) so Salt can read CFN outputs
         write_environment_info(stackname, overwrite=True)
 

--- a/src/buildercore/bootstrap.py
+++ b/src/buildercore/bootstrap.py
@@ -10,7 +10,7 @@ from collections import OrderedDict
 from datetime import datetime
 from . import utils, config, bvars, core, context_handler, project, cloudformation, terraform, sns as snsmod
 from .context_handler import only_if as updates
-from .core import stack_pem, stack_all_ec2_nodes, project_data_for_stackname, stack_conn
+from .core import stack_all_ec2_nodes, project_data_for_stackname, stack_conn
 from .utils import first, ensure, subdict, yaml_dumps, lmap, fab_get, fab_put, fab_put_data
 from .lifecycle import delete_dns
 from .config import BOOTSTRAP_USER


### PR DESCRIPTION
This step in the update seems to put the generated keypair from the CloudFormation stack onto the EC2 instances. I do not know what it would be needed for, this goes back to:
https://github.com/elifesciences/builder/commit/c6eec81ec5b33cd1f7b33a7034cb9cddec908d6d#diff-bfa1d9cba2806d6d2d41031884d3e00eR305

Jenkins is failing when running  on a stack previously used to create an AMI, as the sensitive keys get removed.

I also tested the creation of a master server, which this seemed to relate to, which gets to the

```
[54.204.100.30] out: if this repository resides on github, we suggest
creating a 'deploy key' by pasting in the public key below:
[54.204.100.30] out:
[54.204.100.30] out:     ssh-rsa
AAAAB3NzaC1yc2EAAAADAQABAAABAQD718U10gGM9H1scPE0vrRjr8ULeWNb8csVxysXoKPyxLdm6vTMtrSNgHEQ34gmIne+BbIlketckg1fPXTf6tYL+30tDfRycEYVW06zjTwrj51EgihiDbQO3j1dH5tcOdi5eaRVhZNN8YTanOvh6cr1oEBgkOMbrvXuPlCV9RlYsJR7rqEwwmjJfGJSiRWB6ispEOzEbwAtP8fE0DsHdJJQTsaz63H2Vlr3IiZq6+RwGNomLBVCiNR/FXlVP8fJ6Yylbf+EU8d/5Q4zLh49OOIeQzBYvd2+UwfZOS4DXkFjIUeScruFycD3VIhiNMESRKEkqS32D6v+SVtCOvACgpe1
root@ip-10-0-2-101
[54.204.100.30] out:
[54.204.100.30] out: which you can retrieve with:
[54.204.100.30] out:
[54.204.100.30] out:     ./bldr
download_file:master-server--test,/root/.ssh/id_rsa.pub,/tmp,use_bootstrap_user=True
...
```

without issues. It creates its own `id_rsa` and `id_rsa.pub` anyway.

So my suggestion is to remove this part, making `update` more reliable.