### PR TITLE
Set broken shield log field to null

### DIFF
--- a/projects/elife.yaml
+++ b/projects/elife.yaml
@@ -421,7 +421,9 @@ api-gateway:
         continuumtest:
             fastly:
                 bigquerylogging:
-                    dataset: "staging"
+                    dataset: staging
+                gcslogging:
+                    bucket: staging-elife-fastly
         prod:
             fastly:
                 subdomains:
@@ -540,7 +542,7 @@ journal:
                     - "journal-google-scholar"
                     - "journal-google-scholar-vary"
                 gcslogging:
-                    bucket: "{instance}-elife-fastly"
+                    bucket: staging-elife-fastly
                     path: "journal--{instance}/"
                     period: 600
                 bigquerylogging:
@@ -873,7 +875,7 @@ generic-cdn:
         continuumtest:
             fastly:
                 gcslogging:
-                    bucket: continuumtest-elife-fastly
+                    bucket: staging-elife-fastly
                     path: generic-cdn--continuumtest/
                     period: 600
                 bigquerylogging:
@@ -1757,6 +1759,8 @@ iiif:
             fastly:
                 bigquerylogging:
                     dataset: "staging"
+                gcslogging:
+                    bucket: staging-elife-fastly
         prod:
             ports:
                 - 22

--- a/src/buildercore/terraform.py
+++ b/src/buildercore/terraform.py
@@ -48,7 +48,6 @@ FASTLY_LOG_FORMAT = """{
   "geo_country_code":"%{client.geo.country_code}V",
   "pop_datacenter": "%{server.datacenter}V",
   "pop_region": "%{server.region}V",
-  "shield": "%{req.http.x-shield}V",
   "request":"%{req.request}V",
   "original_host":"%{req.http.X-Forwarded-Host}V",
   "host":"%{req.http.Host}V",


### PR DESCRIPTION
To complete https://github.com/elifesciences/issues/issues/4461

We cannot easily change the schema of BigQuery, so we set the field to `null` explicitly and it will remain empty until implemented.

- [x] `api-gateway--end2end`
- [x] `api-gateway--continuumtest`
- [x] `api-gateway--prod`
- [x] `generic-cdn--end2end`
- [x] `generic-cdn--continuumtest`
- [x] `generic-cdn--prod`
- [x] `iiif--end2end`
- [x] `iiif--continuumtest`
- [x] `iiif--prod`
- [x] `journal--end2end`
- [x] `journal--continuumtest`
- [x] `journal--prod`