### PR TITLE
Make context from S3 authoritative

### DIFF
--- a/src/buildercore/context_handler.py
+++ b/src/buildercore/context_handler.py
@@ -28,9 +28,8 @@ def load_context(stackname):
     """Returns the store context data structure for 'stackname'.
     Downloads from S3 if missing on the local builder instance"""
     path = local_context_file(stackname)
-    if not os.path.exists(path):
-        if not download_from_s3(stackname):
-            raise MissingContextFile("We are missing the context file for %s, even on S3. Does the stack exist?" % stackname)
+    if not download_from_s3(stackname, refresh=True):
+        raise MissingContextFile("We are missing the context file for %s, even on S3. Does the stack exist?" % stackname)
     contents = json.load(open(path, 'r'))
 
     # fallback: if no `aws` key is there, copy from legacy `project.aws` key

--- a/src/buildercore/lifecycle.py
+++ b/src/buildercore/lifecycle.py
@@ -13,7 +13,7 @@ import boto # route53 boto2 > route53 boto3
 from . import config, core
 from .core import boto_conn, find_ec2_instances, find_rds_instances, stack_all_ec2_nodes, current_ec2_node_id, NoPublicIps, NoRunningInstances
 from .utils import call_while, ensure, lmap
-from .context_handler import load_context, download_from_s3
+from .context_handler import load_context
 
 LOG = logging.getLogger(__name__)
 
@@ -83,8 +83,6 @@ def restart(stackname):
 def start(stackname):
     "Puts all EC2 nodes of stackname into the 'started' state. Idempotent"
 
-    # update local copy of context from s3
-    download_from_s3(stackname, refresh=True)
     context = load_context(stackname)
 
     # TODO: do the same exclusion for EC2

--- a/src/tests/test_buildercore_lifecycle.py
+++ b/src/tests/test_buildercore_lifecycle.py
@@ -1,14 +1,14 @@
-import json
 from datetime import datetime
 from mock import patch, MagicMock
 from pytz import utc
 from . import base
 from buildercore.core import parse_stackname
-from buildercore import cfngen, context_handler, lifecycle
+from buildercore import cfngen, lifecycle
 
 
 class TestBuildercoreLifecycle(base.BaseCase):
     def setUp(self):
+        self.contexts = {}
         self._generate_context('dummy1--test')
         self._generate_context('project-with-rds-only--test')
 
@@ -16,7 +16,9 @@ class TestBuildercoreLifecycle(base.BaseCase):
     @patch('buildercore.lifecycle._ec2_connection')
     @patch('buildercore.lifecycle.find_rds_instances')
     @patch('buildercore.lifecycle.find_ec2_instances')
-    def test_start_a_not_running_ec2_instance(self, find_ec2_instances, find_rds_instances, ec2_connection, some_node_is_not_ready):
+    @patch('buildercore.lifecycle.load_context')
+    def test_start_a_not_running_ec2_instance(self, load_context, find_ec2_instances, find_rds_instances, ec2_connection, some_node_is_not_ready):
+        load_context.return_value = self.contexts['dummy1--test']
         find_ec2_instances.side_effect = [
             [self._ec2_instance('stopped')],
             [self._ec2_instance('running')],
@@ -32,7 +34,9 @@ class TestBuildercoreLifecycle(base.BaseCase):
     @patch('buildercore.lifecycle._rds_connection')
     @patch('buildercore.lifecycle.find_rds_instances')
     @patch('buildercore.lifecycle.find_ec2_instances')
-    def test_start_a_not_running_rds_instance(self, find_ec2_instances, find_rds_instances, rds_connection):
+    @patch('buildercore.lifecycle.load_context')
+    def test_start_a_not_running_rds_instance(self, load_context, find_ec2_instances, find_rds_instances, rds_connection):
+        load_context.return_value = self.contexts['project-with-rds-only--test']
         find_ec2_instances.return_value = []
         find_rds_instances.side_effect = [
             [self._rds_instance('stopped')],
@@ -47,18 +51,24 @@ class TestBuildercoreLifecycle(base.BaseCase):
 
     @patch('buildercore.lifecycle.find_rds_instances')
     @patch('buildercore.lifecycle.find_ec2_instances')
-    def test_start_ec2_idempotence(self, find_ec2_instances, find_rds_instances):
+    @patch('buildercore.lifecycle.load_context')
+    def test_start_ec2_idempotence(self, load_context, find_ec2_instances, find_rds_instances):
+        load_context.return_value = self.contexts['dummy1--test']
         find_ec2_instances.return_value = [self._ec2_instance('running')]
         lifecycle.start('dummy1--test')
 
     @patch('buildercore.lifecycle.find_rds_instances')
     @patch('buildercore.lifecycle.find_ec2_instances')
-    def test_start_rds_idempotence(self, find_ec2_instances, find_rds_instances):
+    @patch('buildercore.lifecycle.load_context')
+    def test_start_rds_idempotence(self, load_context, find_ec2_instances, find_rds_instances):
+        load_context.return_value = self.contexts['project-with-rds-only--test']
         find_rds_instances.return_value = [self._rds_instance('available')]
         lifecycle.start('project-with-rds-only--test')
 
     @patch('buildercore.lifecycle.find_ec2_instances')
-    def test_ignores_terminated_stacks_that_have_been_replaced_by_a_new_instance(self, find_ec2_instances):
+    @patch('buildercore.lifecycle.load_context')
+    def test_ignores_terminated_stacks_that_have_been_replaced_by_a_new_instance(self, load_context, find_ec2_instances):
+        load_context.return_value = self.contexts['dummy1--test']
         old = self._ec2_instance('terminated', 'i-123')
         new = self._ec2_instance('running', 'i-456')
 
@@ -68,7 +78,9 @@ class TestBuildercoreLifecycle(base.BaseCase):
     @patch('buildercore.lifecycle._stop')
     @patch('buildercore.lifecycle.find_rds_instances')
     @patch('buildercore.lifecycle.find_ec2_instances')
-    def test_stops_ec2_instance(self, find_ec2_instances, find_rds_instances, _stop):
+    @patch('buildercore.lifecycle.load_context')
+    def test_stops_ec2_instance(self, load_context, find_ec2_instances, find_rds_instances, _stop):
+        load_context.return_value = self.contexts['dummy1--test']
         find_ec2_instances.return_value = [self._ec2_instance('running')]
         find_rds_instances.return_value = []
         lifecycle.stop('dummy1--test')
@@ -76,7 +88,9 @@ class TestBuildercoreLifecycle(base.BaseCase):
     @patch('buildercore.lifecycle._stop')
     @patch('buildercore.lifecycle.find_rds_instances')
     @patch('buildercore.lifecycle.find_ec2_instances')
-    def test_stops_rds_instance(self, find_ec2_instances, find_rds_instances, _stop):
+    @patch('buildercore.lifecycle.load_context')
+    def test_stops_rds_instance(self, load_context, find_ec2_instances, find_rds_instances, _stop):
+        load_context.return_value = self.contexts['project-with-rds-only--test']
         find_ec2_instances.return_value = []
         find_rds_instances.return_value = [self._rds_instance('available')]
         lifecycle.stop('project-with-rds-only--test')
@@ -91,7 +105,7 @@ class TestBuildercoreLifecycle(base.BaseCase):
     def _generate_context(self, stackname):
         (pname, instance_id) = parse_stackname(stackname)
         context = cfngen.build_context(pname, stackname=stackname)
-        context_handler.write_context_locally(stackname, json.dumps(context))
+        self.contexts[stackname] = context
 
     def _ec2_instance(self, state='running', id='i-456', launch_time=datetime(2017, 1, 1, tzinfo=utc)):
         instance = MagicMock()


### PR DESCRIPTION
Current situation is you may have a old context around on your local disk. This applies to `elife-alfred--prod` as well. Making the context always downloaded from S3 avoids this stale copy causing weird bugs like https://alfred.elifesciences.org/job/process/job/process-master-server/7, but it may be slower.