### PR TITLE
Reduce default Fastly TTL

### DIFF
--- a/src/buildercore/fastly/vcl/main.vcl
+++ b/src/buildercore/fastly/vcl/main.vcl
@@ -64,7 +64,7 @@ sub vcl_fetch {
     # keep the ttl here
   } else {
     # apply the default ttl
-    set beresp.ttl = 3600s;
+    set beresp.ttl = 300s;
   }
 
   return(deliver);


### PR DESCRIPTION
If a response doesn't have a `Cache-Control` header it should be treated as misconfiguration. But in the meantime, a 1-hour TTL can create problems (especially with shielding turn on), so this reduces it to 5 minutes.

Checklist:

- [x] `api-gateway--end2end`
- [x] `api-gateway--continuumtest`
- [x] `api-gateway--prod`
- [x] `generic-cdn--end2end`
- [x] `generic-cdn--continuumtest`
- [x] `generic-cdn--prod`
- [x] `iiif--end2end`
- [x] `iiif--continuumtest`
- [x] `iiif--prod`
- [x] `journal--end2end`
- [x] `journal--continuumtest`
- [x] `journal--prod`