### PR TITLE
Make X-Forwarded-Host compatible with Fastly shielding

### DIFF
--- a/src/buildercore/fastly/vcl/original-host.vcl
+++ b/src/buildercore/fastly/vcl/original-host.vcl
@@ -1,1 +1,3 @@
-set req.http.X-Forwarded-Host = req.http.host;
+if (!req.http.Fastly-FF) {
+  set req.http.X-Forwarded-Host = req.http.host;
+}


### PR DESCRIPTION
Untested, but I think enabling shielding would set `X-Forwarded-Host` to be the shield's host header (since the VCL is executed on the edge and again on the shield).