### PR TITLE
Skip parts of update_infrastructure

### DIFF
--- a/src/cfn.py
+++ b/src/cfn.py
@@ -79,10 +79,7 @@ def update_infrastructure(stackname, skip=None):
 
     Allows to skip EC2, SQS, S3 updates by passing `skip=ec2\\,sqs\\,s3`"""
 
-    if skip:
-        skip = skip.split(",")
-    else:
-        skip = []
+    skip = skip.split(",") if skip else []
 
     (pname, _) = core.parse_stackname(stackname)
     more_context = {}

--- a/src/cfn.py
+++ b/src/cfn.py
@@ -63,7 +63,7 @@ def update(stackname, autostart="0", concurrency='serial'):
 
 @task
 @timeit
-def update_infrastructure(stackname):
+def update_infrastructure(stackname, skip=None):
     """Limited update of the Cloudformation template and/or Terraform template.
 
     Resources can be added, but most of the existing ones are immutable.
@@ -75,7 +75,14 @@ def update_infrastructure(stackname):
     but without any software being on it)
 
     Moreover, EC2 instances must be running while this is executed or their
-    resources like PublicIP will be inaccessible"""
+    resources like PublicIP will be inaccessible.
+
+    Allows to skip EC2, SQS, S3 updates by passing `skip=ec2\\,sqs\\,s3`"""
+
+    if skip:
+        skip = skip.split(",")
+    else:
+        skip = []
 
     (pname, _) = core.parse_stackname(stackname)
     more_context = {}
@@ -96,17 +103,17 @@ def update_infrastructure(stackname):
 
     # TODO: move inside bootstrap.update_stack
     # EC2
-    if _are_there_existing_servers(context):
+    if _are_there_existing_servers(context) and not 'ec2' in skip:
         # the /etc/buildvars.json file may need to be updated
         buildvars.refresh(stackname, context)
         update(stackname)
 
     # SQS
-    if context.get('sqs', {}):
+    if context.get('sqs', {}) and not 'sqs' in skip:
         bootstrap.update_stack(stackname, service_list=['sqs'])
 
     # S3
-    if context.get('s3', {}):
+    if context.get('s3', {}) and not 's3' in skip:
         bootstrap.update_stack(stackname, service_list=['s3'])
 
 @requires_project


### PR DESCRIPTION
update_infrastructure runs updates also on EC2, SQS, S3 resources after CloudFormation and Terraform. This is in general necessary e.g. extending the filesystem of a volume after its size has been changed, or subscribing a queue after it has been created. If you really know what you're doing, you can skip some steps for faster feedback