### PR TITLE
Fastly logs delivery to BigQuery

### DIFF
--- a/docs/vault.md
+++ b/docs/vault.md
@@ -33,3 +33,22 @@ To lookup information about a token:
 To revoke a token:
 
 `./bldr vault.token_revoke:<token>`
+
+## Reading and writing secrets (admin only)
+
+Some commands can be manually run to directly interact with Vault's key-value secrets store:
+
+```
+$ VAULT_ADDR=https://master-server.elifesciences.org:8200 vault kv get secret/builder/apikey/fastly-gcs-logging
+Key                 Value
+---                 -----
+email               fastly@elife-fastly.iam.gserviceaccount.com
+secret_key          -----BEGIN PRIVATE KEY-----
+...
+-----END PRIVATE KEY-----
+```
+
+```
+$ VAULT_ADDR=https://master-server.elifesciences.org:8200 vault kv put secret/builder/apikey/fastly-gcp-logging email=fastly@elife-fastly.iam.gserviceaccount.com secret_key=@../../fastly-gcp-logging.secret
+Success! Data written to: secret/builder/apikey/fastly-gcp-logging
+```

--- a/projects/elife.yaml
+++ b/projects/elife.yaml
@@ -834,6 +834,10 @@ generic-cdn:
                         article-figure-video:
                             path: /articles/26866/elife-26866-fig3-video1.mp4
                             expected: "article/26866 article/26866/videos"
+            bigquerylogging:
+                project: "elife-fastly"
+                dataset: "{instance}"
+                table: "generic_cdn"
     aws-alt:
         # have to specify this because otherwise configuration such as `fresh` inherited from defaults won't see the ec2: false in `aws:` and test_validation.py will fail for all of them?
         fresh:
@@ -860,6 +864,8 @@ generic-cdn:
                     bucket: continuumtest-elife-fastly
                     path: generic-cdn--continuumtest/
                     period: 600
+                bigquerylogging:
+                    dataset: "staging"
         prod:
             fastly:
                 subdomains:
@@ -2107,7 +2113,6 @@ fastly-logs:
     aws:
         ec2: false
         gcs:
-            # TODO: recreate `continuumtest` as `staging`
             "{instance}-elife-fastly":
                 project: elife-fastly
     gcp:
@@ -2116,6 +2121,10 @@ fastly-logs:
                 project: elife-fastly
                 tables:
                     api_gateway:
+                        schema: ./src/buildercore/bigquery/schemas/fastly-logs-201809.json
+                    generic_cdn:
+                        schema: ./src/buildercore/bigquery/schemas/fastly-logs-201809.json
+                    journal:
                         schema: ./src/buildercore/bigquery/schemas/fastly-logs-201809.json
                     iiif:
                         schema: ./src/buildercore/bigquery/schemas/fastly-logs-201809.json

--- a/projects/elife.yaml
+++ b/projects/elife.yaml
@@ -151,6 +151,7 @@ defaults:
                     - 151.101.130.217
                     - 151.101.194.217
             gcslogging: false
+            bigquerylogging: false
             healthcheck: false
             errors: false
             vcl:
@@ -403,6 +404,10 @@ api-gateway:
                 bucket: "{instance}-elife-fastly"
                 path: "api-gateway--{instance}/"
                 period: 600
+            bigquerylogging:
+                project: "elife-fastly"
+                dataset: "{instance}"
+                table: "api_gateway"
     aws-alt:
         standalone:
             # for now a copy of standalone1404
@@ -2107,6 +2112,8 @@ fastly-logs:
             "{instance}":
                 project: elife-fastly
                 tables:
+                    api_gateway:
+                        schema: ./src/buildercore/bigquery/schemas/fastly-logs-201809.json
                     iiif:
                         schema: ./src/buildercore/bigquery/schemas/fastly-logs-201809.json
     aws-alt: {}

--- a/projects/elife.yaml
+++ b/projects/elife.yaml
@@ -418,7 +418,10 @@ api-gateway:
                 masterless: true
             fastly: false
         end2end: {}
-        continuumtest: {}
+        continuumtest:
+            fastly:
+                bigquerylogging:
+                    dataset: "staging"
         prod:
             fastly:
                 subdomains:

--- a/projects/elife.yaml
+++ b/projects/elife.yaml
@@ -1640,6 +1640,10 @@ iiif:
                 bucket: "{instance}-elife-fastly"
                 path: "iiif--{instance}/"
                 period: 600
+            bigquerylogging:
+                project: "elife-fastly"
+                dataset: "{instance}"
+                table: "iiif"
             healthcheck:
                 path: /ping-fastly
                 check-interval: 10000
@@ -1738,6 +1742,9 @@ iiif:
                     - https
                 healthcheck:
                     path: /
+            fastly:
+                bigquerylogging:
+                    dataset: "staging"
         prod:
             ports:
                 - 22

--- a/projects/elife.yaml
+++ b/projects/elife.yaml
@@ -2099,6 +2099,7 @@ fastly-logs:
     aws:
         ec2: false
         gcs:
+            # TODO: recreate `continuumtest` as `staging`
             "{instance}-elife-fastly":
                 project: elife-fastly
     gcp:

--- a/projects/elife.yaml
+++ b/projects/elife.yaml
@@ -503,6 +503,10 @@ journal:
                     bucket: "{instance}-elife-fastly"
                     path: "journal--{instance}/"
                     period: 600
+                bigquerylogging:
+                    project: "elife-fastly"
+                    dataset: "{instance}"
+                    table: "journal"
         continuumtest:
             elasticache:
                 engine: redis
@@ -539,6 +543,10 @@ journal:
                     bucket: "{instance}-elife-fastly"
                     path: "journal--{instance}/"
                     period: 600
+                bigquerylogging:
+                    project: "elife-fastly"
+                    dataset: "staging"
+                    table: "journal"
         prod:
             description: prod environment for journal. ELB on top of multiple EC2 instances
             ec2:
@@ -598,6 +606,10 @@ journal:
                     bucket: "{instance}-elife-fastly"
                     path: "journal--{instance}/"
                     period: 600
+                bigquerylogging:
+                    project: "elife-fastly"
+                    dataset: "{instance}"
+                    table: "journal"
     vagrant:
         box: ubuntu/trusty64 # Ubuntu 14.04, deprecated
         ram: 4096

--- a/src/buildercore/cfngen.py
+++ b/src/buildercore/cfngen.py
@@ -391,6 +391,13 @@ def build_context_fastly(pdata, context):
 
         return gcslogging
 
+    def _parameterize_bigquerylogging(bigquerylogging):
+        if bigquerylogging:
+            bigquerylogging['dataset'] = _parameterize(bigquerylogging['dataset'])
+            bigquerylogging['table'] = _parameterize(bigquerylogging['table'])
+
+        return bigquerylogging
+
     context['fastly'] = False
     if pdata['aws'].get('fastly'):
         backends = pdata['aws']['fastly'].get('backends', OrderedDict({}))
@@ -404,6 +411,7 @@ def build_context_fastly(pdata, context):
             'healthcheck': pdata['aws']['fastly']['healthcheck'],
             'errors': pdata['aws']['fastly']['errors'],
             'gcslogging': _parameterize_gcslogging(pdata['aws']['fastly']['gcslogging']),
+            'biguerylogging': _parameterize_bigquerylogging(pdata['aws']['fastly']['bigquerylogging']),
             'vcl': pdata['aws']['fastly']['vcl'],
             'surrogate-keys': pdata['aws']['fastly']['surrogate-keys'],
         }

--- a/src/buildercore/cfngen.py
+++ b/src/buildercore/cfngen.py
@@ -411,7 +411,7 @@ def build_context_fastly(pdata, context):
             'healthcheck': pdata['aws']['fastly']['healthcheck'],
             'errors': pdata['aws']['fastly']['errors'],
             'gcslogging': _parameterize_gcslogging(pdata['aws']['fastly']['gcslogging']),
-            'biguerylogging': _parameterize_bigquerylogging(pdata['aws']['fastly']['bigquerylogging']),
+            'bigquerylogging': _parameterize_bigquerylogging(pdata['aws']['fastly']['bigquerylogging']),
             'vcl': pdata['aws']['fastly']['vcl'],
             'surrogate-keys': pdata['aws']['fastly']['surrogate-keys'],
         }

--- a/src/buildercore/terraform.py
+++ b/src/buildercore/terraform.py
@@ -212,7 +212,7 @@ def render_fastly(context):
             'project_id': bigquerylogging['project'],
             'dataset': bigquerylogging['dataset'],
             'table': bigquerylogging['table'],
-        #    'format': FASTLY_LOG_FORMAT,
+            'format': FASTLY_LOG_FORMAT,
         #    'email': "${data.%s.%s.data[\"email\"]}" % (DATA_TYPE_VAULT_GENERIC_SECRET, DATA_NAME_VAULT_GCS_LOGGING),
         #    'secret_key': "${data.%s.%s.data[\"secret_key\"]}" % (DATA_TYPE_VAULT_GENERIC_SECRET, DATA_NAME_VAULT_GCS_LOGGING),
         #}

--- a/src/buildercore/terraform.py
+++ b/src/buildercore/terraform.py
@@ -19,6 +19,7 @@ DATA_TYPE_VAULT_GENERIC_SECRET = 'vault_generic_secret'
 DATA_TYPE_HTTP = 'http'
 DATE_TYPE_TEMPLATE = 'template_file'
 DATA_NAME_VAULT_GCS_LOGGING = 'fastly-gcs-logging'
+DATA_NAME_VAULT_GCP_LOGGING = 'fastly-gcp-logging'
 DATA_NAME_VAULT_FASTLY_API_KEY = 'fastly'
 
 # keys to lookup in Vault
@@ -26,6 +27,7 @@ DATA_NAME_VAULT_FASTLY_API_KEY = 'fastly'
 #     VAULT_ADDR=https://...:8200 vault put secret/builder/apikey/fastly-gcs-logging email=... secret_key=@~/file.json
 VAULT_PATH_FASTLY = 'secret/builder/apikey/fastly'
 VAULT_PATH_FASTLY_GCS_LOGGING = 'secret/builder/apikey/fastly-gcs-logging'
+VAULT_PATH_FASTLY_GCP_LOGGING = 'secret/builder/apikey/fastly-gcp-logging'
 
 FASTLY_GZIP_TYPES = ['text/html', 'application/x-javascript', 'text/css', 'application/javascript',
                      'text/javascript', 'application/json', 'application/vnd.ms-fontobject',
@@ -213,13 +215,13 @@ def render_fastly(context):
             'dataset': bigquerylogging['dataset'],
             'table': bigquerylogging['table'],
             'format': FASTLY_LOG_FORMAT,
-        #    'email': "${data.%s.%s.data[\"email\"]}" % (DATA_TYPE_VAULT_GENERIC_SECRET, DATA_NAME_VAULT_GCS_LOGGING),
-        #    'secret_key': "${data.%s.%s.data[\"secret_key\"]}" % (DATA_TYPE_VAULT_GENERIC_SECRET, DATA_NAME_VAULT_GCS_LOGGING),
-        #}
-        #data[DATA_TYPE_VAULT_GENERIC_SECRET] = {
-        #    DATA_NAME_VAULT_GCS_LOGGING: {
-        #        'path': VAULT_PATH_FASTLY_GCS_LOGGING,
-        #    }
+            'email': "${data.%s.%s.data[\"email\"]}" % (DATA_TYPE_VAULT_GENERIC_SECRET, DATA_NAME_VAULT_GCP_LOGGING),
+            'secret_key': "${data.%s.%s.data[\"secret_key\"]}" % (DATA_TYPE_VAULT_GENERIC_SECRET, DATA_NAME_VAULT_GCP_LOGGING),
+        }
+        data[DATA_TYPE_VAULT_GENERIC_SECRET] = {
+            DATA_NAME_VAULT_GCP_LOGGING: {
+                'path': VAULT_PATH_FASTLY_GCP_LOGGING,
+            }
         }
 
     if vcl_constant_snippets or vcl_templated_snippets:

--- a/src/buildercore/terraform.py
+++ b/src/buildercore/terraform.py
@@ -74,6 +74,16 @@ FASTLY_LOG_FORMAT = """{
 # see https://docs.fastly.com/guides/streaming-logs/changing-log-line-formats#available-message-formats
 FASTLY_LOG_LINE_PREFIX = 'blank' # no prefix
 
+# keeps different logging configurations unique in the syslog implementation
+# used by Fastly, avoiding
+#     fastly_service_v1.fastly-cdn: 409 - Conflict:
+#     Title:  Duplicate record
+#     Detail: Duplicate logging_syslog: 'default'
+FASTLY_LOG_UNIQUE_IDENTIFIERS = {
+    'gcs': 'default', # historically the first one
+    'bigquery': 'bigquery',
+}
+
 # at the moment VCL snippets are unsupported, this can be worked
 # around by using a full VCL
 # https://github.com/terraform-providers/terraform-provider-fastly/issues/7 tracks when snippets could become available in Terraform
@@ -190,7 +200,7 @@ def render_fastly(context):
     if context['fastly']['gcslogging']:
         gcslogging = context['fastly']['gcslogging']
         tf_file['resource'][RESOURCE_TYPE_FASTLY][RESOURCE_NAME_FASTLY]['gcslogging'] = {
-            'name': 'default',
+            'name': FASTLY_LOG_UNIQUE_IDENTIFIERS['gcs'],
             'bucket_name': gcslogging['bucket'],
             # TODO: validate it starts with /
             'path': gcslogging['path'],
@@ -210,7 +220,7 @@ def render_fastly(context):
     if context['fastly']['bigquerylogging']:
         bigquerylogging = context['fastly']['bigquerylogging']
         tf_file['resource'][RESOURCE_TYPE_FASTLY][RESOURCE_NAME_FASTLY]['bigquerylogging'] = {
-            'name': 'default',
+            'name': FASTLY_LOG_UNIQUE_IDENTIFIERS['bigquery'],
             'project_id': bigquerylogging['project'],
             'dataset': bigquerylogging['dataset'],
             'table': bigquerylogging['table'],

--- a/src/buildercore/terraform.py
+++ b/src/buildercore/terraform.py
@@ -612,8 +612,8 @@ def destroy(stackname, context):
     terraform_directory = join(TERRAFORM_DIR, stackname)
     shutil.rmtree(terraform_directory)
 
-# TODO: not a great function name. 'stack_tform_path' ? 'tform_stackfile_path' ?
-def _file_path(stackname, name, extension='tf.json'):
+def _file_path_for_generation(stackname, name, extension='tf.json'):
+    "builds a path for a file to be placed in conf.TERRAFORM_DIR"
     return join(TERRAFORM_DIR, stackname, '%s.%s' % (name, extension))
 
 def _open(stackname, name, extension='tf.json', mode='r'):
@@ -625,4 +625,4 @@ def _open(stackname, name, extension='tf.json', mode='r'):
     if os.path.exists(deprecated_path):
         os.remove(deprecated_path)
 
-    return open(_file_path(stackname, name, extension), mode)
+    return open(_file_path_for_generation(stackname, name, extension), mode)

--- a/src/buildercore/terraform.py
+++ b/src/buildercore/terraform.py
@@ -9,7 +9,7 @@ from . import fastly
 from functools import reduce
 
 EMPTY_TEMPLATE = '{}'
-PROVIDER_FASTLY_VERSION = '0.1.4',
+PROVIDER_FASTLY_VERSION = '0.4.0',
 PROVIDER_VAULT_VERSION = '1.1'
 
 RESOURCE_TYPE_FASTLY = 'fastly_service_v1'

--- a/src/buildercore/terraform.py
+++ b/src/buildercore/terraform.py
@@ -453,6 +453,8 @@ def render_bigquery(context):
             schema_ref = '${file("%s")}' % schema_file
 
         tf_file['resource']['google_bigquery_table'][fqrn] = {
+            # TODO: this should refer to the dataset resource to express the implicit dependency
+            # otherwise a table can be created before the dataset, which fails
             'dataset_id': table_options['dataset_id'], # "dataset"
             'table_id': table_id, # "csv_report_380"
             'project': table_options['project'], # "elife-data-pipeline"

--- a/src/buildercore/terraform.py
+++ b/src/buildercore/terraform.py
@@ -464,6 +464,9 @@ def render_bigquery(context):
     if not tf_file['resource']['google_bigquery_table']:
         del tf_file['resource']['google_bigquery_table']
 
+    if not tf_file['data'][DATA_TYPE_HTTP]:
+        del tf_file['data'][DATA_TYPE_HTTP]
+
     return tf_file
 
 def write_template(stackname, contents):

--- a/src/buildercore/terraform.py
+++ b/src/buildercore/terraform.py
@@ -205,6 +205,23 @@ def render_fastly(context):
             }
         }
 
+    if context['fastly']['bigquerylogging']:
+        bigquerylogging = context['fastly']['bigquerylogging']
+        tf_file['resource'][RESOURCE_TYPE_FASTLY][RESOURCE_NAME_FASTLY]['bigquerylogging'] = {
+            'name': 'default',
+            'project_id': bigquerylogging['project'],
+            'dataset': bigquerylogging['dataset'],
+            'table': bigquerylogging['table'],
+        #    'format': FASTLY_LOG_FORMAT,
+        #    'email': "${data.%s.%s.data[\"email\"]}" % (DATA_TYPE_VAULT_GENERIC_SECRET, DATA_NAME_VAULT_GCS_LOGGING),
+        #    'secret_key': "${data.%s.%s.data[\"secret_key\"]}" % (DATA_TYPE_VAULT_GENERIC_SECRET, DATA_NAME_VAULT_GCS_LOGGING),
+        #}
+        #data[DATA_TYPE_VAULT_GENERIC_SECRET] = {
+        #    DATA_NAME_VAULT_GCS_LOGGING: {
+        #        'path': VAULT_PATH_FASTLY_GCS_LOGGING,
+        #    }
+        }
+
     if vcl_constant_snippets or vcl_templated_snippets:
         # constant snippets
         tf_file['resource'][RESOURCE_TYPE_FASTLY][RESOURCE_NAME_FASTLY]['vcl'] = [

--- a/src/buildercore/terraform.py
+++ b/src/buildercore/terraform.py
@@ -455,7 +455,7 @@ def render_bigquery(context):
         tf_file['resource']['google_bigquery_table'][fqrn] = {
             # TODO: this should refer to the dataset resource to express the implicit dependency
             # otherwise a table can be created before the dataset, which fails
-            'dataset_id': table_options['dataset_id'], # "dataset"
+            'dataset_id': "${google_bigquery_dataset.%s.dataset_id}" % dataset_id, # "dataset"
             'table_id': table_id, # "csv_report_380"
             'project': table_options['project'], # "elife-data-pipeline"
             'schema': schema_ref,

--- a/src/buildercore/terraform.py
+++ b/src/buildercore/terraform.py
@@ -107,6 +107,7 @@ def render_fastly(context):
     request_settings = []
     headers = []
     data = {}
+    data[DATA_TYPE_VAULT_GENERIC_SECRET] = {}
     vcl_constant_snippets = context['fastly']['vcl']
     vcl_templated_snippets = OrderedDict()
 
@@ -201,10 +202,9 @@ def render_fastly(context):
             'email': "${data.%s.%s.data[\"email\"]}" % (DATA_TYPE_VAULT_GENERIC_SECRET, DATA_NAME_VAULT_GCS_LOGGING),
             'secret_key': "${data.%s.%s.data[\"secret_key\"]}" % (DATA_TYPE_VAULT_GENERIC_SECRET, DATA_NAME_VAULT_GCS_LOGGING),
         }
-        data[DATA_TYPE_VAULT_GENERIC_SECRET] = {
-            DATA_NAME_VAULT_GCS_LOGGING: {
-                'path': VAULT_PATH_FASTLY_GCS_LOGGING,
-            }
+        # TODO: refactor to TerraformTemplate().add_data([DATA_TYPE_VAULT_GENERIC_SECRET, DATA_NAME_VAULT_GCS_LOGGING, 'path'], VAULT_PATH_FASTLY_GCS_LOGGING)
+        data[DATA_TYPE_VAULT_GENERIC_SECRET][DATA_NAME_VAULT_GCS_LOGGING] = {
+            'path': VAULT_PATH_FASTLY_GCS_LOGGING,
         }
 
     if context['fastly']['bigquerylogging']:
@@ -218,10 +218,8 @@ def render_fastly(context):
             'email': "${data.%s.%s.data[\"email\"]}" % (DATA_TYPE_VAULT_GENERIC_SECRET, DATA_NAME_VAULT_GCP_LOGGING),
             'secret_key': "${data.%s.%s.data[\"secret_key\"]}" % (DATA_TYPE_VAULT_GENERIC_SECRET, DATA_NAME_VAULT_GCP_LOGGING),
         }
-        data[DATA_TYPE_VAULT_GENERIC_SECRET] = {
-            DATA_NAME_VAULT_GCP_LOGGING: {
-                'path': VAULT_PATH_FASTLY_GCP_LOGGING,
-            }
+        data[DATA_TYPE_VAULT_GENERIC_SECRET][DATA_NAME_VAULT_GCP_LOGGING] = {
+            'path': VAULT_PATH_FASTLY_GCP_LOGGING,
         }
 
     if vcl_constant_snippets or vcl_templated_snippets:
@@ -291,6 +289,9 @@ def render_fastly(context):
 
     if request_settings:
         tf_file['resource'][RESOURCE_TYPE_FASTLY][RESOURCE_NAME_FASTLY]['request_setting'] = request_settings
+
+    if not data[DATA_TYPE_VAULT_GENERIC_SECRET]:
+        del data[DATA_TYPE_VAULT_GENERIC_SECRET]
 
     if data:
         tf_file['data'] = data

--- a/src/buildercore/terraform.py
+++ b/src/buildercore/terraform.py
@@ -467,6 +467,9 @@ def render_bigquery(context):
     if not tf_file['data'][DATA_TYPE_HTTP]:
         del tf_file['data'][DATA_TYPE_HTTP]
 
+    if not tf_file['data']:
+        del tf_file['data']
+
     return tf_file
 
 def write_template(stackname, contents):

--- a/src/buildercore/terraform.py
+++ b/src/buildercore/terraform.py
@@ -464,7 +464,7 @@ def render_bigquery(context):
             schema_ref = '${file("%s")}' % schema_file
 
         tf_file['resource']['google_bigquery_table'][fqrn] = {
-            # TODO: this should refer to the dataset resource to express the implicit dependency
+            # this refers to the dataset resource to express the implicit dependency
             # otherwise a table can be created before the dataset, which fails
             'dataset_id': "${google_bigquery_dataset.%s.dataset_id}" % dataset_id, # "dataset"
             'table_id': table_id, # "csv_report_380"

--- a/src/tests/fixtures/additional-projects/dummy-project-eu.yaml
+++ b/src/tests/fixtures/additional-projects/dummy-project-eu.yaml
@@ -26,6 +26,7 @@ defaults:
             default-ttl: 3600 # seconds
             shield: false
             gcslogging: false
+            bigquerylogging: false
             healthcheck: false
             errors: false
             vcl: []

--- a/src/tests/fixtures/projects/dummy-project.yaml
+++ b/src/tests/fixtures/projects/dummy-project.yaml
@@ -108,6 +108,7 @@ defaults:
             default-ttl: 3600 # seconds
             shield: false
             gcslogging: false
+            bigquerylogging: false
             healthcheck: false
             errors: false
             vcl: []
@@ -402,6 +403,20 @@ project-with-fastly-gcs:
                 bucket: my-bucket
                 path: my-project/
                 period: 1800
+
+project-with-fastly-bigquery:
+    repo: ssh://git@github.com/elifesciences/dummy3
+    subdomain: www
+    aws:
+        ports:
+            - 80
+        fastly:
+            subdomains:
+                - "{instance}--cdn-of-www"
+            bigquerylogging:
+                project: my-project
+                dataset: my_dataset
+                table: my_table
 
 project-with-fastly-shield:
     repo: ssh://git@github.com/elifesciences/dummy3

--- a/src/tests/test_buildercore_project.py
+++ b/src/tests/test_buildercore_project.py
@@ -9,7 +9,7 @@ ALL_PROJECTS = [
     'dummy1', 'dummy2', 'dummy3',
     'just-some-sns', 'project-with-sqs', 'project-with-s3',
     'project-with-ext', 'project-with-cloudfront', 'project-with-cloudfront-minimal',
-    'project-with-cloudfront-error-pages', 'project-with-cloudfront-origins', 'project-with-fastly-minimal', 'project-with-fastly-complex', 'project-with-fastly-gcs', 'project-with-fastly-shield', 'project-with-fastly-shield-pop',
+    'project-with-cloudfront-error-pages', 'project-with-cloudfront-origins', 'project-with-fastly-minimal', 'project-with-fastly-complex', 'project-with-fastly-gcs', 'project-with-fastly-bigquery', 'project-with-fastly-shield', 'project-with-fastly-shield-pop',
     'project-with-ec2-custom-root',
     'project-with-cluster', 'project-with-cluster-suppressed', 'project-with-cluster-overrides', 'project-with-cluster-empty',
     'project-with-stickiness', 'project-with-multiple-elb-listeners',

--- a/src/tests/test_buildercore_terraform.py
+++ b/src/tests/test_buildercore_terraform.py
@@ -488,7 +488,7 @@ class TestBuildercoreTerraform(base.BaseCase):
 
         table = template['resource']['google_bigquery_table']['my_dataset_prod_widgets']
         self.assertEqual(table, {
-            'dataset_id': 'my_dataset_prod',
+            'dataset_id': '${google_bigquery_dataset.my_dataset_prod.dataset_id}',
             'table_id': 'widgets',
             'project': 'elife-something',
             'schema': '${file("key-value.json")}',
@@ -514,13 +514,13 @@ class TestBuildercoreTerraform(base.BaseCase):
                     'google_bigquery_table': {
                         'my_dataset_prod_remote': {
                             'project': 'elife-something',
-                            'dataset_id': 'my_dataset_prod',
+                            'dataset_id': '${google_bigquery_dataset.my_dataset_prod.dataset_id}',
                             'table_id': 'remote',
                             'schema': '${data.http.my_dataset_prod_remote.body}'
                         },
                         'my_dataset_prod_local': {
                             'project': 'elife-something',
-                            'dataset_id': 'my_dataset_prod',
+                            'dataset_id': '${google_bigquery_dataset.my_dataset_prod.dataset_id}',
                             'table_id': 'local',
                             'schema': '${file("key-value.json")}'
                         }

--- a/src/tests/test_buildercore_terraform.py
+++ b/src/tests/test_buildercore_terraform.py
@@ -429,6 +429,19 @@ class TestBuildercoreTerraform(base.BaseCase):
         service = template['resource']['fastly_service_v1']['fastly-cdn']
         self.assertIn('bigquerylogging', service)
         self.assertEqual(service['bigquerylogging'].get('name'), 'default')
+        self.assertEqual(service['bigquerylogging'].get('project_id'), 'my-project')
+        self.assertEqual(service['bigquerylogging'].get('dataset'), 'my_dataset')
+        self.assertEqual(service['bigquerylogging'].get('table'), 'my_table')
+        #self.assertEqual(service['gcslogging'].get('email'), '${data.vault_generic_secret.fastly-gcs-logging.data["email"]}')
+        #self.assertEqual(service['gcslogging'].get('secret_key'), '${data.vault_generic_secret.fastly-gcs-logging.data["secret_key"]}')
+
+        #log_format = service['gcslogging'].get('format')
+        ## the non-rendered log_format is not even valid JSON
+        #self.assertIsNotNone(log_format)
+        #self.assertRegex(log_format, "\{.*\}")
+
+        #data = template['data']['vault_generic_secret']['fastly-gcs-logging']
+        #self.assertEqual(data, {'path': 'secret/builder/apikey/fastly-gcs-logging'})
 
     def test_gcp_template(self):
         extra = {

--- a/src/tests/test_buildercore_terraform.py
+++ b/src/tests/test_buildercore_terraform.py
@@ -432,16 +432,16 @@ class TestBuildercoreTerraform(base.BaseCase):
         self.assertEqual(service['bigquerylogging'].get('project_id'), 'my-project')
         self.assertEqual(service['bigquerylogging'].get('dataset'), 'my_dataset')
         self.assertEqual(service['bigquerylogging'].get('table'), 'my_table')
-        #self.assertEqual(service['gcslogging'].get('email'), '${data.vault_generic_secret.fastly-gcs-logging.data["email"]}')
-        #self.assertEqual(service['gcslogging'].get('secret_key'), '${data.vault_generic_secret.fastly-gcs-logging.data["secret_key"]}')
+        self.assertEqual(service['bigquerylogging'].get('email'), '${data.vault_generic_secret.fastly-gcp-logging.data["email"]}')
+        self.assertEqual(service['bigquerylogging'].get('secret_key'), '${data.vault_generic_secret.fastly-gcp-logging.data["secret_key"]}')
 
         log_format = service['bigquerylogging'].get('format')
         # the non-rendered log_format is not even valid JSON
         self.assertIsNotNone(log_format)
         self.assertRegex(log_format, "\{.*\}")
 
-        #data = template['data']['vault_generic_secret']['fastly-gcs-logging']
-        #self.assertEqual(data, {'path': 'secret/builder/apikey/fastly-gcs-logging'})
+        data = template['data']['vault_generic_secret']['fastly-gcp-logging']
+        self.assertEqual(data, {'path': 'secret/builder/apikey/fastly-gcp-logging'})
 
     def test_gcp_template(self):
         extra = {

--- a/src/tests/test_buildercore_terraform.py
+++ b/src/tests/test_buildercore_terraform.py
@@ -428,7 +428,7 @@ class TestBuildercoreTerraform(base.BaseCase):
         template = self._parse_template(terraform_template)
         service = template['resource']['fastly_service_v1']['fastly-cdn']
         self.assertIn('bigquerylogging', service)
-        self.assertEqual(service['bigquerylogging'].get('name'), 'default')
+        self.assertEqual(service['bigquerylogging'].get('name'), 'bigquery')
         self.assertEqual(service['bigquerylogging'].get('project_id'), 'my-project')
         self.assertEqual(service['bigquerylogging'].get('dataset'), 'my_dataset')
         self.assertEqual(service['bigquerylogging'].get('table'), 'my_table')

--- a/src/tests/test_buildercore_terraform.py
+++ b/src/tests/test_buildercore_terraform.py
@@ -419,6 +419,17 @@ class TestBuildercoreTerraform(base.BaseCase):
         data = template['data']['vault_generic_secret']['fastly-gcs-logging']
         self.assertEqual(data, {'path': 'secret/builder/apikey/fastly-gcs-logging'})
 
+    def test_fastly_template_bigquery_logging(self):
+        extra = {
+            'stackname': 'project-with-fastly-bigquery--prod',
+        }
+        context = cfngen.build_context('project-with-fastly-bigquery', **extra)
+        terraform_template = terraform.render(context)
+        template = self._parse_template(terraform_template)
+        service = template['resource']['fastly_service_v1']['fastly-cdn']
+        self.assertIn('bigquerylogging', service)
+        self.assertEqual(service['bigquerylogging'].get('name'), 'default')
+
     def test_gcp_template(self):
         extra = {
             'stackname': 'project-on-gcp--prod',

--- a/src/tests/test_buildercore_terraform.py
+++ b/src/tests/test_buildercore_terraform.py
@@ -435,10 +435,10 @@ class TestBuildercoreTerraform(base.BaseCase):
         #self.assertEqual(service['gcslogging'].get('email'), '${data.vault_generic_secret.fastly-gcs-logging.data["email"]}')
         #self.assertEqual(service['gcslogging'].get('secret_key'), '${data.vault_generic_secret.fastly-gcs-logging.data["secret_key"]}')
 
-        #log_format = service['gcslogging'].get('format')
-        ## the non-rendered log_format is not even valid JSON
-        #self.assertIsNotNone(log_format)
-        #self.assertRegex(log_format, "\{.*\}")
+        log_format = service['bigquerylogging'].get('format')
+        # the non-rendered log_format is not even valid JSON
+        self.assertIsNotNone(log_format)
+        self.assertRegex(log_format, "\{.*\}")
 
         #data = template['data']['vault_generic_secret']['fastly-gcs-logging']
         #self.assertEqual(data, {'path': 'secret/builder/apikey/fastly-gcs-logging'})


### PR DESCRIPTION
~~Added configuration format, but waiting on https://github.com/elifesciences/builder/pull/402 to avoid conflicts.~~

Progressively configures `bigquerylogging` for a few Fastly-using services, leaving `gcslogging` in place.