### PR TITLE
Clarify instruction for giving access to a new master server

### DIFF
--- a/scripts/init-master.sh
+++ b/scripts/init-master.sh
@@ -52,10 +52,10 @@ if [ ! -d /opt/builder-private ]; then
         echo "
 ----------
 
-could not clone your 'builder-private' repository:
+could not clone the 'builder-private' repository:
     $pillar_repo
 
-if this repository resides on github, we suggest creating a 'deploy key' by pasting in the public key below:
+add the following public key to the elife-master-builder Github user:
 
     $pubkey
 
@@ -67,7 +67,7 @@ after the setup of the key, complete this process by running builder's 'update' 
 
     ./bldr update:$stackname
 
-Note this key must be added also tom any private formula you want the master-server to use.
+This key will also be used to access to any private formula you want the master-server to use. The elife-master-builder Github user should already have access to these formulas.
 
 ----------"
 

--- a/scripts/init-master.sh
+++ b/scripts/init-master.sh
@@ -67,7 +67,9 @@ after the setup of the key, complete this process by running builder's 'update' 
 
     ./bldr update:$stackname
 
-This key will also be used to access to any private formula you want the master-server to use. The elife-master-builder Github user should already have access to these formulas.
+This key will also be used to access any private formula you want the master-server to use.
+
+The elife-master-builder Github user should already have access to these formulas.
 
 ----------"
 


### PR DESCRIPTION
Deploy keys do not work here, as they cannot be used for more than one repository; both `builder-private` and `crm-formula` are private.