### PR TITLE
Add missing fields to fastly-logs schema

### DIFF
--- a/projects/elife.yaml
+++ b/projects/elife.yaml
@@ -2162,13 +2162,13 @@ fastly-logs:
                 project: elife-fastly
                 tables:
                     api_gateway:
-                        schema: ./src/buildercore/bigquery/schemas/fastly-logs-201809.json
+                        schema: ./src/buildercore/bigquery/schemas/fastly-logs-201810.json
                     generic_cdn:
-                        schema: ./src/buildercore/bigquery/schemas/fastly-logs-201809.json
+                        schema: ./src/buildercore/bigquery/schemas/fastly-logs-201810.json
                     journal:
-                        schema: ./src/buildercore/bigquery/schemas/fastly-logs-201809.json
+                        schema: ./src/buildercore/bigquery/schemas/fastly-logs-201810.json
                     iiif:
-                        schema: ./src/buildercore/bigquery/schemas/fastly-logs-201809.json
+                        schema: ./src/buildercore/bigquery/schemas/fastly-logs-201810.json
     aws-alt: {}
 
 data-pipeline:

--- a/src/buildercore/bigquery/schemas/fastly-logs-201810.json
+++ b/src/buildercore/bigquery/schemas/fastly-logs-201810.json
@@ -24,10 +24,6 @@
     "type": "STRING"
   },
   {
-    "name": "forwarded_for",
-    "type": "STRING"
-  },
-  {
     "name": "geo_city",
     "type": "STRING"
   },
@@ -52,10 +48,6 @@
     "type": "STRING"
   },
   {
-    "name": "original_host",
-    "type": "STRING"
-  },
-  {
     "name": "host",
     "type": "STRING"
   },
@@ -72,10 +64,6 @@
     "type": "STRING"
   },
   {
-    "name": "request_accept",
-    "type": "STRING"
-  },
-  {
     "name": "request_accept_language",
     "type": "STRING"
   },
@@ -89,6 +77,18 @@
   },
   {
     "name": "cache_status",
+    "type": "STRING"
+  },
+  {
+    "name": "forwarded_for",
+    "type": "STRING"
+  },
+  {
+    "name": "original_host",
+    "type": "STRING"
+  },
+  {
+    "name": "request_accept",
     "type": "STRING"
   }
 ]

--- a/src/buildercore/bigquery/schemas/fastly-logs-201810.json
+++ b/src/buildercore/bigquery/schemas/fastly-logs-201810.json
@@ -1,0 +1,94 @@
+[
+  {
+    "name": "timestamp",
+    "type": "DATETIME"
+  },
+  {
+    "name": "time_elapsed",
+    "type": "INTEGER"
+  },
+  {
+    "name": "object_hits",
+    "type": "INTEGER"
+  },
+  {
+    "name": "object_lastuse",
+    "type": "FLOAT"
+  },
+  {
+    "name": "is_tls",
+    "type": "BOOLEAN"
+  },
+  {
+    "name": "client_ip",
+    "type": "STRING"
+  },
+  {
+    "name": "forwarded_for",
+    "type": "STRING"
+  },
+  {
+    "name": "geo_city",
+    "type": "STRING"
+  },
+  {
+    "name": "geo_country_code",
+    "type": "STRING"
+  },
+  {
+    "name": "pop_datacenter",
+    "type": "STRING"
+  },
+  {
+    "name": "pop_region",
+    "type": "STRING"
+  },
+  {
+    "name": "shield",
+    "type": "STRING"
+  },
+  {
+    "name": "request",
+    "type": "STRING"
+  },
+  {
+    "name": "original_host",
+    "type": "STRING"
+  },
+  {
+    "name": "host",
+    "type": "STRING"
+  },
+  {
+    "name": "url",
+    "type": "STRING"
+  },
+  {
+    "name": "request_referer",
+    "type": "STRING"
+  },
+  {
+    "name": "request_user_agent",
+    "type": "STRING"
+  },
+  {
+    "name": "request_accept",
+    "type": "STRING"
+  },
+  {
+    "name": "request_accept_language",
+    "type": "STRING"
+  },
+  {
+    "name": "request_accept_charset",
+    "type": "STRING"
+  },
+  {
+    "name": "response_status",
+    "type": "STRING"
+  },
+  {
+    "name": "cache_status",
+    "type": "STRING"
+  }
+]


### PR DESCRIPTION
For https://github.com/elifesciences/issues/issues/4461

They were defined in the log delivered by Fastly, but dropped until the BigQuery table schema is updated to collect them.

Thankfully we can add columns, but only at the end.