### PR TITLE
Serve stale content on an error

### DIFF
--- a/src/buildercore/fastly/vcl/error-page.vcl.tpl
+++ b/src/buildercore/fastly/vcl/error-page.vcl.tpl
@@ -1,5 +1,10 @@
 if (obj.status == ${code}) {
-   set obj.http.Content-Type = "text/html; charset=us-ascii";
-      synthetic {"${synthetic_response}"};
-     return(deliver);
+  if (stale.exists) {
+    return(deliver_stale);
+  }
+
+  set obj.http.Content-Type = "text/html; charset=us-ascii";
+  synthetic {"${synthetic_response}"};
+
+  return(deliver);
 }

--- a/src/buildercore/fastly/vcl/error-page.vcl.tpl
+++ b/src/buildercore/fastly/vcl/error-page.vcl.tpl
@@ -1,10 +1,5 @@
 if (obj.status == ${code}) {
-  if (stale.exists) {
-    return(deliver_stale);
-  }
-
-  set obj.http.Content-Type = "text/html; charset=us-ascii";
-  synthetic {"${synthetic_response}"};
-
-  return(deliver);
+   set obj.http.Content-Type = "text/html; charset=us-ascii";
+      synthetic {"${synthetic_response}"};
+     return(deliver);
 }

--- a/src/buildercore/fastly/vcl/main.vcl
+++ b/src/buildercore/fastly/vcl/main.vcl
@@ -1,5 +1,6 @@
 sub vcl_recv {
   if (req.restarts < 1) {
+    # Sanitise header
     unset req.http.X-eLife-Restart;
   }
 
@@ -22,7 +23,7 @@ sub vcl_fetch {
 
     if (req.restarts < 1 && (req.request == "GET" || req.request == "HEAD")) {
       set req.http.X-eLife-Restart = "fetch," beresp.status;
-      unset req.http.Cookie;
+      unset req.http.Cookie; # Temporarily log out the user
 
       restart;
     }

--- a/src/buildercore/fastly/vcl/main.vcl
+++ b/src/buildercore/fastly/vcl/main.vcl
@@ -75,6 +75,10 @@ sub vcl_deliver {
 }
 
 sub vcl_error {
+  if (obj.status >= 500 && obj.status < 600 && stale.exists) {
+    return(deliver_stale);
+  }
+
   #FASTLY error
 }
 

--- a/src/buildercore/fastly/vcl/main.vcl
+++ b/src/buildercore/fastly/vcl/main.vcl
@@ -29,6 +29,7 @@ sub vcl_fetch {
     }
 
     if (!beresp.http.Content-Length || beresp.http.Content-Length == "0") {
+      # Elastic Load Balancer returns empty error responses
       error beresp.status;
     }
   }


### PR DESCRIPTION
Currently viewable on https://continuumtest--cdn-journal.elifesciences.org/ (I've tweaked the `Cache-Control` there to make it cacheable, though it'll be reset on the next highstate so you might need to change it to `public, max-age=30, stale-if-error=86400`).

This also strips the `Cookie` header when restarting so logged-in users might get a stale logged-out version, rather than an error page. This is the only controversial part. /cc @BlueReZZ

Testing as public:

1. View a page on the site a few times to populate the cache (make sure you're logged out).
2. Stop Nginx.
3. Wait 30 seconds.
4. Verify the equivalent page on https://continuumtest--journal.elifesciences.org/ doesn't work.
5. Verify the page through the CDN is continues to be displayed and the `Age` is beyond the `max-age`.
6. Verify that other pages through the CDN return a 503 (when there's no cache entry).

Testing as a logged-in user:

1. View a page on the site a few times to populate the cache (make sure you're logged out).
2. Log in to the site (uses ORCID sandbox).
2. Stop Nginx.
3. Wait 30 seconds.
4. Verify the equivalent page on https://continuumtest--journal.elifesciences.org/ doesn't work.
5. Verify the page through the CDN is continues is displayed, the `Age` is beyond the `max-age` and that you are logged out.
6. Verify that other pages through the CDN return a 503 (when there's no cache entry).
7. Start Nginx.
8. Verify the equivalent page on https://continuumtest--journal.elifesciences.org/ now works.
9. Verify you appear back as logged in on https://continuumtest--cdn-journal.elifesciences.org/.