### PR TITLE
Remove (most of) Journal's CloudFronts

### DIFF
--- a/projects/elife.yaml
+++ b/projects/elife.yaml
@@ -452,37 +452,9 @@ journal:
                 protocol:
                     - https
                     - http
-            cloudfront:
-                subdomains:
-                    - "{instance}--cdn-journal"
-                headers:
-                    - X-Requested-With
-                    - Host
-                cookies:
-                    - journal
-                errors: 
-                    # TODO: this is not being deployed to, it's empty
-                    domain: end2end-elife-error-pages.s3-website-us-east-1.amazonaws.com
-                    pattern: "???.html"
-                    codes:
-                        # ELB with no active instances
-                        503: "/5xx.html"
-                    protocol: http
-                origins:
-                    CloudFrontCDNOrigin:
-                        hostname: end2end--journal.elifesciences.org
-                    LogInOrigin:
-                        hostname: end2end--journal.elifesciences.org
-                        pattern: /log-in
-                        headers:
-                            - X-Requested-With
-                            - Host
-                            - Referer
-                        cookies:
-                            - journal
             fastly:
                 subdomains:
-                    - "{instance}--fastly-journal"
+                    - "{instance}--cdn-journal"
                 healthcheck:
                     path: /ping-fastly
                     check-interval: 10000
@@ -511,35 +483,9 @@ journal:
                 protocol:
                     - https
                     - http
-            cloudfront:
-                subdomains:
-                    - "{instance}--cdn-journal"
-                headers:
-                    - X-Requested-With
-                    - Host
-                cookies:
-                    - journal
-                errors: 
-                    domain: continuumtest-elife-error-pages.s3-website-us-east-1.amazonaws.com
-                    pattern: "???.html"
-                    codes:
-                        503: "/5xx.html"
-                    protocol: http
-                origins:
-                    CloudFrontCDNOrigin:
-                        hostname: continuumtest--journal.elifesciences.org
-                    LogInOrigin:
-                        hostname: continuumtest--journal.elifesciences.org
-                        pattern: /log-in
-                        headers:
-                            - X-Requested-With
-                            - Host
-                            - Referer
-                        cookies:
-                            - journal
             fastly:
                 subdomains:
-                    - "{instance}--fastly-journal"
+                    - "{instance}--cdn-journal"
                 healthcheck:
                     path: /ping-fastly
                     check-interval: 10000
@@ -576,17 +522,9 @@ journal:
                     - http
             cloudfront:
                 subdomains:
-                    - "{instance}--cdn-journal"
                     - www
                     - elife
                     - prod
-                subdomains-without-dns:
-                    - ""
-                headers:
-                    - X-Requested-With
-                    - Host
-                cookies:
-                    - journal
                 errors: 
                     domain: prod-elife-error-pages.s3-website-us-east-1.amazonaws.com
                     pattern: "???.html"
@@ -597,17 +535,6 @@ journal:
                 origins:
                     CloudFrontCDNOrigin:
                         hostname: prod--journal.elifesciences.org
-                    LogInOrigin:
-                        hostname: prod--journal.elifesciences.org
-                        pattern: /log-in
-                        headers:
-                            - X-Requested-With
-                            - Host
-                            - Referer
-                        cookies:
-                            - journal
-                logging:
-                    bucket: elife-cloudfront-logs
             fastly:
                 subdomains:
                     - "{instance}--fastly-journal"

--- a/projects/elife.yaml
+++ b/projects/elife.yaml
@@ -522,6 +522,7 @@ journal:
                     - http
             cloudfront:
                 subdomains:
+                    - "placeholder2-prod-journal" # only here to avoid rewriting the following values
                     - www
                     - elife
                     - prod

--- a/projects/elife.yaml
+++ b/projects/elife.yaml
@@ -537,7 +537,7 @@ journal:
                         hostname: prod--journal.elifesciences.org
             fastly:
                 subdomains:
-                    - "{instance}--fastly-journal"
+                    - "{instance}--cdn-journal"
                     - "placeholder-prod-journal" # only here to avoid rewriting the following values
                     - ""
                 healthcheck:

--- a/projects/elife.yaml
+++ b/projects/elife.yaml
@@ -526,7 +526,9 @@ journal:
                     - www
                     - elife
                     - prod
-                errors: 
+                headers:
+                    - Host
+                errors:
                     domain: prod-elife-error-pages.s3-website-us-east-1.amazonaws.com
                     pattern: "???.html"
                     codes:

--- a/projects/elife.yaml
+++ b/projects/elife.yaml
@@ -532,9 +532,6 @@ journal:
                         # ELB with no active instances
                         503: "/5xx.html"
                     protocol: http
-                origins:
-                    CloudFrontCDNOrigin:
-                        hostname: prod--journal.elifesciences.org
             fastly:
                 subdomains:
                     - "{instance}--cdn-journal"


### PR DESCRIPTION
Main problem is end2end is still using CloudFront rather than Fastly (https://github.com/elifesciences/elife-spectrum/pull/120).