### PR TITLE
Basic support for BigQuery

### DIFF
--- a/projects/elife.yaml
+++ b/projects/elife.yaml
@@ -2070,12 +2070,11 @@ fastly-logs:
                 project: elife-fastly
     gcp:
         bigquery:
-            datasets:
-                "{instance}":
-                    project: elife-fastly
-                    tables:
-                        iiif:
-                            schema: fastly-logs-201809
+            "{instance}":
+                project: elife-fastly
+                tables:
+                    iiif:
+                        schema: fastly-logs-201809
     aws-alt: {}
 
 data-pipeline:

--- a/projects/elife.yaml
+++ b/projects/elife.yaml
@@ -2071,11 +2071,11 @@ fastly-logs:
     gcp:
         bigquery:
             datasets:
-                "sample_dataset_{instance}":
+                "{instance}":
                     project: elife-fastly
-                    tables: {}
-                    #    widgets:
-                    #        schema: key-value
+                    tables:
+                        iiif:
+                            schema: fastly-logs-201809
     aws-alt: {}
 
 data-pipeline:

--- a/projects/elife.yaml
+++ b/projects/elife.yaml
@@ -207,6 +207,8 @@ defaults:
                 ami: ami-089646d3d52f14f1f # created from basebox--1804
                                            # us-east-1, build date 20180814, hvm:ebs-ssd, AMI built on 20180828
                 masterless: true
+    gcp:
+        bigquery: false
     vagrant:
         # why 'bento'? https://bugs.launchpad.net/cloud-images/+bug/1569237
         box: bento/ubuntu-16.04 # Ubuntu 16.04 "Xenial"
@@ -2066,6 +2068,14 @@ fastly-logs:
         gcs:
             "{instance}-elife-fastly":
                 project: elife-fastly
+    gcp:
+        bigquery:
+            datasets:
+                "sample_dataset_{instance}":
+                    project: elife-fastly
+                    tables: {}
+                    #    widgets:
+                    #        schema: key-value
     aws-alt: {}
 
 data-pipeline:

--- a/src/buildercore/bigquery.py
+++ b/src/buildercore/bigquery.py
@@ -1,0 +1,4 @@
+BIGQUERY_SCHEMAS_FOLDER = 'src/buildercore/bigquery/schemas'
+
+def schema(schema_name):
+    return open('%s/%s.json' % (BIGQUERY_SCHEMAS_FOLDER, schema_name))

--- a/src/buildercore/bigquery/schemas/fastly-logs-201809.json
+++ b/src/buildercore/bigquery/schemas/fastly-logs-201809.json
@@ -1,0 +1,82 @@
+[
+  {
+    "name": "timestamp",
+    "type": "DATETIME"
+  },
+  {
+    "name": "time_elapsed",
+    "type": "INTEGER"
+  },
+  {
+    "name": "object_hits",
+    "type": "INTEGER"
+  },
+  {
+    "name": "object_lastuse",
+    "type": "FLOAT"
+  },
+  {
+    "name": "is_tls",
+    "type": "BOOLEAN"
+  },
+  {
+    "name": "client_ip",
+    "type": "STRING"
+  },
+  {
+    "name": "geo_city",
+    "type": "STRING"
+  },
+  {
+    "name": "geo_country_code",
+    "type": "STRING"
+  },
+  {
+    "name": "pop_datacenter",
+    "type": "STRING"
+  },
+  {
+    "name": "pop_region",
+    "type": "STRING"
+  },
+  {
+    "name": "shield",
+    "type": "STRING"
+  },
+  {
+    "name": "request",
+    "type": "STRING"
+  },
+  {
+    "name": "host",
+    "type": "STRING"
+  },
+  {
+    "name": "url",
+    "type": "STRING"
+  },
+  {
+    "name": "request_referer",
+    "type": "STRING"
+  },
+  {
+    "name": "request_user_agent",
+    "type": "STRING"
+  },
+  {
+    "name": "request_accept_language",
+    "type": "STRING"
+  },
+  {
+    "name": "request_accept_charset",
+    "type": "STRING"
+  },
+  {
+    "name": "response_status",
+    "type": "STRING"
+  },
+  {
+    "name": "cache_status",
+    "type": "STRING"
+  }
+]

--- a/src/buildercore/bigquery/schemas/key-value.json
+++ b/src/buildercore/bigquery/schemas/key-value.json
@@ -1,0 +1,10 @@
+[
+    {
+        "name": "key",
+        "type": "INTEGER"
+    },
+    {
+        "name": "value",
+        "type": "STRING"
+    }
+]

--- a/src/buildercore/cfngen.py
+++ b/src/buildercore/cfngen.py
@@ -140,7 +140,8 @@ def build_context(pname, **more_context):
         build_context_s3,
         build_context_cloudfront,
         build_context_fastly,
-        build_context_gcp,
+        build_context_gcs,
+        build_context_bigquery,
         build_context_subdomains,
         build_context_elasticache,
         build_context_vault,
@@ -407,7 +408,7 @@ def build_context_fastly(pdata, context):
         }
     return context
 
-def build_context_gcp(pdata, context):
+def build_context_gcs(pdata, context):
     context['gcs'] = False
     if 'gcs' in pdata['aws']:
         context['gcs'] = OrderedDict()
@@ -415,6 +416,18 @@ def build_context_gcp(pdata, context):
             bucket_name = parameterize(context)(bucket_template_name)
             context['gcs'][bucket_name] = {
                 'project': options['project'],
+            }
+    return context
+
+def build_context_bigquery(pdata, context):
+    context['bigquery'] = False
+    if 'bigquery' in pdata['gcp']:
+        context['bigquery'] = OrderedDict()
+        for dataset_template_name, options in pdata['gcp']['bigquery']['datasets'].items():
+            dataset_name = parameterize(context)(dataset_template_name)
+            context['bigquery'][dataset_name] = {
+                'project': options['project'],
+                'tables': options.get('tables', OrderedDict()),
             }
     return context
 

--- a/src/buildercore/cfngen.py
+++ b/src/buildercore/cfngen.py
@@ -423,7 +423,7 @@ def build_context_bigquery(pdata, context):
     context['bigquery'] = False
     if pdata['gcp']['bigquery']:
         context['bigquery'] = OrderedDict()
-        for dataset_template_name, options in pdata['gcp']['bigquery']['datasets'].items():
+        for dataset_template_name, options in pdata['gcp']['bigquery'].items():
             dataset_name = parameterize(context)(dataset_template_name)
             context['bigquery'][dataset_name] = {
                 'project': options['project'],

--- a/src/buildercore/cfngen.py
+++ b/src/buildercore/cfngen.py
@@ -421,7 +421,7 @@ def build_context_gcs(pdata, context):
 
 def build_context_bigquery(pdata, context):
     context['bigquery'] = False
-    if 'bigquery' in pdata['gcp']:
+    if pdata['gcp']['bigquery']:
         context['bigquery'] = OrderedDict()
         for dataset_template_name, options in pdata['gcp']['bigquery']['datasets'].items():
             dataset_name = parameterize(context)(dataset_template_name)

--- a/src/buildercore/terraform.py
+++ b/src/buildercore/terraform.py
@@ -393,25 +393,27 @@ def render_bigquery(context):
             table_options['dataset_id'] = dataset_name
             tables[table_name] = table_options
 
-    return {
-        'resource': {
-            'google_bigquery_dataset': {
-                dataset_name: {
-                    'dataset_id': dataset_name,
-                    'project': options['project'],
-                } for dataset_name, options in context['bigquery'].items()
-            },
-            'google_bigquery_table': {
-                # generated fully qualified resource name
-                ("%s_%s" % (options['dataset_id'], table_name)): {
-                    'dataset_id': options['dataset_id'],
-                    # TODO 'table_id' : table_id
-                    'table_id': table_name,
-                    'schema': _generate_bigquery_schema_file(context['stackname'], options['schema']),
-                } for table_name, options in tables.items()
-            }
-        },
+    resources = {'resource': OrderedDict()}
+
+    resources['resource']['google_bigquery_dataset'] = {
+        dataset_name: {
+            'dataset_id': dataset_name,
+            'project': options['project'],
+        } for dataset_name, options in context['bigquery'].items()
     }
+
+    if tables:
+        resources['resource']['google_bigquery_table'] = {
+            # generated fully qualified resource name
+            ("%s_%s" % (options['dataset_id'], table_name)): {
+                'dataset_id': options['dataset_id'],
+                # TODO 'table_id' : table_id
+                'table_id': table_name,
+                'schema': _generate_bigquery_schema_file(context['stackname'], options['schema']),
+            } for table_name, options in tables.items()
+        }
+    
+    return resources
 
 def _generate_bigquery_schema_file(stackname, schema_name):
     """

--- a/src/buildercore/terraform.py
+++ b/src/buildercore/terraform.py
@@ -414,7 +414,7 @@ def render_bigquery(context):
                 'schema': _generate_bigquery_schema_file(context['stackname'], options['schema']),
             } for table_name, options in tables.items()
         }
-    
+
     return resources
 
 def _generate_bigquery_schema_file(stackname, schema_name):
@@ -515,7 +515,7 @@ def init(stackname, context):
                     'region': 'us-east4',
                     # TODO: the system-wide authentication is being used
                     # to provision through this provider (see `gcloud auth list`)
-                    # It could be possible to create a Service Account for 
+                    # It could be possible to create a Service Account for
                     # a certain project and put it in Vault to allow more
                     # people to run `update_infrastructure`
                     # This is not ideal anyway, as it would be a set of credentials

--- a/src/buildercore/terraform.py
+++ b/src/buildercore/terraform.py
@@ -511,6 +511,13 @@ def init(stackname, context):
                 'google': {
                     'version': "= %s" % '1.13.0',
                     'region': 'us-east4',
+                    # TODO: the system-wide authentication is being used
+                    # to provision through this provider (see `gcloud auth list`)
+                    # It could be possible to create a Service Account for 
+                    # a certain project and put it in Vault to allow more
+                    # people to run `update_infrastructure`
+                    # This is not ideal anyway, as it would be a set of credentials
+                    # with large powers (but maybe limited to the single GCP project)
                 },
                 'vault': {
                     'address': context['vault']['address'],

--- a/src/buildercore/terraform.py
+++ b/src/buildercore/terraform.py
@@ -385,6 +385,12 @@ def render_bigquery(context):
     if not context['bigquery']:
         return {}
 
+    tables = OrderedDict({})
+    for dataset_name, dataset_options in context['bigquery'].items():
+        for table_name, table_options in dataset_options['tables'].items():
+            table_options['dataset_id'] = dataset_name
+            tables[table_name] = table_options
+
     return {
         'resource': {
             'google_bigquery_dataset': {
@@ -393,6 +399,14 @@ def render_bigquery(context):
                     'project': options['project'],
                 } for dataset_name, options in context['bigquery'].items()
             },
+            'google_bigquery_table': {
+                # generated fully qualified resource name
+                ("%s_%s" % (options['dataset_id'], table_name)): {
+                    'dataset_id': options['dataset_id'],
+                    # : table_id
+                    'table_id': table_name,
+                } for table_name, options in tables.items()
+            }
         },
     }
 

--- a/src/buildercore/terraform.py
+++ b/src/buildercore/terraform.py
@@ -81,7 +81,8 @@ FASTLY_MAIN_VCL_KEY = 'main'
 
 def render(context):
     generated_template = render_fastly(context)
-    generated_template.update(render_gcp(context))
+    generated_template.update(render_gcs(context))
+    generated_template.update(render_bigquery(context))
 
     if not generated_template:
         return EMPTY_TEMPLATE
@@ -363,7 +364,7 @@ def _generate_vcl_file(stackname, content, key, extension='vcl'):
         fp.write(str(content))
         return '${file("%s")}' % basename(fp.name)
 
-def render_gcp(context):
+def render_gcs(context):
     if not context['gcs']:
         return {}
 
@@ -376,6 +377,21 @@ def render_gcp(context):
                     'storage_class': 'REGIONAL',
                     'project': options['project'],
                 } for bucket_name, options in context['gcs'].items()
+            },
+        },
+    }
+
+def render_bigquery(context):
+    if not context['bigquery']:
+        return {}
+
+    return {
+        'resource': {
+            'google_bigquery_dataset': {
+                dataset_name: {
+                    'dataset_id': dataset_name,
+                    'project': options['project'],
+                } for dataset_name, options in context['bigquery'].items()
             },
         },
     }

--- a/src/buildercore/terraform.py
+++ b/src/buildercore/terraform.py
@@ -391,6 +391,7 @@ def render_bigquery(context):
     for dataset_name, dataset_options in context['bigquery'].items():
         for table_name, table_options in dataset_options['tables'].items():
             table_options['dataset_id'] = dataset_name
+            table_options['project'] = dataset_options['project']
             tables[table_name] = table_options
 
     resources = {'resource': OrderedDict()}
@@ -409,6 +410,7 @@ def render_bigquery(context):
                 'dataset_id': options['dataset_id'],
                 # TODO 'table_id' : table_id
                 'table_id': table_name,
+                'project': options['project'],
                 'schema': _generate_bigquery_schema_file(context['stackname'], options['schema']),
             } for table_name, options in tables.items()
         }

--- a/src/buildercore/terraform.py
+++ b/src/buildercore/terraform.py
@@ -8,7 +8,7 @@ from python_terraform import Terraform, IsFlagged, IsNotFlagged
 from .config import BUILDER_BUCKET, BUILDER_REGION, TERRAFORM_DIR
 from .context_handler import only_if, load_context
 from .utils import ensure, mkdir_p
-from . import fastly
+from . import fastly, bigquery
 
 EMPTY_TEMPLATE = '{}'
 PROVIDER_FASTLY_VERSION = '0.1.4',
@@ -78,8 +78,6 @@ FASTLY_LOG_LINE_PREFIX = 'blank' # no prefix
 # around by using a full VCL
 # https://github.com/terraform-providers/terraform-provider-fastly/issues/7 tracks when snippets could become available in Terraform
 FASTLY_MAIN_VCL_KEY = 'main'
-
-BIGQUERY_SCHEMAS_FOLDER = 'src/buildercore/bigquery/schemas'
 
 def render(context):
     generated_template = render_fastly(context)
@@ -421,8 +419,7 @@ def _generate_bigquery_schema_file(stackname, schema_name):
     """
     places a schema JSON file for Terraform to dynamically load it on apply
     """
-    # TODO: extract into buildercore.bigquery
-    with open('%s/%s.json' % (BIGQUERY_SCHEMAS_FOLDER, schema_name)) as source:
+    with bigquery.schema(schema_name) as source:
         with _open(stackname, schema_name, extension='json', mode='w') as target:
             target.write(source.read())
             return '${file("%s")}' % basename(target.name)

--- a/src/buildercore/terraform.py
+++ b/src/buildercore/terraform.py
@@ -386,31 +386,30 @@ def render_bigquery(context):
         return {}
 
     tables = OrderedDict({})
-    for dataset_name, dataset_options in context['bigquery'].items():
-        for table_name, table_options in dataset_options['tables'].items():
-            table_options['dataset_id'] = dataset_name
+    for dataset_id, dataset_options in context['bigquery'].items():
+        for table_id, table_options in dataset_options['tables'].items():
+            table_options['dataset_id'] = dataset_id
             table_options['project'] = dataset_options['project']
-            tables[table_name] = table_options
+            tables[table_id] = table_options
 
     resources = {'resource': OrderedDict()}
 
     resources['resource']['google_bigquery_dataset'] = {
-        dataset_name: {
-            'dataset_id': dataset_name,
+        dataset_id: {
+            'dataset_id': dataset_id,
             'project': options['project'],
-        } for dataset_name, options in context['bigquery'].items()
+        } for dataset_id, options in context['bigquery'].items()
     }
 
     if tables:
         resources['resource']['google_bigquery_table'] = {
             # generated fully qualified resource name
-            ("%s_%s" % (options['dataset_id'], table_name)): {
+            ("%s_%s" % (options['dataset_id'], table_id)): {
                 'dataset_id': options['dataset_id'],
-                # TODO 'table_id' : table_id
-                'table_id': table_name,
+                'table_id': table_id,
                 'project': options['project'],
                 'schema': _generate_bigquery_schema_file(context['stackname'], options['schema']),
-            } for table_name, options in tables.items()
+            } for table_id, options in tables.items()
         }
 
     return resources

--- a/src/tests/fixtures/additional-projects/dummy-project-eu.yaml
+++ b/src/tests/fixtures/additional-projects/dummy-project-eu.yaml
@@ -31,6 +31,8 @@ defaults:
             vcl: []
             surrogate-keys: {}
         subdomains: []
+    gcp:
+        bigquery: false
     vagrant:
         box: ubuntu/trusty64 # Ubuntu 14.04
 

--- a/src/tests/fixtures/dummy1-project.json
+++ b/src/tests/fixtures/dummy1-project.json
@@ -41,6 +41,9 @@
             22
         ]
     }, 
+    "gcp": {
+        "bigquery": false
+    },
     "vagrant": {
         "box": "ubuntu/trusty64", 
         "box-url": null, 

--- a/src/tests/fixtures/dummy2-project.json
+++ b/src/tests/fixtures/dummy2-project.json
@@ -174,6 +174,9 @@
             ]
         }
     }, 
+    "gcp": {
+        "bigquery": false
+    },
     "vagrant": {
         "box": "ubuntu/trusty64", 
         "box-url": null, 

--- a/src/tests/fixtures/dummy3-project.json
+++ b/src/tests/fixtures/dummy3-project.json
@@ -168,6 +168,9 @@
             ]
         }
     }, 
+    "gcp": {
+        "bigquery": false
+    },
     "meta": {
         "description": "foo"
     }

--- a/src/tests/fixtures/projects/dummy-project.yaml
+++ b/src/tests/fixtures/projects/dummy-project.yaml
@@ -630,6 +630,19 @@ project-on-gcp:
                 #
     aws-alt: {}
 
+project-with-bigquery-datasets-only:
+    description: project on Google Cloud Platform, using BigQuery
+    domain: False
+    intdomain: False
+    # see project-on-gcp:
+    aws:
+        ec2: false
+    gcp:
+        bigquery:
+            my_dataset_{instance}:
+                project: elife-something
+    aws-alt: {}
+
 project-with-bigquery:
     description: project on Google Cloud Platform, using BigQuery
     domain: False
@@ -646,5 +659,3 @@ project-with-bigquery:
                     widgets:
                         schema: key-value
     aws-alt: {}
-
-# TODO: add project with datasets but no tables

--- a/src/tests/fixtures/projects/dummy-project.yaml
+++ b/src/tests/fixtures/projects/dummy-project.yaml
@@ -618,7 +618,7 @@ project-on-gcp:
     intdomain: False
     # I know, this should be gcp, but actually should be renamed
     # to "cloud" or "remote" or similar
-    # TODO: use separate key with 'gcp'?
+    # TODO: move onto separate key with 'gcp'?
     aws:
         ec2: false
         gcs:
@@ -626,4 +626,20 @@ project-on-gcp:
                 project: elife-something
                 # space for options
                 #
+    aws-alt: {}
+
+project-with-bigquery:
+    description: project on Google Cloud Platform, using BigQuery
+    domain: False
+    intdomain: False
+    # see project-on-gcp:
+    aws:
+        ec2: false
+    gcp:
+        bigquery:
+            #location: US
+            datasets:
+                "my-dataset-{instance}":
+                    project: elife-something
+                    tables: {}
     aws-alt: {}

--- a/src/tests/fixtures/projects/dummy-project.yaml
+++ b/src/tests/fixtures/projects/dummy-project.yaml
@@ -642,9 +642,12 @@ project-with-bigquery:
             #location: US
             # TODO: drop `datasets` indirection as there is no property that goes outside of a dataset
             datasets:
+                # TODO: change to my_dataset_{instance}
                 "my-dataset-{instance}":
                     project: elife-something
                     tables:
                         widgets:
                             schema: key-value
     aws-alt: {}
+
+# TODO: add project with datasets but no tables

--- a/src/tests/fixtures/projects/dummy-project.yaml
+++ b/src/tests/fixtures/projects/dummy-project.yaml
@@ -133,6 +133,8 @@ defaults:
             description: uses a plain Ubuntu basebox instead of an ami
             ec2:
                 ami: ami-9eaa1cf6 # Ubuntu 14.04
+    gcp:
+        bigquery: false
     vagrant:
         box: ubuntu/trusty64 # Ubuntu 14.04
         box-url: null # not needed for boxes hosted on Atlas 

--- a/src/tests/fixtures/projects/dummy-project.yaml
+++ b/src/tests/fixtures/projects/dummy-project.yaml
@@ -640,8 +640,7 @@ project-with-bigquery:
     gcp:
         bigquery:
             #location: US
-            # TODO: change to my_dataset_{instance}
-            "my-dataset-{instance}":
+            "my_dataset_{instance}":
                 project: elife-something
                 tables:
                     widgets:

--- a/src/tests/fixtures/projects/dummy-project.yaml
+++ b/src/tests/fixtures/projects/dummy-project.yaml
@@ -641,5 +641,7 @@ project-with-bigquery:
             datasets:
                 "my-dataset-{instance}":
                     project: elife-something
-                    tables: {}
+                    tables:
+                        widgets:
+                            schema: key-value.schema.csv
     aws-alt: {}

--- a/src/tests/fixtures/projects/dummy-project.yaml
+++ b/src/tests/fixtures/projects/dummy-project.yaml
@@ -640,14 +640,12 @@ project-with-bigquery:
     gcp:
         bigquery:
             #location: US
-            # TODO: drop `datasets` indirection as there is no property that goes outside of a dataset
-            datasets:
-                # TODO: change to my_dataset_{instance}
-                "my-dataset-{instance}":
-                    project: elife-something
-                    tables:
-                        widgets:
-                            schema: key-value
+            # TODO: change to my_dataset_{instance}
+            "my-dataset-{instance}":
+                project: elife-something
+                tables:
+                    widgets:
+                        schema: key-value
     aws-alt: {}
 
 # TODO: add project with datasets but no tables

--- a/src/tests/fixtures/projects/dummy-project.yaml
+++ b/src/tests/fixtures/projects/dummy-project.yaml
@@ -638,10 +638,11 @@ project-with-bigquery:
     gcp:
         bigquery:
             #location: US
+            # TODO: drop `datasets` indirection as there is no property that goes outside of a dataset
             datasets:
                 "my-dataset-{instance}":
                     project: elife-something
                     tables:
                         widgets:
-                            schema: key-value.schema.csv
+                            schema: key-value
     aws-alt: {}

--- a/src/tests/fixtures/projects/dummy-project2.yaml
+++ b/src/tests/fixtures/projects/dummy-project2.yaml
@@ -71,6 +71,8 @@ defaults:
             description: uses a plain Ubuntu basebox instead of an ami
             ec2:
                 ami: ami-9eaa1cf6 # Ubuntu 14.04
+    gcp:
+        bigquery: false
     vagrant:
         box: ubuntu/trusty64 # Ubuntu 14.04
         box-url: null # not needed for boxes hosted on Atlas 

--- a/src/tests/test_buildercore_project.py
+++ b/src/tests/test_buildercore_project.py
@@ -14,7 +14,7 @@ ALL_PROJECTS = [
     'project-with-cluster', 'project-with-cluster-suppressed', 'project-with-cluster-overrides', 'project-with-cluster-empty',
     'project-with-stickiness', 'project-with-multiple-elb-listeners',
     'project-with-cluster-integration-tests', 'project-with-db-params', 'project-with-rds-only', 'project-with-rds-encryption', 'project-with-elasticache-redis', 'project-with-multiple-elasticaches', 'project-with-fully-overridden-elasticaches',
-    'project-on-gcp', 'project-with-bigquery',
+    'project-on-gcp', 'project-with-bigquery-datasets-only', 'project-with-bigquery',
 ]
 
 class TestProject(base.BaseCase):

--- a/src/tests/test_buildercore_project.py
+++ b/src/tests/test_buildercore_project.py
@@ -14,7 +14,7 @@ ALL_PROJECTS = [
     'project-with-cluster', 'project-with-cluster-suppressed', 'project-with-cluster-overrides', 'project-with-cluster-empty',
     'project-with-stickiness', 'project-with-multiple-elb-listeners',
     'project-with-cluster-integration-tests', 'project-with-db-params', 'project-with-rds-only', 'project-with-rds-encryption', 'project-with-elasticache-redis', 'project-with-multiple-elasticaches', 'project-with-fully-overridden-elasticaches',
-    'project-on-gcp',
+    'project-on-gcp', 'project-with-bigquery',
 ]
 
 class TestProject(base.BaseCase):

--- a/src/tests/test_buildercore_terraform.py
+++ b/src/tests/test_buildercore_terraform.py
@@ -451,6 +451,7 @@ class TestBuildercoreTerraform(base.BaseCase):
         self.assertEqual(table, {
             'dataset_id': 'my-dataset-prod',
             'table_id': 'widgets',
+            'project': 'elife-something',
             'schema': '${file("key-value.json")}',
         })
 

--- a/src/tests/test_buildercore_terraform.py
+++ b/src/tests/test_buildercore_terraform.py
@@ -441,15 +441,15 @@ class TestBuildercoreTerraform(base.BaseCase):
         context = cfngen.build_context('project-with-bigquery', **extra)
         terraform_template = terraform.render(context)
         template = self._parse_template(terraform_template)
-        dataset = template['resource']['google_bigquery_dataset']['my-dataset-prod']
+        dataset = template['resource']['google_bigquery_dataset']['my_dataset_prod']
         self.assertEqual(dataset, {
-            'dataset_id': 'my-dataset-prod',
+            'dataset_id': 'my_dataset_prod',
             'project': 'elife-something',
         })
 
-        table = template['resource']['google_bigquery_table']['my-dataset-prod_widgets']
+        table = template['resource']['google_bigquery_table']['my_dataset_prod_widgets']
         self.assertEqual(table, {
-            'dataset_id': 'my-dataset-prod',
+            'dataset_id': 'my_dataset_prod',
             'table_id': 'widgets',
             'project': 'elife-something',
             'schema': '${file("key-value.json")}',

--- a/src/tests/test_buildercore_terraform.py
+++ b/src/tests/test_buildercore_terraform.py
@@ -434,7 +434,22 @@ class TestBuildercoreTerraform(base.BaseCase):
             'project': 'elife-something',
         })
 
-    def test_bigquery_template(self):
+    def test_bigquery_datasets_only(self):
+        extra = {
+            'stackname': 'project-with-bigquery-datasets-only--prod',
+        }
+        context = cfngen.build_context('project-with-bigquery-datasets-only', **extra)
+        terraform_template = terraform.render(context)
+        template = self._parse_template(terraform_template)
+        dataset = template['resource']['google_bigquery_dataset']['my_dataset_prod']
+        self.assertEqual(dataset, {
+            'dataset_id': 'my_dataset_prod',
+            'project': 'elife-something',
+        })
+
+        self.assertNotIn('google_bigquery_table', template['resource'])
+
+    def test_bigquery_full_template(self):
         extra = {
             'stackname': 'project-with-bigquery--prod',
         }

--- a/src/tests/test_buildercore_terraform.py
+++ b/src/tests/test_buildercore_terraform.py
@@ -434,6 +434,19 @@ class TestBuildercoreTerraform(base.BaseCase):
             'project': 'elife-something',
         })
 
+    def test_bigquery_template(self):
+        extra = {
+            'stackname': 'project-with-bigquery--prod',
+        }
+        context = cfngen.build_context('project-with-bigquery', **extra)
+        terraform_template = terraform.render(context)
+        template = self._parse_template(terraform_template)
+        service = template['resource']['google_bigquery_dataset']['my-dataset-prod']
+        self.assertEqual(service, {
+            'dataset_id': 'my-dataset-prod',
+            'project': 'elife-something',
+        })
+
     def test_sanity_of_rendered_log_format(self):
         def _render_log_format_with_dummy_template():
             return re.sub(

--- a/src/tests/test_buildercore_terraform.py
+++ b/src/tests/test_buildercore_terraform.py
@@ -426,8 +426,8 @@ class TestBuildercoreTerraform(base.BaseCase):
         context = cfngen.build_context('project-on-gcp', **extra)
         terraform_template = terraform.render(context)
         template = self._parse_template(terraform_template)
-        service = template['resource']['google_storage_bucket']['widgets-prod']
-        self.assertEqual(service, {
+        bucket = template['resource']['google_storage_bucket']['widgets-prod']
+        self.assertEqual(bucket, {
             'name': 'widgets-prod',
             'location': 'us-east4',
             'storage_class': 'REGIONAL',
@@ -441,10 +441,16 @@ class TestBuildercoreTerraform(base.BaseCase):
         context = cfngen.build_context('project-with-bigquery', **extra)
         terraform_template = terraform.render(context)
         template = self._parse_template(terraform_template)
-        service = template['resource']['google_bigquery_dataset']['my-dataset-prod']
-        self.assertEqual(service, {
+        dataset = template['resource']['google_bigquery_dataset']['my-dataset-prod']
+        self.assertEqual(dataset, {
             'dataset_id': 'my-dataset-prod',
             'project': 'elife-something',
+        })
+
+        table = template['resource']['google_bigquery_table']['my-dataset-prod_widgets']
+        self.assertEqual(table, {
+            'dataset_id': 'my-dataset-prod',
+            'table_id': 'widgets',
         })
 
     def test_sanity_of_rendered_log_format(self):

--- a/src/tests/test_buildercore_terraform.py
+++ b/src/tests/test_buildercore_terraform.py
@@ -451,6 +451,7 @@ class TestBuildercoreTerraform(base.BaseCase):
         self.assertEqual(table, {
             'dataset_id': 'my-dataset-prod',
             'table_id': 'widgets',
+            'schema': '${file("key-value.json")}',
         })
 
     def test_sanity_of_rendered_log_format(self):


### PR DESCRIPTION
For https://github.com/elifesciences/issues/issues/4461

Adds a `gcp` top-level configuration akin to `aws` (with no support for `gcp-alt` yet). This key allows to configure one or more BigQuery datasets, each with zero or more tables. Each table has a schema to be stored inside a folder here with a codename.

Has been used to create the [`iiif` table](https://console.cloud.google.com/bigquery?authuser=1&folder=&organizationId=567577722038&project=elife-fastly&p=elife-fastly&d=test&t=iiif&page=table) in the `test` dataset in the `elife-fastly` project.

Various TODOs are left throughout the code to be addressed before merging.