### PR TITLE
Deploy RDS with encryption in elife-xpub--prod

### DIFF
--- a/projects/elife.yaml
+++ b/projects/elife.yaml
@@ -1980,6 +1980,7 @@ elife-xpub:
                 storage: 5 # GB
                 storage-type: gp2
                 backup-retention: 28 # days
+                encryption: arn:aws:kms:us-east-1:512686554592:key/b626157a-1e5b-4bf6-8799-211505efe072 
                 deletion-policy: Snapshot
     vagrant:
         ram: 2048


### PR DESCRIPTION
For https://github.com/elifesciences/elife-xpub/issues/623

Implemented in https://github.com/elifesciences/builder/pull/394

This needed deletion (don't try this at home) and recreation of the RDS instance.