### PR TITLE
Support for builder-configuration in masterless instances

### DIFF
--- a/scripts/init-master.sh
+++ b/scripts/init-master.sh
@@ -95,10 +95,6 @@ else
     git reset --hard
     git pull
 fi
-cp /opt/builder-private/etc-salt-master /etc/salt/master.template
-if [ -d /vagrant ]; then
-    cp /etc/salt/master.template /vagrant/etc-salt-master.template
-fi
 
 
 # clone all formulas

--- a/scripts/update-masterless-formula.sh
+++ b/scripts/update-masterless-formula.sh
@@ -12,6 +12,9 @@ formula_root="/opt/formulas"
 if [ "$pname" = "builder-private" ]; then
     formula_root="/opt"
 fi
+if [ "$pname" = "builder-configuration" ]; then
+    formula_root="/opt"
+fi
 formula_path="$formula_root/$pname"
 
 mkdir -p "$formula_root"

--- a/src/buildercore/bootstrap.py
+++ b/src/buildercore/bootstrap.py
@@ -502,7 +502,7 @@ def update_ec2_stack(stackname, context, concurrency=None, formula_revisions=Non
                 'BUILDER_TOPFILE': os.environ.get('BUILDER_TOPFILE', '')
             }
             # Vagrant's equivalent is 'init-vagrant-formulas.sh'
-            run_script('init-masterless-formulas.sh', formula_list, fdata['private-repo'], **envvars)
+            run_script('init-masterless-formulas.sh', formula_list, fdata['private-repo'], fdata['configuration-repo'], **envvars)
 
             # second pass to optionally update formulas to specific revisions
             for repo, formula, revision in formula_revisions or []:


### PR DESCRIPTION
For https://github.com/elifesciences/issues/issues/3691

These builds would otherwise be broken since the introduction of https://github.com/elifesciences/builder-private/commit/91bc84e56142134de03d697b9ce8230139d8c8f6 which makes `top.sls` rely on some files in `builder-configuration`.