### PR TITLE
Deal with no instances (temporarily) being found

### DIFF
--- a/src/buildercore/core.py
+++ b/src/buildercore/core.py
@@ -300,7 +300,8 @@ def stack_all_ec2_nodes(stackname, workfn, username=config.DEPLOY_USER, concurre
 
     if not public_ips:
         LOG.info("No EC2 nodes to execute on")
-        return
+        # should be a dictionary mapping ip address to result
+        return {}
 
     LOG.info("Executing on ec2 nodes (%s), concurrency %s", public_ips, concurrency)
 

--- a/src/buildercore/lifecycle.py
+++ b/src/buildercore/lifecycle.py
@@ -133,7 +133,7 @@ def _some_node_is_not_ready(stackname, **kwargs):
         # TODO: what if there are more than 1 node?
         ip_to_ready = stack_all_ec2_nodes(stackname, _daemons_ready, username=config.BOOTSTRAP_USER, **kwargs)
         LOG.info("_daemons_ready: %s", ip_to_ready)
-        return False in ip_to_ready.values()
+        return len(ip_to_ready) == 0 or False in ip_to_ready.values()
     except NoPublicIps as e:
         LOG.info("No public ips available yet: %s", e)
         return True

--- a/src/tests/test_buildercore_core.py
+++ b/src/tests/test_buildercore_core.py
@@ -162,6 +162,14 @@ class SimpleCases(base.BaseCase):
 
 class Errors(base.BaseCase):
     @patch('buildercore.core.stack_data')
+    def test_no_running_instances_found(self, stack_data):
+        stack_data.return_value = []
+        self.assertEqual(
+            core.stack_all_ec2_nodes('dummy1--test', lambda: True),
+            {}
+        )
+
+    @patch('buildercore.core.stack_data')
     def test_no_public_ips_available(self, stack_data):
         stack_data.return_value = [
             {'InstanceId': 'i-1', 'PublicIpAddress': None, 'Tags': []},


### PR DESCRIPTION
During startup it may happen that the EC2 API shows an eventually
consistent behavior and returns an empty set of EC2 instances despite
the fact that we have already seen all of them as `running` e.g.
https://alfred.elifesciences.org/blue/organizations/jenkins/test-elife-xpub/detail/test-elife-xpub/546/pipeline

Here we return an empty dictionary from `stack_all_ec2_nodes` which is
the same type as the positive result, rather than a `None`.

From the polling layer, this condition leads to wait some more until
servers appear.