### PR TITLE
Allow destroying someone else's stack

### DIFF
--- a/src/buildercore/cloudformation.py
+++ b/src/buildercore/cloudformation.py
@@ -218,7 +218,7 @@ def destroy(stackname, context):
         # ClientError(u'An error occurred (ValidationError) when calling the DescribeStacks operation: Stack with id basebox--1234 does not exist',)
         # e.operation_name == 'DescribeStacks'
         # e.response['Error'] == {'Message': 'Stack with id basebox--1234 does not exist', 'Code': 'ValidationError', 'Type': 'Sender'}
-        if ex.operation_name == 'DescribeStacks' && "does not exist" in err['Message']:
+        if ex.operation_name == 'DescribeStacks' and "does not exist" in err['Message']:
             LOG.info("Stack %s does not exist on CloudFormation", stackname)
             return
 

--- a/src/buildercore/cloudformation.py
+++ b/src/buildercore/cloudformation.py
@@ -85,6 +85,7 @@ def bootstrap(stackname, context):
     parameters = []
     on_start = _noop
     on_error = _noop
+    # TODO: should use context by this point
     if pdata['aws']['ec2']:
         parameters.append({'ParameterKey': 'KeyName', 'ParameterValue': stackname})
         on_start = lambda: keypair.create_keypair(stackname)

--- a/src/buildercore/cloudformation.py
+++ b/src/buildercore/cloudformation.py
@@ -192,10 +192,6 @@ def _update_template(stackname, template):
     call_while(stack_is_updating, interval=2, timeout=7200, update_msg=waiting, done_msg=done)
 
 def destroy(stackname, context):
-    stack_body = core.stack_json(stackname)
-    if json.loads(stack_body) == EMPTY_TEMPLATE:
-        return
-
     try:
         core.describe_stack(stackname).delete()
 
@@ -216,7 +212,15 @@ def destroy(stackname, context):
         err = ex.response['Error']
         # ll: [400: ValidationError] No updates are to be performed (request-id: dc28fd8f-4456-11e8-8851-d9346a742012)
         if "No updates are to be performed" in err['Message']:
+            LOG.info("Stack %s does not need updates on CloudFormation", stackname)
             return
+        # ClientError(u'An error occurred (ValidationError) when calling the DescribeStacks operation: Stack with id basebox--1234 does not exist',)
+        # e.operation_name == 'DescribeStacks'
+        # e.response['Error'] == {'Message': 'Stack with id basebox--1234 does not exist', 'Code': 'ValidationError', 'Type': 'Sender'}
+        if ex.operation_name == 'DescribeStacks' && "does not exist" in err['Message']:
+            LOG.info("Stack %s does not exist on CloudFormation", stackname)
+            return
+
         LOG.exception(msg, meta['HTTPStatusCode'], err['Code'], err['Message'], meta['RequestId'], extra={'response': ex.response})
         # ll: ClientError: An error occurred (ValidationError) when calling the DeleteStack operation: Stack [arn:aws:cloudformation:us-east-1:512686554592:stack/elife-xpub--prod/a0b1af 60-793f-11e8-bd5a-5044763dbb7b] cannot be deleted while in status UPDATE_COMPLETE_CLEANUP_IN_PROGRESS
         raise

--- a/src/cfn.py
+++ b/src/cfn.py
@@ -141,7 +141,7 @@ def generate_stack_from_input(pname, instance_id=None, alt_config=None):
                 alt_config = utils._pick('alternative config', alt_config_choices, helpfn=helpfn)
             if alt_config != default:
                 more_context['alt-config'] = alt_config
-    # TODO: return the templates used here, so that they can be passed down to 
+    # TODO: return the templates used here, so that they can be passed down to
     # bootstrap.create_stack() without relying on them implicitly existing
     # on the filesystem
     cfngen.generate_stack(pname, **more_context)

--- a/src/cfn.py
+++ b/src/cfn.py
@@ -141,6 +141,9 @@ def generate_stack_from_input(pname, instance_id=None, alt_config=None):
                 alt_config = utils._pick('alternative config', alt_config_choices, helpfn=helpfn)
             if alt_config != default:
                 more_context['alt-config'] = alt_config
+    # TODO: return the templates used here, so that they can be passed down to 
+    # bootstrap.create_stack() without relying on them implicitly existing
+    # on the filesystem
     cfngen.generate_stack(pname, **more_context)
     return stackname
 


### PR DESCRIPTION
We cannot rely on a local `.cfn/stacks/*.json` file, as it may have been
launched from another node. Better to use as the source of truth the
CloudFormation API, which we were calling anyway.

Other operations don't have to rely on a template at all as they can regenerate it from `context` which is synced through S3. For destroy this would be overkill, especially if the stack is in a broken state.