### PR TITLE
Add bucket for elife-xpub styleguide versions

### DIFF
--- a/projects/elife.yaml
+++ b/projects/elife.yaml
@@ -2021,6 +2021,10 @@ elife-xpub:
             device: /dev/sdh
             type: gp2
     aws-alt:
+        ci:
+            s3:
+                "{instance}-elife-xpub-styleguide":
+                    public: true
         end2end:
             s3:
                 "{instance}-elife-xpub":


### PR DESCRIPTION
For https://github.com/elifesciences/elife-xpub/issues/408

Makes https://s3.amazonaws.com/ci-elife-xpub-styleguide available (already done).