### PR TITLE
Add RDS to elife-xpub--prod

### DIFF
--- a/projects/elife.yaml
+++ b/projects/elife.yaml
@@ -1972,6 +1972,15 @@ elife-xpub:
             s3:
                 "{instance}-elife-xpub":
                      deletion-policy: retain
+            rds:
+                multi-az: true
+                engine: postgres # or 'MySQL'
+                version: '10.5'
+                type: db.t2.small
+                storage: 5 # GB
+                storage-type: gp2
+                backup-retention: 28 # days
+                deletion-policy: Snapshot
     vagrant:
         ram: 2048
         ports:

--- a/projects/elife.yaml
+++ b/projects/elife.yaml
@@ -1975,7 +1975,7 @@ elife-xpub:
             rds:
                 multi-az: true
                 engine: postgres # or 'MySQL'
-                version: '10.5'
+                version: '10.4'
                 type: db.t2.small
                 storage: 5 # GB
                 storage-type: gp2


### PR DESCRIPTION
For https://github.com/elifesciences/elife-xpub/issues/623

Sets up RDS only for `elife-xpub--prod`; splitted out:

- encryption at rest, will be covered later by re-creating the instance.
- [`elife-xpub--end2end`, will be created later](https://github.com/elifesciences/elife-xpub/issues/648)

To be precise, we standardize on RDS Postgres, not Aurora.