### PR TITLE
Add S3 bucket for elife-xpub

### DIFF
--- a/projects/elife.yaml
+++ b/projects/elife.yaml
@@ -1971,6 +1971,7 @@ elife-xpub:
                 - xpub
             s3:
                 "{instance}-elife-xpub":
+                     deletion-policy: retain
     vagrant:
         ram: 2048
         ports:

--- a/projects/elife.yaml
+++ b/projects/elife.yaml
@@ -1963,9 +1963,14 @@ elife-xpub:
             device: /dev/sdh
             type: gp2
     aws-alt:
+        demo:
+            s3:
+                "{instance}-elife-xpub":
         prod:
             subdomains:
                 - xpub
+            s3:
+                "{instance}-elife-xpub":
     vagrant:
         ram: 2048
         ports:


### PR DESCRIPTION
For https://github.com/elifesciences/elife-xpub/issues/622

Covers the bucket, but not any IAM user or policies, which are configured manually with admin rights.