### PR TITLE
Let Fastly set the host header

### DIFF
--- a/src/buildercore/fastly/vcl/main.vcl
+++ b/src/buildercore/fastly/vcl/main.vcl
@@ -81,6 +81,11 @@ sub vcl_hit {
 
 sub vcl_miss {
   #FASTLY miss
+
+  if (!req.backend.is_shield) {
+    unset bereq.http.host;
+  }
+
   return(fetch);
 }
 
@@ -109,6 +114,10 @@ sub vcl_error {
 
 sub vcl_pass {
   #FASTLY pass
+
+  if (!req.backend.is_shield) {
+    unset bereq.http.host;
+  }
 }
 
 sub vcl_log {

--- a/src/buildercore/terraform.py
+++ b/src/buildercore/terraform.py
@@ -100,6 +100,11 @@ def render_fastly(context):
     vcl_constant_snippets = context['fastly']['vcl']
     vcl_templated_snippets = {}
 
+    request_settings.append(_fastly_request_setting({
+        'name': 'force-ssl',
+        'force_ssl': True,
+    }))
+
     all_allowed_subdomains = context['fastly']['subdomains'] + context['fastly']['subdomains-without-dns']
 
     if context['fastly']['backends']:
@@ -309,7 +314,6 @@ def _fastly_backend(hostname, name, request_condition=None, shield=None):
 def _fastly_request_setting(override):
     request_setting_resource = {
         'name': 'default',
-        'force_ssl': True,
         # shouldn't need to replicate the defaults
         # https://github.com/terraform-providers/terraform-provider-fastly/issues/50
         # https://github.com/terraform-providers/terraform-provider-fastly/issues/67

--- a/src/buildercore/terraform.py
+++ b/src/buildercore/terraform.py
@@ -113,14 +113,10 @@ def render_fastly(context):
                 })
                 request_settings.append(_fastly_request_setting({
                     'name': 'backend-%s-request-settings' % name,
-                    'default_host': backend['hostname'],
                     'request_condition': condition_name,
                 }))
                 backend_condition_name = condition_name
             else:
-                request_settings.append(_fastly_request_setting({
-                    'default_host': backend['hostname']
-                }))
                 backend_condition_name = None
             shield = backend['shield'].get('pop')
             backends.append(_fastly_backend(
@@ -129,20 +125,13 @@ def render_fastly(context):
                 request_condition=backend_condition_name,
                 shield=shield
             ))
-            if shield:
-                all_allowed_subdomains.append(backend['hostname'])
     else:
-        request_settings.append(_fastly_request_setting({
-            'default_host': context['full_hostname']
-        }))
         shield = context['fastly']['shield'].get('pop')
         backends.append(_fastly_backend(
             context['full_hostname'],
             name=context['stackname'],
             shield=shield
         ))
-        if shield:
-            all_allowed_subdomains.append(context['full_hostname'])
 
     tf_file = {
         'resource': {
@@ -266,7 +255,8 @@ def render_fastly(context):
     if headers:
         tf_file['resource'][RESOURCE_TYPE_FASTLY][RESOURCE_NAME_FASTLY]['header'] = headers
 
-    tf_file['resource'][RESOURCE_TYPE_FASTLY][RESOURCE_NAME_FASTLY]['request_setting'] = request_settings
+    if request_settings:
+        tf_file['resource'][RESOURCE_TYPE_FASTLY][RESOURCE_NAME_FASTLY]['request_setting'] = request_settings
 
     if data:
         tf_file['data'] = data

--- a/src/tests/test_buildercore_terraform.py
+++ b/src/tests/test_buildercore_terraform.py
@@ -87,13 +87,6 @@ class TestBuildercoreTerraform(base.BaseCase):
                                 'ssl_check_cert': True,
                             }],
                             'default_ttl': 3600,
-                            'request_setting': [{
-                                'name': 'default',
-                                'default_host': 'prod--www.example.org',
-                                'force_ssl': True,
-                                'timer_support': True,
-                                'xff': 'leave',
-                            }],
                             'gzip': {
                                 'name': 'default',
                                 'content_types': ['application/javascript', 'application/json',
@@ -163,15 +156,6 @@ class TestBuildercoreTerraform(base.BaseCase):
                                 {
                                     'name': 'future.example.org'
                                 },
-                                {
-                                    'name': 'prod-special.example.org'
-                                },
-                                {
-                                    'name': 'prod-special2.example.org'
-                                },
-                                {
-                                    'name': 'prod-special3.example.org'
-                                },
                             ],
                             'backend': [
                                 {
@@ -223,15 +207,7 @@ class TestBuildercoreTerraform(base.BaseCase):
                             ],
                             'request_setting': [
                                 {
-                                    'name': 'default',
-                                    'default_host': 'default.example.org',
-                                    'force_ssl': True,
-                                    'timer_support': True,
-                                    'xff': 'leave',
-                                },
-                                {
                                     'name': 'backend-articles-request-settings',
-                                    'default_host': 'prod-special.example.org',
                                     'force_ssl': True,
                                     'timer_support': True,
                                     'xff': 'leave',
@@ -239,7 +215,6 @@ class TestBuildercoreTerraform(base.BaseCase):
                                 },
                                 {
                                     'name': 'backend-articles2-request-settings',
-                                    'default_host': 'prod-special2.example.org',
                                     'force_ssl': True,
                                     'timer_support': True,
                                     'xff': 'leave',
@@ -247,7 +222,6 @@ class TestBuildercoreTerraform(base.BaseCase):
                                 },
                                 {
                                     'name': 'backend-articles3-request-settings',
-                                    'default_host': 'prod-special3.example.org',
                                     'force_ssl': True,
                                     'timer_support': True,
                                     'xff': 'leave',
@@ -343,7 +317,6 @@ class TestBuildercoreTerraform(base.BaseCase):
         service = template['resource']['fastly_service_v1']['fastly-cdn']
         self.assertEqual(service['backend'][0].get('shield'), 'dca-dc-us')
         self.assertIn('domain', service)
-        self.assertEqual(service['domain'][0].get('name'), service['backend'][0]['address'])
 
     def test_fastly_template_shield_pop(self):
         extra = {
@@ -355,7 +328,6 @@ class TestBuildercoreTerraform(base.BaseCase):
         service = template['resource']['fastly_service_v1']['fastly-cdn']
         self.assertEqual(service['backend'][0].get('shield'), 'london-uk')
         self.assertIn('domain', service)
-        self.assertEqual(service['domain'][0].get('name'), service['backend'][0]['address'])
 
     def test_fastly_template_shield_aws_region(self):
         base.switch_in_test_settings('dummy-settings2.yaml')

--- a/src/tests/test_buildercore_terraform.py
+++ b/src/tests/test_buildercore_terraform.py
@@ -87,6 +87,14 @@ class TestBuildercoreTerraform(base.BaseCase):
                                 'ssl_check_cert': True,
                             }],
                             'default_ttl': 3600,
+                            'request_setting': [
+                                {
+                                    'name': 'force-ssl',
+                                    'force_ssl': True,
+                                    'timer_support': True,
+                                    'xff': 'leave',
+                                }
+                            ],
                             'gzip': {
                                 'name': 'default',
                                 'content_types': ['application/javascript', 'application/json',
@@ -207,22 +215,25 @@ class TestBuildercoreTerraform(base.BaseCase):
                             ],
                             'request_setting': [
                                 {
-                                    'name': 'backend-articles-request-settings',
+                                    'name': 'force-ssl',
                                     'force_ssl': True,
+                                    'timer_support': True,
+                                    'xff': 'leave',
+                                },
+                                {
+                                    'name': 'backend-articles-request-settings',
                                     'timer_support': True,
                                     'xff': 'leave',
                                     'request_condition': 'backend-articles-condition',
                                 },
                                 {
                                     'name': 'backend-articles2-request-settings',
-                                    'force_ssl': True,
                                     'timer_support': True,
                                     'xff': 'leave',
                                     'request_condition': 'backend-articles2-condition',
                                 },
                                 {
                                     'name': 'backend-articles3-request-settings',
-                                    'force_ssl': True,
                                     'timer_support': True,
                                     'xff': 'leave',
                                     'request_condition': 'backend-articles3-condition',


### PR DESCRIPTION
#377 is currently blocked as Fastly don't allow multiple domains. This unsets the `Host` header when making a request to the backend, Fastly will then set the value.