### PR TITLE
Feature: data-pipeline registry client

### DIFF
--- a/projects/elife.yaml
+++ b/projects/elife.yaml
@@ -2086,4 +2086,5 @@ data-pipeline:
         cpus: 2
         ram: 2048
         ports:
-            1222: 80
+            1222: 8080 # bypass nginx for development, it's glitchy
+            1223: 18080 # nifi-registry service

--- a/projects/elife.yaml
+++ b/projects/elife.yaml
@@ -2068,6 +2068,16 @@ data-pipeline:
                  deletion-policy: delete
             "{instance}-elife-data-pipeline-archive":
                  deletion-policy: retain
+    aws-alt:
+        masterless:
+            ec2:
+                masterless: True
+            ports:
+                - 22
+                - 80 # used only to upgrade to https
+                - 443
+                - 18443
+            s3: {}
     gcp:
         bigquery:
             "{instance}": # dataset


### PR DESCRIPTION
some project tweaks while the registry client is sorted

* vagrant ports now bypass nginx and go directly to the nifi service. can't figure out why api port is not being proxied locally vs remotely
* vagrant port now has registry client opened up. this won't be the case remotely