### PR TITLE
Fastly PASS for uncacheable Journal content

### DIFF
--- a/projects/elife.yaml
+++ b/projects/elife.yaml
@@ -494,6 +494,7 @@ journal:
                         503: "503.html"
                 vcl:
                     - "original-host"
+                    - "ping-status"
                     - "strip-non-journal-cookies"
                 gcslogging:
                     bucket: "{instance}-elife-fastly"
@@ -548,6 +549,7 @@ journal:
                         503: "503.html"
                 vcl:
                     - "original-host"
+                    - "ping-status"
                     - "strip-non-journal-cookies"
                 gcslogging:
                     bucket: "{instance}-elife-fastly"
@@ -618,6 +620,7 @@ journal:
                         503: "503.html"
                 vcl:
                     - "original-host"
+                    - "ping-status"
                     - "strip-non-journal-cookies"
                 gcslogging:
                     bucket: "{instance}-elife-fastly"

--- a/src/buildercore/fastly.py
+++ b/src/buildercore/fastly.py
@@ -104,6 +104,12 @@ VCL_SNIPPETS = {
         type='recv',
         hook='after'
     ),
+    'ping-status': FastlyVCLSnippet(
+        name='ping-status',
+        content=_read_vcl_file('ping-status.vcl'),
+        type='recv',
+        hook='after'
+    ),
     'strip-non-journal-cookies': FastlyVCLSnippet(
         name='strip-non-journal-cookies',
         content=_read_vcl_file('strip-non-journal-cookies.vcl'),

--- a/src/buildercore/fastly/vcl/ping-status.vcl
+++ b/src/buildercore/fastly/vcl/ping-status.vcl
@@ -1,0 +1,3 @@
+if (req.url.path == "/ping" || req.url.path == "/status") {
+    return(pass);
+}

--- a/src/buildercore/fastly/vcl/strip-non-journal-cookies.vcl
+++ b/src/buildercore/fastly/vcl/strip-non-journal-cookies.vcl
@@ -1,7 +1,8 @@
 declare local var.journal_cookie STRING;
 set var.journal_cookie = req.http.Cookie:journal;
-if (var.journal_cookie != "") {
+if (var.journal_cookie != "" && req.url.path !~ "^/assets/") {
     set req.http.Cookie = "journal=" var.journal_cookie ";";
+    return(pass);
 } else {
     unset req.http.Cookie;
 }


### PR DESCRIPTION
Little hard to test without current access to Fastly logs, but there's no need to go through the cache if you're logged in (and not requesting static assets).

The `/ping` and `/status` pages will also never cache.