### PR TITLE
Avoid Terraform conflicts on existing/missing keys

### DIFF
--- a/src/buildercore/terraform.py
+++ b/src/buildercore/terraform.py
@@ -270,7 +270,6 @@ def render_fastly(context):
                 'content': '${data.template_file.%s.rendered}' % snippet_name,
             }) for snippet_name in vcl_templated_snippets]
 
-
         # main
         linked_main_vcl = fastly.MAIN_VCL_TEMPLATE
         inclusions = [fastly.VCL_SNIPPETS[name].as_inclusion() for name in vcl_constant_snippets] + list(vcl_templated_snippets.values())
@@ -364,7 +363,7 @@ def _render_fastly_errors(context, template, vcl_templated_snippets):
                     'url': '%s%s' % (errors['url'], path),
                 }
             )
-                
+
             name = 'error-page-vcl-%d' % code
             template.add_data(
                 # TODO: rename to DATA_*
@@ -565,7 +564,7 @@ class TerraformTemplate():
         if not data:
             data = OrderedDict()
         self.data = data
-        
+
     def add_resource(self, type, name, argument=None, block=None):
         if not type in self.resource:
             self.resource[type] = OrderedDict()

--- a/src/buildercore/terraform.py
+++ b/src/buildercore/terraform.py
@@ -17,7 +17,7 @@ RESOURCE_NAME_FASTLY = 'fastly-cdn'
 
 DATA_TYPE_VAULT_GENERIC_SECRET = 'vault_generic_secret'
 DATA_TYPE_HTTP = 'http'
-DATE_TYPE_TEMPLATE = 'template_file'
+DATA_TYPE_TEMPLATE = 'template_file'
 DATA_NAME_VAULT_GCS_LOGGING = 'fastly-gcs-logging'
 DATA_NAME_VAULT_GCP_LOGGING = 'fastly-gcp-logging'
 DATA_NAME_VAULT_FASTLY_API_KEY = 'fastly'
@@ -367,7 +367,7 @@ def _render_fastly_errors(context, template, vcl_templated_snippets):
             name = 'error-page-vcl-%d' % code
             template.populate_data(
                 # TODO: rename to DATA_*
-                DATE_TYPE_TEMPLATE,
+                DATA_TYPE_TEMPLATE,
                 name,
                 {
                     'template': error_vcl_template_file,
@@ -388,7 +388,7 @@ def _render_fastly_errors(context, template, vcl_templated_snippets):
             )
             name = 'error-page-vcl-4xx'
             template.populate_data(
-                DATE_TYPE_TEMPLATE,
+                DATA_TYPE_TEMPLATE,
                 name,
                 {
                     'template': error_vcl_template_file,
@@ -409,7 +409,7 @@ def _render_fastly_errors(context, template, vcl_templated_snippets):
             )
             name = 'error-page-vcl-5xx'
             template.populate_data(
-                DATE_TYPE_TEMPLATE,
+                DATA_TYPE_TEMPLATE,
                 name,
                 {
                     'template': error_vcl_template_file,

--- a/src/buildercore/terraform.py
+++ b/src/buildercore/terraform.py
@@ -579,7 +579,7 @@ class TerraformTemplate():
         else:
             target[name] = block
 
-    # TODO: optional `argument`
+    # TODO: optional `argument`?
     def add_resource_element(self, type, name, argument, block=None):
         if not type in self.resource:
             self.resource[type] = OrderedDict()
@@ -596,9 +596,6 @@ class TerraformTemplate():
         self.data[type][name] = block
 
     def to_dict(self):
-        """supported and not deprecated anymore
-        
-        https://docs.python.org/3/library/collections.html#collections.somenamedtuple._asdict"""
         result = {}
         if self.resource:
             result['resource'] = self.resource

--- a/src/buildercore/terraform.py
+++ b/src/buildercore/terraform.py
@@ -366,7 +366,6 @@ def _render_fastly_errors(context, template, vcl_templated_snippets):
 
             name = 'error-page-vcl-%d' % code
             template.populate_data(
-                # TODO: rename to DATA_*
                 DATA_TYPE_TEMPLATE,
                 name,
                 {
@@ -568,31 +567,32 @@ class TerraformTemplate():
             data = OrderedDict()
         self.data = data
 
-    def populate_resource(self, type, name, argument=None, block=None):
+    # for naming see https://www.terraform.io/docs/configuration/resources.html#syntax
+    def populate_resource(self, type, name, key=None, block=None):
         if not type in self.resource:
             self.resource[type] = OrderedDict()
         target = self.resource[type]
-        if argument:
+        if key:
             if not name in target:
                 target[name] = OrderedDict()
-            if argument in target[name]:
+            if key in target[name]:
                 raise TerraformTemplateError(
-                    "Resource %s being overwritten (%s)" % ((type, name, argument), target[name][argument])
+                    "Resource %s being overwritten (%s)" % ((type, name, key), target[name][key])
                 )
-            target[name][argument] = block
+            target[name][key] = block
         else:
             target[name] = block
 
-    # TODO: optional `argument`?
-    def populate_resource_element(self, type, name, argument, block=None):
+    # TODO: optional `key`?
+    def populate_resource_element(self, type, name, key, block=None):
         if not type in self.resource:
             self.resource[type] = OrderedDict()
         target = self.resource[type]
         if not name in target:
             target[name] = OrderedDict()
-        if not argument in target[name]:
-            target[name][argument] = []
-        target[name][argument].append(block)
+        if not key in target[name]:
+            target[name][key] = []
+        target[name][key].append(block)
 
     def populate_data(self, type, name, block=None):
         if not type in self.data:

--- a/src/buildercore/terraform.py
+++ b/src/buildercore/terraform.py
@@ -217,7 +217,7 @@ def render_fastly(context):
                 'secret_key': "${data.%s.%s.data[\"secret_key\"]}" % (DATA_TYPE_VAULT_GENERIC_SECRET, DATA_NAME_VAULT_GCS_LOGGING),
             }
         )
-        template.add_data(
+        template.populate_data(
             DATA_TYPE_VAULT_GENERIC_SECRET,
             DATA_NAME_VAULT_GCS_LOGGING,
             block={
@@ -241,7 +241,7 @@ def render_fastly(context):
                 'secret_key': "${data.%s.%s.data[\"secret_key\"]}" % (DATA_TYPE_VAULT_GENERIC_SECRET, DATA_NAME_VAULT_GCP_LOGGING),
             }
         )
-        template.add_data(
+        template.populate_data(
             DATA_TYPE_VAULT_GENERIC_SECRET,
             DATA_NAME_VAULT_GCP_LOGGING,
             {
@@ -356,7 +356,7 @@ def _render_fastly_errors(context, template, vcl_templated_snippets):
         codes = errors.get('codes', {})
         fallbacks = errors.get('fallbacks', {})
         for code, path in codes.items():
-            template.add_data(
+            template.populate_data(
                 DATA_TYPE_HTTP,
                 'error-page-%d' % code,
                 block={
@@ -365,7 +365,7 @@ def _render_fastly_errors(context, template, vcl_templated_snippets):
             )
 
             name = 'error-page-vcl-%d' % code
-            template.add_data(
+            template.populate_data(
                 # TODO: rename to DATA_*
                 DATE_TYPE_TEMPLATE,
                 name,
@@ -379,7 +379,7 @@ def _render_fastly_errors(context, template, vcl_templated_snippets):
             )
             vcl_templated_snippets[name] = error_vcl_template.as_inclusion(name)
         if fallbacks.get('4xx'):
-            template.add_data(
+            template.populate_data(
                 DATA_TYPE_HTTP,
                 'error-page-4xx',
                 {
@@ -387,7 +387,7 @@ def _render_fastly_errors(context, template, vcl_templated_snippets):
                 }
             )
             name = 'error-page-vcl-4xx'
-            template.add_data(
+            template.populate_data(
                 DATE_TYPE_TEMPLATE,
                 name,
                 {
@@ -400,7 +400,7 @@ def _render_fastly_errors(context, template, vcl_templated_snippets):
             )
             vcl_templated_snippets[name] = error_vcl_template.as_inclusion(name)
         if fallbacks.get('5xx'):
-            template.add_data(
+            template.populate_data(
                 DATA_TYPE_HTTP,
                 'error-page-5xx',
                 {
@@ -408,7 +408,7 @@ def _render_fastly_errors(context, template, vcl_templated_snippets):
                 }
             )
             name = 'error-page-vcl-5xx'
-            template.add_data(
+            template.populate_data(
                 DATE_TYPE_TEMPLATE,
                 name,
                 {
@@ -594,7 +594,7 @@ class TerraformTemplate():
             target[name][argument] = []
         target[name][argument].append(block)
 
-    def add_data(self, type, name, block=None):
+    def populate_data(self, type, name, block=None):
         if not type in self.data:
             self.data[type] = OrderedDict()
         if name in self.data[type]:

--- a/src/buildercore/terraform.py
+++ b/src/buildercore/terraform.py
@@ -576,7 +576,9 @@ class TerraformTemplate():
             if not name in target:
                 target[name] = OrderedDict()
             if argument in target[name]:
-                raise TerraformTemplateError("Target %s being overwritten (%s)" % ((type, name, argument), target[name][argument]))
+                raise TerraformTemplateError(
+                    "Resource %s being overwritten (%s)" % ((type, name, argument), target[name][argument])
+                )
             target[name][argument] = block
         else:
             target[name] = block
@@ -595,6 +597,10 @@ class TerraformTemplate():
     def add_data(self, type, name, block=None):
         if not type in self.data:
             self.data[type] = OrderedDict()
+        if name in self.data[type]:
+            raise TerraformTemplateError(
+                "Data %s being overwritten (%s)" % ((type, name), self.data[type][name])
+            )
         self.data[type][name] = block
 
     def to_dict(self):

--- a/src/tests/test_buildercore_terraform.py
+++ b/src/tests/test_buildercore_terraform.py
@@ -31,7 +31,7 @@ class TestTerraformTemplate(TestCase):
 
     def test_nested_resource_creation(self):
         template = terraform.TerraformTemplate()
-        template.populate_resource('google_bigquery_dataset', 'my_dataset', argument='labels', block={
+        template.populate_resource('google_bigquery_dataset', 'my_dataset', key='labels', block={
             'project': 'journal',
         })
         self.assertEqual(
@@ -49,10 +49,10 @@ class TestTerraformTemplate(TestCase):
 
     def test_nested_resource_creation_if_already_existing(self):
         template = terraform.TerraformTemplate()
-        template.populate_resource('google_bigquery_dataset', 'my_dataset', argument='labels', block={
+        template.populate_resource('google_bigquery_dataset', 'my_dataset', key='labels', block={
             'project': 'journal',
         })
-        overwrite = lambda: template.populate_resource('google_bigquery_dataset', 'my_dataset', argument='labels', block={ 'project': 'lax', })
+        overwrite = lambda: template.populate_resource('google_bigquery_dataset', 'my_dataset', key='labels', block={'project': 'lax', })
         self.assertRaises(terraform.TerraformTemplateError, overwrite)
 
     def test_resource_creation_in_multiple_phases(self):
@@ -60,7 +60,7 @@ class TestTerraformTemplate(TestCase):
         template.populate_resource('google_bigquery_dataset', 'my_dataset', block={
             'location': 'EU',
         })
-        template.populate_resource('google_bigquery_dataset', 'my_dataset', argument='labels', block={
+        template.populate_resource('google_bigquery_dataset', 'my_dataset', key='labels', block={
             'project': 'journal',
         })
         self.assertEqual(
@@ -79,10 +79,10 @@ class TestTerraformTemplate(TestCase):
 
     def test_resource_elements_creation(self):
         template = terraform.TerraformTemplate()
-        template.populate_resource_element('google_bigquery_dataset', 'my_dataset', argument='access', block={
+        template.populate_resource_element('google_bigquery_dataset', 'my_dataset', key='access', block={
             'role': 'reader',
         })
-        template.populate_resource_element('google_bigquery_dataset', 'my_dataset', argument='access', block={
+        template.populate_resource_element('google_bigquery_dataset', 'my_dataset', key='access', block={
             'role': 'writer',
         })
         self.assertEqual(
@@ -180,7 +180,7 @@ class TestTerraformTemplate(TestCase):
         template.populate_data('vault_generic_secret', 'my_credentials', block={
             'username': 'mickey',
         })
-        overwrite = lambda: template.populate_data('vault_generic_secret', 'my_credentials', block={ 'username': 'minnie' })
+        overwrite = lambda: template.populate_data('vault_generic_secret', 'my_credentials', block={'username': 'minnie'})
         self.assertRaises(terraform.TerraformTemplateError, overwrite)
 
 

--- a/src/tests/test_buildercore_terraform.py
+++ b/src/tests/test_buildercore_terraform.py
@@ -29,7 +29,7 @@ class TestTerraformTemplate(TestCase):
             }
         )
 
-    def test_resource_partial_creation(self):
+    def test_nested_resource_creation(self):
         template = terraform.TerraformTemplate()
         template.add_resource('google_bigquery_dataset', 'my_dataset', argument='labels', block={
             'project': 'journal',
@@ -40,6 +40,29 @@ class TestTerraformTemplate(TestCase):
                 'resource': OrderedDict([
                     ('google_bigquery_dataset', OrderedDict([
                         ('my_dataset', OrderedDict([
+                            ('labels', {'project': 'journal'}),
+                        ])),
+                    ])),
+                ])
+            }
+        )
+
+    def test_resource_creation_in_multiple_phases(self):
+        template = terraform.TerraformTemplate()
+        # TODO: naming needs to change, we are configuring/populating a resource rather then creating it from scratch every time
+        template.add_resource('google_bigquery_dataset', 'my_dataset', block={
+            'location': 'EU',
+        })
+        template.add_resource('google_bigquery_dataset', 'my_dataset', argument='labels', block={
+            'project': 'journal',
+        })
+        self.assertEqual(
+            template.to_dict(),
+            {
+                'resource': OrderedDict([
+                    ('google_bigquery_dataset', OrderedDict([
+                        ('my_dataset', OrderedDict([
+                            ('location', 'EU'),
                             ('labels', {'project': 'journal'}),
                         ])),
                     ])),

--- a/src/tests/test_buildercore_terraform.py
+++ b/src/tests/test_buildercore_terraform.py
@@ -15,7 +15,7 @@ from buildercore import cfngen, terraform
 class TestTerraformTemplate(TestCase):
     def test_resource_creation(self):
         template = terraform.TerraformTemplate()
-        template.add_resource('google_bigquery_dataset', 'my_dataset', block={
+        template.populate_resource('google_bigquery_dataset', 'my_dataset', block={
             'location': 'EU',
         })
         self.assertEqual(
@@ -31,7 +31,7 @@ class TestTerraformTemplate(TestCase):
 
     def test_nested_resource_creation(self):
         template = terraform.TerraformTemplate()
-        template.add_resource('google_bigquery_dataset', 'my_dataset', argument='labels', block={
+        template.populate_resource('google_bigquery_dataset', 'my_dataset', argument='labels', block={
             'project': 'journal',
         })
         self.assertEqual(
@@ -47,13 +47,20 @@ class TestTerraformTemplate(TestCase):
             }
         )
 
+    def test_nested_resource_creation_if_already_existing(self):
+        template = terraform.TerraformTemplate()
+        template.populate_resource('google_bigquery_dataset', 'my_dataset', argument='labels', block={
+            'project': 'journal',
+        })
+        overwrite = lambda: template.populate_resource('google_bigquery_dataset', 'my_dataset', argument='labels', block={ 'project': 'lax', })
+        self.assertRaises(terraform.TerraformTemplateError, overwrite)
+
     def test_resource_creation_in_multiple_phases(self):
         template = terraform.TerraformTemplate()
-        # TODO: naming needs to change, we are configuring/populating a resource rather then creating it from scratch every time
-        template.add_resource('google_bigquery_dataset', 'my_dataset', block={
+        template.populate_resource('google_bigquery_dataset', 'my_dataset', block={
             'location': 'EU',
         })
-        template.add_resource('google_bigquery_dataset', 'my_dataset', argument='labels', block={
+        template.populate_resource('google_bigquery_dataset', 'my_dataset', argument='labels', block={
             'project': 'journal',
         })
         self.assertEqual(
@@ -72,10 +79,10 @@ class TestTerraformTemplate(TestCase):
 
     def test_resource_elements_creation(self):
         template = terraform.TerraformTemplate()
-        template.add_resource_element('google_bigquery_dataset', 'my_dataset', argument='access', block={
+        template.populate_resource_element('google_bigquery_dataset', 'my_dataset', argument='access', block={
             'role': 'reader',
         })
-        template.add_resource_element('google_bigquery_dataset', 'my_dataset', argument='access', block={
+        template.populate_resource_element('google_bigquery_dataset', 'my_dataset', argument='access', block={
             'role': 'writer',
         })
         self.assertEqual(
@@ -94,7 +101,6 @@ class TestTerraformTemplate(TestCase):
             }
         )
 
-    # def test_resource_nested_already_exists
     # def test_data
     # def test_data_same_type
     # def test_data_different_type

--- a/src/tests/test_buildercore_terraform.py
+++ b/src/tests/test_buildercore_terraform.py
@@ -94,6 +94,12 @@ class TestTerraformTemplate(TestCase):
             }
         )
 
+    # def test_resource_nested_already_exists
+    # def test_data
+    # def test_data_same_type
+    # def test_data_different_type
+    # def test_data_already_exists
+
 
 class TestBuildercoreTerraform(base.BaseCase):
     def setUp(self):

--- a/src/tests/test_buildercore_terraform.py
+++ b/src/tests/test_buildercore_terraform.py
@@ -103,7 +103,7 @@ class TestTerraformTemplate(TestCase):
 
     def test_data_creation(self):
         template = terraform.TerraformTemplate()
-        template.add_data('vault_generic_secret', 'my_credentials', block={
+        template.populate_data('vault_generic_secret', 'my_credentials', block={
             'username': 'mickey',
             'password': 'mouse',
         })
@@ -123,11 +123,11 @@ class TestTerraformTemplate(TestCase):
 
     def test_data_creation_same_type(self):
         template = terraform.TerraformTemplate()
-        template.add_data('vault_generic_secret', 'my_credentials', block={
+        template.populate_data('vault_generic_secret', 'my_credentials', block={
             'username': 'mickey',
             'password': 'mouse',
         })
-        template.add_data('vault_generic_secret', 'my_ssh_key', block={
+        template.populate_data('vault_generic_secret', 'my_ssh_key', block={
             'private': '-----BEGIN RSA PRIVATE KEY-----',
         })
         self.assertEqual(
@@ -149,11 +149,11 @@ class TestTerraformTemplate(TestCase):
 
     def test_data_creation_different_type(self):
         template = terraform.TerraformTemplate()
-        template.add_data('vault_generic_secret', 'my_credentials', block={
+        template.populate_data('vault_generic_secret', 'my_credentials', block={
             'username': 'mickey',
             'password': 'mouse',
         })
-        template.add_data('http', 'my_page', block={
+        template.populate_data('http', 'my_page', block={
             'url': 'https://example.com',
         })
         self.assertEqual(
@@ -177,10 +177,10 @@ class TestTerraformTemplate(TestCase):
 
     def test_data_creation_if_already_existing(self):
         template = terraform.TerraformTemplate()
-        template.add_data('vault_generic_secret', 'my_credentials', block={
+        template.populate_data('vault_generic_secret', 'my_credentials', block={
             'username': 'mickey',
         })
-        overwrite = lambda: template.add_data('vault_generic_secret', 'my_credentials', block={ 'username': 'minnie' })
+        overwrite = lambda: template.populate_data('vault_generic_secret', 'my_credentials', block={ 'username': 'minnie' })
         self.assertRaises(terraform.TerraformTemplateError, overwrite)
 
 

--- a/src/tests/test_buildercore_terraform.py
+++ b/src/tests/test_buildercore_terraform.py
@@ -70,6 +70,30 @@ class TestTerraformTemplate(TestCase):
             }
         )
 
+    def test_resource_elements_creation(self):
+        template = terraform.TerraformTemplate()
+        template.add_resource_element('google_bigquery_dataset', 'my_dataset', argument='access', block={
+            'role': 'reader',
+        })
+        template.add_resource_element('google_bigquery_dataset', 'my_dataset', argument='access', block={
+            'role': 'writer',
+        })
+        self.assertEqual(
+            template.to_dict(),
+            {
+                'resource': OrderedDict([
+                    ('google_bigquery_dataset', OrderedDict([
+                        ('my_dataset', OrderedDict([
+                            ('access', [
+                                {'role': 'reader'},
+                                {'role': 'writer'},
+                            ]),
+                        ])),
+                    ])),
+                ])
+            }
+        )
+
 
 class TestBuildercoreTerraform(base.BaseCase):
     def setUp(self):

--- a/src/tests/test_buildercore_terraform.py
+++ b/src/tests/test_buildercore_terraform.py
@@ -1,3 +1,4 @@
+from collections import OrderedDict
 import json
 import os
 import re
@@ -5,8 +6,47 @@ import shutil
 import yaml
 from os.path import exists, join
 from mock import patch, MagicMock
+# pylint: disable-msg=import-error
+from unittest2 import TestCase
 from . import base
 from buildercore import cfngen, terraform
+
+
+class TestTerraformTemplate(TestCase):
+    def test_resource_creation(self):
+        template = terraform.TerraformTemplate()
+        template.add_resource('google_bigquery_dataset', 'my_dataset', block={
+            'location': 'EU',
+        })
+        self.assertEqual(
+            template.to_dict(),
+            {
+                'resource': OrderedDict([
+                    ('google_bigquery_dataset', OrderedDict([
+                        ('my_dataset', {'location': 'EU'}),
+                    ])),
+                ])
+            }
+        )
+
+    def test_resource_partial_creation(self):
+        template = terraform.TerraformTemplate()
+        template.add_resource('google_bigquery_dataset', 'my_dataset', argument='labels', block={
+            'project': 'journal',
+        })
+        self.assertEqual(
+            template.to_dict(),
+            {
+                'resource': OrderedDict([
+                    ('google_bigquery_dataset', OrderedDict([
+                        ('my_dataset', OrderedDict([
+                            ('labels', {'project': 'journal'}),
+                        ])),
+                    ])),
+                ])
+            }
+        )
+
 
 class TestBuildercoreTerraform(base.BaseCase):
     def setUp(self):


### PR DESCRIPTION
I initially thought it would be enough to separate each provider into its own `*.tf` file. I was wrong on this as even inside the same resource (`fastly_service_v1`) it is possible to get errors on:

- the various branches of the tree being missing (trying to configure `data.http.something` before `data.http` exists
- a branch existing when it shouldn't e.g. `data.http` or even `data` being rendered as an empty list which [causes a Terraform error](https://github.com/elifesciences/builder/pull/412/files#diff-c266af1366f88d308f6fcb68d77552bcR480)

This approach borrows from `troposphere` and the way it allows multiple rendering processes to populate a single template, even when different types are being added; in CloudFormation, `resources` vs. `outputs` while here `resources` vs. `data`.