### PR TITLE
Always treat aws-alt keys as strings

### DIFF
--- a/src/buildercore/core.py
+++ b/src/buildercore/core.py
@@ -578,6 +578,9 @@ def find_region(stackname=None):
     if more than one region available, it will raise an MultipleRegionsError.
     until we have some means of supporting multiple regions, this is the best solution"""
     if stackname:
+        # TODO: should use context, not project data
+        # as updates in project data do not immediately affect existing stacks
+        # which reside in a region
         pdata = project_data_for_stackname(stackname)
         return pdata['aws']['region']
 

--- a/src/tests/test_buildercore_project_files.py
+++ b/src/tests/test_buildercore_project_files.py
@@ -24,3 +24,13 @@ class TestFiles(base.BaseCase):
         self.assertIn('rds', list(dummy2['aws-alt']['alt-config1'].keys()))
         self.assertNotIn('elb', list(dummy2['aws-alt']['alt-config1'].keys()))
         self.assertNotIn('cloudfront', list(dummy2['aws-alt']['alt-config1'].keys()))
+
+    def test_project_aws_alt_integer_names_should_be_converted_to_string(self):
+        self.assertEqual(
+            files.project_aws_alt(
+                {1804: {'ec2': {'ami': 'ami-22222222'}}},
+                project_base_aws={},
+                global_aws={}
+            ),
+            {'1804': {'ec2': {'ami': 'ami-22222222'}}},
+        )


### PR DESCRIPTION
Otherwise `alt_config` arguments passed to `launch` are not matched, being strings vs. YAML integers