### PR TITLE
Support RDS encryption at rest

### DIFF
--- a/src/buildercore/cfngen.py
+++ b/src/buildercore/cfngen.py
@@ -224,7 +224,6 @@ def project_wrangler(pdata, context):
     context['project'] = subdict(pdata, keepers)
 
     # limited to just master/masterless servers
-    print(pdata)
     is_masterless = pdata['aws'].get('ec2') and pdata['aws']['ec2']['masterless']
     is_master = core.is_master_server_stack(context['stackname'])
     if is_master or is_masterless:
@@ -304,7 +303,6 @@ def build_context_rds(pdata, context, existing_context):
         'rds_dbname': core.rds_dbname(stackname, context), # name of default application db
         'rds_instance_id': core.rds_iid(stackname), # name of rds instance
         'rds_params': pdata['aws']['rds'].get('params', []),
-
         'rds': pdata['aws']['rds'],
     })
     context['rds']['deletion-policy'] = deletion_policy

--- a/src/buildercore/trop.py
+++ b/src/buildercore/trop.py
@@ -286,6 +286,8 @@ def render_rds(context, template):
         "Tags": tags,
         "AllowMajorVersionUpgrade": False, # default? not specified.
         "AutoMinorVersionUpgrade": True, # default
+        'StorageEncrypted': True if lu('rds.encryption') else False,
+        'KmsKeyId': lu('rds.encryption') if isinstance(lu('rds.encryption'), str) else '',
     }
 
     if param_group_ref:

--- a/src/tests/fixtures/dummy2-project.json
+++ b/src/tests/fixtures/dummy2-project.json
@@ -43,6 +43,7 @@
             "storage-type": "standard",
             "backup-retention": 28, 
             "params": [], 
+            "encryption": false,
             "subnets": [
                 "subnet-foo", 
                 "subnet-bar"
@@ -96,6 +97,7 @@
                 "storage-type": "standard",
                 "backup-retention": 28, 
                 "params": [], 
+                "encryption": false,
                 "subnets": [
                     "subnet-foo", 
                     "subnet-bar"
@@ -149,6 +151,7 @@
                 "storage-type": "standard",
                 "backup-retention": 28, 
                 "params": [], 
+                "encryption": false,
                 "subnets": [
                     "subnet-foo", 
                     "subnet-bar"

--- a/src/tests/fixtures/dummy3-project.json
+++ b/src/tests/fixtures/dummy3-project.json
@@ -103,6 +103,7 @@
                 "storage-type": "standard",
                 "backup-retention": 28, 
                 "params": [], 
+                "encryption": false,
                 "subnets": [
                     "subnet-foo", 
                     "subnet-bar"
@@ -151,6 +152,7 @@
                 "storage-type": "standard",
                 "backup-retention": 28, 
                 "params": [], 
+                "encryption": false,
                 "subnets": [
                     "subnet-foo", 
                     "subnet-bar"

--- a/src/tests/fixtures/projects/dummy-project.yaml
+++ b/src/tests/fixtures/projects/dummy-project.yaml
@@ -56,6 +56,7 @@ defaults:
             # two subnets are required in two different availability zones
             # http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-rds-dbsubnet-group.html
             params: []
+            encryption: false
             subnets:
                 # two are required
                 - subnet-foo
@@ -547,6 +548,13 @@ project-with-rds-only:
         ec2: false
         rds:
             storage: 5
+
+project-with-rds-encryption:
+    repo: ssh://git@github.com/elifesciences/dummy3
+    aws:
+        rds:
+            storage: 5
+            encryption: arn:aws:kms:us-east-1:1234:key/12345678-1234-1234-1234-123456789012
 
 project-with-elasticache-redis:
     domain: False

--- a/src/tests/test_buildercore_project.py
+++ b/src/tests/test_buildercore_project.py
@@ -13,7 +13,7 @@ ALL_PROJECTS = [
     'project-with-ec2-custom-root',
     'project-with-cluster', 'project-with-cluster-suppressed', 'project-with-cluster-overrides', 'project-with-cluster-empty',
     'project-with-stickiness', 'project-with-multiple-elb-listeners',
-    'project-with-cluster-integration-tests', 'project-with-db-params', 'project-with-rds-only', 'project-with-elasticache-redis', 'project-with-multiple-elasticaches', 'project-with-fully-overridden-elasticaches',
+    'project-with-cluster-integration-tests', 'project-with-db-params', 'project-with-rds-only', 'project-with-rds-encrypted', 'project-with-elasticache-redis', 'project-with-multiple-elasticaches', 'project-with-fully-overridden-elasticaches',
     'project-on-gcp',
 ]
 

--- a/src/tests/test_buildercore_project.py
+++ b/src/tests/test_buildercore_project.py
@@ -13,7 +13,7 @@ ALL_PROJECTS = [
     'project-with-ec2-custom-root',
     'project-with-cluster', 'project-with-cluster-suppressed', 'project-with-cluster-overrides', 'project-with-cluster-empty',
     'project-with-stickiness', 'project-with-multiple-elb-listeners',
-    'project-with-cluster-integration-tests', 'project-with-db-params', 'project-with-rds-only', 'project-with-rds-encrypted', 'project-with-elasticache-redis', 'project-with-multiple-elasticaches', 'project-with-fully-overridden-elasticaches',
+    'project-with-cluster-integration-tests', 'project-with-db-params', 'project-with-rds-only', 'project-with-rds-encryption', 'project-with-elasticache-redis', 'project-with-multiple-elasticaches', 'project-with-fully-overridden-elasticaches',
     'project-on-gcp',
 ]
 

--- a/src/tests/test_buildercore_trop.py
+++ b/src/tests/test_buildercore_trop.py
@@ -73,6 +73,17 @@ class TestBuildercoreTrop(base.BaseCase):
         }
         self.assertEqual(cfntemplate['Resources']['RDSDBParameterGroup'], expected)
 
+    def test_rds_encryption(self):
+        extra = {
+            'stackname': 'project-with-rds-encryption--test',
+        }
+        context = cfngen.build_context('project-with-rds-encryption', **extra)
+        cfn_template = json.loads(trop.render(context))
+        self.assertIn('AttachedDB', cfn_template['Resources'])
+        db = cfn_template['Resources']['AttachedDB']['Properties']
+        self.assertTrue(db['StorageEncrypted'])
+        self.assertEquals(db['KmsKeyId'], 'arn:aws:kms:us-east-1:1234:key/12345678-1234-1234-1234-123456789012')
+
     def test_sns_template(self):
         extra = {
             'stackname': 'just-some-sns--prod',


### PR DESCRIPTION
Eventually for https://github.com/elifesciences/elife-xpub/issues/623

A key is managed by AWS, still to be seen which permissions that key should have for RDS to pick it up.

Key at https://console.aws.amazon.com/iam/home?region=us-east-1#/encryptionKeys/us-east-1/b626157a-1e5b-4bf6-8799-211505efe072 if you can see it.