### PR TITLE
Add end2end--xpub--1.elifesciences.org

### DIFF
--- a/docs/dns.md
+++ b/docs/dns.md
@@ -1,0 +1,38 @@
+# DNS
+
+DNS entries for servers are maintained by builder for various cases.
+
+All configuration fields described here relate to [project definitions](../projects/elife.yaml).
+
+## External and internal
+
+`External` DNS correspond to `*.elifesciences.org` entries, resolving to a public IP address and accessible over the public Internet.
+
+`Internal` DNS entries correspond to `*.elife.internal` entries, resolving to a private IP address and accessible withing eLife's AWS VPC(s).
+
+External entries need to be maintained upon servers being stopped, started or rebooted; the public IP addresses are reassigned. Internal entries do not need to, as the private IP addresses are static.
+
+### HTTPS constraints
+
+Practically all external DNS entries have the form of 3-level subdomains (`*.elifesciences.org`) to allow a wildcard certificate being used to implement HTTPS on them.
+
+## Default entries
+
+The `domain` and `intdomain` configuration fields respectively configure the presence of an external and internal DNS entry for the whole stack. They can be set to `false` to disable the creation of the entries.
+
+The `subdomain` field provides a project-specific subdomain to use together with the environment name in these entries. For example, a subdomain like `profiles` will result in entries like `prod--profiles.elifesciences.org` and `prod--profiles.elife.internal` being created.
+
+## CNAMEs
+
+The `subdomains` field allow additional CNAMEs to be specified on a stack.
+
+Specialized resources like `fastly` have their own way of specifying this, in this particular case a `cname` field.
+
+## Multiple nodes
+
+Multiple nodes in a cluster usually do not have individual DNS entries as they are hidden behind a load balancer.
+
+These settings enable additional DNS entries:
+
+- `ec2.dns-internal` allows the creation of internal DNS entries that can be used to make nodes in a cluster collaborate e.g. `prod--xpub--1.elife.internal`
+- `ec2.dns-external-primary` allows the creation of a single external DNS entry for the [primary node](../docs/lingo.md) e.g. `end2end--xpub--1.elifesciences.org`

--- a/docs/lingo.md
+++ b/docs/lingo.md
@@ -1,14 +1,24 @@
-# lingo
+# Lingo
 
 Builder describes `projects` and their environment requirements in the project file using YAML.
 
-From this abstract definitions an intermediate `context` is generated (`.cfn/contexts`) in JSON format. This is deployed to EC2 instances so that they can use it to configure themselves e.g. pulling a database password from it.
-
-From the context, a Cloudformation `template` that describes a `stack` of AWS resources using JSON is generated (`.cfn/stacks`). This template does not just describe the EC2 instances but also additional resources such as RDS databases, DNS entries, S3 buckets, SQS queues, Elastic Load Balancers, and so on.
-
-A `stackname` is the unique name of a `project` instance, pointing to a single Cloudformation resource `stack`.
+A `stackname` is the unique name of a `project` instance, pointing to a single `stack` (of resources).
 
 It comprises the `project name` and an `instance id`, usually indicating an `environment`, delimited by double hyphens.
 
 For example, `journal--prod` is the project `journal` within the environment `prod`. `journal--20170601` is the project `journal` where the instance id is used to indicate an ad-hoc instance used for tests rather than a environment.
 
+## Generation process
+
+From YAML abstract definitions an intermediate `context` is generated (`.cfn/contexts`) in JSON format. This is stored remotely in an S3 bucket dedicated to builder, and also deployed to EC2 instances so that they can use it to configure themselves e.g. pulling a database password from it.
+
+From the context, multiple provisioning system can be used for each stack:
+
+- a Cloudformation `template` that describes a `stack` of AWS resources using JSON is generated (`.cfn/stacks`). This template does not just describe the EC2 instances but also additional resources such as RDS databases, DNS entries, S3 buckets, SQS queues, Elastic Load Balancers, and everything AWS-related.
+- a Terraform folder of disparate resources is generated (`.cfn/terraform/`) for services that are not tied to AWS like Google Cloud Platform or Fastly.
+
+## Multiple nodes
+
+A stack may have from 0 to N identical servers called `nodes`. The set of all nodes for that stack is called a `cluster`. Each node has a progressive number giving it an identity, starting from `1`.
+
+A primary node is defined as node 1 of a cluster. Sometimes this node is special as it runs processes like a testing database or a unique process that should not be running on other nodes.

--- a/projects/elife.yaml
+++ b/projects/elife.yaml
@@ -29,6 +29,9 @@ defaults:
         ec2:
             # how many EC2 instance per stack instance
             cluster-size: 1
+            # whether the first EC2 node should get an external DNS entry such as env--project--1.elifesciences.org
+            # only makes sense if cluster-size > 1
+            dns-external-primary: True
             # whether the EC2 nodes should get a per-node internal DNS entry such as env--project--1.elife.internal
             # only makes sense if cluster-size > 1
             dns-internal: False
@@ -1920,6 +1923,14 @@ elife-xpub:
             ec2:
                 cluster-size: 2
                 dns-internal: True
+            ports:
+                - 22
+                - 80
+                - 443
+                - 2222:
+                    cidr-ip: 10.0.0.0/16 # access via VPC ip range only
+                - 8020 # nginx-public-folders via HTTP
+                - 8021 # nginx-public-folders via HTTPS
             elb:
                 protocol:
                     - 443
@@ -1937,6 +1948,7 @@ elife-xpub:
                 encryption: arn:aws:kms:us-east-1:512686554592:key/b626157a-1e5b-4bf6-8799-211505efe072 
             ec2:
                 cluster-size: 2
+                dns-external-primary: True
                 dns-internal: True
             elb:
                 protocol:

--- a/projects/elife.yaml
+++ b/projects/elife.yaml
@@ -1312,7 +1312,7 @@ search:
                     cidr-ip: 10.0.0.0/16 # follower nodes
             ec2:
                 cluster-size: 2
-                dns-internal: True
+                dns-internal: true
             elb: 
                 protocol: 
                     - http
@@ -1327,7 +1327,7 @@ search:
                     cidr-ip: 10.0.0.0/16 # follower nodes
             ec2:
                 cluster-size: 2
-                dns-internal: True
+                dns-internal: true
             elb: 
                 protocol: 
                     - http
@@ -1922,7 +1922,7 @@ elife-xpub:
                 encryption: arn:aws:kms:us-east-1:512686554592:key/b626157a-1e5b-4bf6-8799-211505efe072 
             ec2:
                 cluster-size: 2
-                dns-internal: True
+                dns-internal: true
             ports:
                 - 22
                 - 80
@@ -1948,8 +1948,8 @@ elife-xpub:
                 encryption: arn:aws:kms:us-east-1:512686554592:key/b626157a-1e5b-4bf6-8799-211505efe072 
             ec2:
                 cluster-size: 2
-                dns-external-primary: True
-                dns-internal: True
+                dns-external-primary: true
+                dns-internal: true
             elb:
                 protocol:
                     - 443
@@ -1972,7 +1972,7 @@ elife-xpub:
                 deletion-policy: Snapshot
             ec2:
                 cluster-size: 2
-                dns-internal: True
+                dns-internal: true
             elb:
                 protocol:
                     - 443

--- a/projects/elife.yaml
+++ b/projects/elife.yaml
@@ -31,10 +31,10 @@ defaults:
             cluster-size: 1
             # whether the first EC2 node should get an external DNS entry such as env--project--1.elifesciences.org
             # only makes sense if cluster-size > 1
-            dns-external-primary: True
+            dns-external-primary: false
             # whether the EC2 nodes should get a per-node internal DNS entry such as env--project--1.elife.internal
             # only makes sense if cluster-size > 1
-            dns-internal: False
+            dns-internal: false
             # override 'ext' (only supported key)
             # for some EC2 instances
             overrides: {}

--- a/src/buildercore/cfngen.py
+++ b/src/buildercore/cfngen.py
@@ -535,7 +535,7 @@ def generate_stack(pname, **more_context):
 # can't add ExtDNS: it changes dynamically when we start/stop instances and should not be touched after creation
 UPDATABLE_TITLE_PATTERNS = ['^CloudFront.*', '^ElasticLoadBalancer.*', '^EC2Instance.*', '.*Bucket$', '.*BucketPolicy', '^StackSecurityGroup$', '^ELBSecurityGroup$', '^CnameDNS.+$', 'FastlyDNS\\d+$', '^AttachedDB$', '^AttachedDBSubnet$', '^ExtraStorage.+$', '^MountPoint.+$', '^IntDNS.*$', '^ElastiCache.*$']
 
-REMOVABLE_TITLE_PATTERNS = ['^CloudFront.*', '^CnameDNS\\d+$', 'FastlyDNS\\d+$', '^ExtDNS$', '^ExtraStorage.+$', '^MountPoint.+$', '^.+Queue$', '^EC2Instance.+$', '^IntDNS.*$', '^ElastiCache.*$', '^.+Topic$', '^AttachedDB$', '^AttachedDBSubnet$', '^VPCSecurityGroup$', '^KeyName$']
+REMOVABLE_TITLE_PATTERNS = ['^CloudFront.*', '^CnameDNS\\d+$', 'FastlyDNS\\d+$', '^ExtDNS$', '^ExtDNS1$', '^ExtraStorage.+$', '^MountPoint.+$', '^.+Queue$', '^EC2Instance.+$', '^IntDNS.*$', '^ElastiCache.*$', '^.+Topic$', '^AttachedDB$', '^AttachedDBSubnet$', '^VPCSecurityGroup$', '^KeyName$']
 EC2_NOT_UPDATABLE_PROPERTIES = ['ImageId', 'Tags', 'UserData']
 
 # CloudFormation is nicely chopped up into:

--- a/src/buildercore/core.py
+++ b/src/buildercore/core.py
@@ -678,6 +678,7 @@ def hostname_struct(stackname):
     if domain:
         updates['project_hostname'] = subdomain + "." + domain
         updates['full_hostname'] = hostname + "." + domain
+        updates['ext_node_hostname'] = hostname + "--%s." + domain
 
     if intdomain:
         updates['int_project_hostname'] = subdomain + "." + intdomain

--- a/src/buildercore/core.py
+++ b/src/buildercore/core.py
@@ -132,7 +132,7 @@ def tags2dict(tags):
     return dict((el['Key'], el['Value']) for el in tags)
 
 def find_ec2_instances(stackname, state='running', node_ids=None, allow_empty=False):
-    "returns list of ec2 instances data for a *specific* stackname"
+    "returns list of ec2 instances data for a *specific* stackname. Ordered by node index (1 to N)"
     # http://docs.aws.amazon.com/AWSEC2/latest/APIReference/API_DescribeInstances.html
     conn = boto_conn(stackname, 'ec2')
     filters = [

--- a/src/buildercore/core.py
+++ b/src/buildercore/core.py
@@ -668,8 +668,8 @@ def hostname_struct(stackname):
         return struct
 
     # removes any non-alphanumeric or hyphen characters
-    subsubdomain = re.sub(r'[^\w\-]', '', instance_id)
-    hostname = subsubdomain + "--" + subdomain
+    instance_subdomain_fragment = re.sub(r'[^\w\-]', '', instance_id)
+    hostname = instance_subdomain_fragment + "--" + subdomain
 
     updates = {
         'hostname': hostname,

--- a/src/buildercore/lifecycle.py
+++ b/src/buildercore/lifecycle.py
@@ -267,8 +267,9 @@ def update_dns(stackname):
     if context['ec2']['dns-external-primary']:
         primary = 1
         primary_hostname = context['ext_node_hostname'] % primary
+        primary_ip_address = nodes[0].public_ip_address
         LOG.info("External primary full hostname: %s", primary_hostname)
-        _update_dns_a_record(context['domain'], primary_hostname, node.public_ip_address)
+        _update_dns_a_record(context['domain'], primary_hostname, primary_ip_address)
 
     if context.get('elb', False):
         # ELB has its own DNS, EC2 nodes will autoregister

--- a/src/buildercore/lifecycle.py
+++ b/src/buildercore/lifecycle.py
@@ -281,15 +281,6 @@ def update_dns(stackname):
         for node in nodes:
             _update_dns_a_record(context['domain'], context['full_hostname'], node.public_ip_address)
 
-    # We don't strictly need to do this, as the private ip address
-    # inside a VPC should stay the same. For consistency we update all DNS
-    # entries as the operation is idempotent
-    # TODO: possibly drop
-    LOG.info("Internal full hostname: %s", context['int_full_hostname'])
-    if context['int_full_hostname']:
-        for node in nodes:
-            _update_dns_a_record(context['int_domain'], context['int_full_hostname'], node.private_ip_address)
-
 def delete_dns(stackname):
     context = load_context(stackname)
     if context['full_hostname']:

--- a/src/buildercore/trop.py
+++ b/src/buildercore/trop.py
@@ -513,7 +513,7 @@ def render_ec2_dns(context, template):
             template.add_resource(dns_record)
 
     # primary ec2 node in a cluster may get an external hostname
-    if context['ec2']['dns-external-primary']:
+    if context['domain'] and context['ec2']['dns-external-primary']:
         hostedzone = context['domain'] + "."
         primary = 1
         dns_record = route53.RecordSetType(

--- a/src/buildercore/trop.py
+++ b/src/buildercore/trop.py
@@ -35,6 +35,7 @@ DBSUBNETGROUP_TITLE = 'AttachedDBSubnet'
 EXT_TITLE = "ExtraStorage%s"
 EXT_MP_TITLE = "MountPoint%s"
 R53_EXT_TITLE = "ExtDNS"
+R53_EXT_TITLE_NODE = "ExtDNS%s"
 R53_INT_TITLE = "IntDNS"
 R53_INT_TITLE_NODE = "IntDNS%s"
 R53_CDN_TITLE = "CloudFrontCDNDNS%s"
@@ -510,6 +511,21 @@ def render_ec2_dns(context, template):
                 ResourceRecords=[GetAtt(EC2_TITLE_NODE % node, "PrivateIp")],
             )
             template.add_resource(dns_record)
+
+    # primary ec2 node in a cluster may get an external hostname
+    if context['ec2']['dns-external-primary']:
+        hostedzone = context['domain'] + "."
+        primary = 1
+        dns_record = route53.RecordSetType(
+            R53_EXT_TITLE_NODE % primary,
+            HostedZoneName=hostedzone,
+            Comment="External DNS record for EC2 primary",
+            Name=context['ext_node_hostname'] % primary,
+            Type="A",
+            TTL="60",
+            ResourceRecords=[GetAtt(EC2_TITLE_NODE % primary, "PublicIp")],
+        )
+        template.add_resource(dns_record)
 
 def render_sns(context, template):
     for topic_name in context['sns']:

--- a/src/tests/fixtures/dummy1-project.json
+++ b/src/tests/fixtures/dummy1-project.json
@@ -15,6 +15,7 @@
     "aws": {
         "ec2": {
             "cluster-size": 1, 
+            "dns-external-primary": false,
             "dns-internal": false, 
             "suppressed": [], 
             "overrides": {}, 

--- a/src/tests/fixtures/dummy2-project.json
+++ b/src/tests/fixtures/dummy2-project.json
@@ -15,6 +15,7 @@
     "aws": {
         "ec2": {
             "cluster-size": 1, 
+            "dns-external-primary": false,
             "dns-internal": false, 
             "suppressed": [], 
             "overrides": {}, 
@@ -69,6 +70,7 @@
         "fresh": {
             "ec2": {
                 "cluster-size": 1, 
+                "dns-external-primary": false,
                 "dns-internal": false, 
                 "suppressed": [], 
                 "overrides": {}, 
@@ -123,6 +125,7 @@
         "alt-config1": {
             "ec2": {
                 "cluster-size": 1, 
+                "dns-external-primary": false,
                 "dns-internal": false, 
                 "suppressed": [], 
                 "overrides": {}, 

--- a/src/tests/fixtures/dummy3-project.json
+++ b/src/tests/fixtures/dummy3-project.json
@@ -15,6 +15,7 @@
     "aws": {
         "ec2": {
             "cluster-size": 1, 
+            "dns-external-primary": false,
             "dns-internal": false, 
             "suppressed": [], 
             "overrides": {}, 
@@ -45,6 +46,7 @@
         "fresh": {
             "ec2": {
                 "cluster-size": 1, 
+                "dns-external-primary": false,
                 "dns-internal": false, 
                 "suppressed": [], 
                 "overrides": {}, 
@@ -75,6 +77,7 @@
         "alt-config1": {
             "ec2": {
                 "cluster-size": 1, 
+                "dns-external-primary": false,
                 "dns-internal": false, 
                 "suppressed": [], 
                 "overrides": {}, 
@@ -124,6 +127,7 @@
         "alt-config2": {
             "ec2": {
                 "cluster-size": 1, 
+                "dns-external-primary": false,
                 "dns-internal": false, 
                 "suppressed": [], 
                 "overrides": {}, 

--- a/src/tests/fixtures/projects/dummy-project.yaml
+++ b/src/tests/fixtures/projects/dummy-project.yaml
@@ -24,7 +24,7 @@ defaults:
     aws:
         ec2:
             cluster-size: 1
-            tns-external-primary: false
+            dns-external-primary: false
             dns-internal: false
             # nodes to temporarily delete, for later recreation
             # https://martinfowler.com/bliki/PhoenixServer.html

--- a/src/tests/fixtures/projects/dummy-project.yaml
+++ b/src/tests/fixtures/projects/dummy-project.yaml
@@ -24,6 +24,7 @@ defaults:
     aws:
         ec2:
             cluster-size: 1
+            dns-external-primary: False
             dns-internal: False
             # nodes to temporarily delete, for later recreation
             # https://martinfowler.com/bliki/PhoenixServer.html
@@ -454,6 +455,7 @@ project-with-cluster:
             - 80
         ec2:
             cluster-size: 2
+            dns-external-primary: True
             dns-internal: True
         elb: 
             protocol: http

--- a/src/tests/fixtures/projects/dummy-project.yaml
+++ b/src/tests/fixtures/projects/dummy-project.yaml
@@ -24,8 +24,8 @@ defaults:
     aws:
         ec2:
             cluster-size: 1
-            dns-external-primary: False
-            dns-internal: False
+            dns-external-primary: false
+            dns-internal: false
             # nodes to temporarily delete, for later recreation
             # https://martinfowler.com/bliki/PhoenixServer.html
             suppressed: []

--- a/src/tests/fixtures/projects/dummy-project.yaml
+++ b/src/tests/fixtures/projects/dummy-project.yaml
@@ -24,7 +24,7 @@ defaults:
     aws:
         ec2:
             cluster-size: 1
-            dns-external-primary: false
+            tns-external-primary: false
             dns-internal: false
             # nodes to temporarily delete, for later recreation
             # https://martinfowler.com/bliki/PhoenixServer.html
@@ -455,8 +455,8 @@ project-with-cluster:
             - 80
         ec2:
             cluster-size: 2
-            dns-external-primary: True
-            dns-internal: True
+            dns-external-primary: true
+            dns-internal: true
         elb: 
             protocol: http
         subdomains:

--- a/src/tests/fixtures/projects/dummy-project2.yaml
+++ b/src/tests/fixtures/projects/dummy-project2.yaml
@@ -22,6 +22,7 @@ defaults:
     aws:
         ec2:
             cluster-size: 1
+            dns-external-primary: false
             dns-internal: False
             # find more here: http://cloud-images.ubuntu.com/releases/
             ami: ami-9eaa1cf6  # Ubuntu 14.04

--- a/src/tests/fixtures/projects/dummy-project2.yaml
+++ b/src/tests/fixtures/projects/dummy-project2.yaml
@@ -23,7 +23,7 @@ defaults:
         ec2:
             cluster-size: 1
             dns-external-primary: false
-            dns-internal: False
+            dns-internal: false
             # find more here: http://cloud-images.ubuntu.com/releases/
             ami: ami-9eaa1cf6  # Ubuntu 14.04
             master_ip: 192.168.1.254

--- a/src/tests/test_buildercore_core.py
+++ b/src/tests/test_buildercore_core.py
@@ -37,6 +37,7 @@ class SimpleCases(base.BaseCase):
             'int_project_hostname': 'dummy2.example.internal',
             'full_hostname': 'ci--dummy2.example.org',
             'int_full_hostname': 'ci--dummy2.example.internal',
+            'ext_node_hostname': 'ci--dummy2--%s.example.org',
             'int_node_hostname': 'ci--dummy2--%s.example.internal',
         }
         stackname = 'dummy2--ci'

--- a/src/tests/test_buildercore_trop.py
+++ b/src/tests/test_buildercore_trop.py
@@ -315,6 +315,19 @@ class TestBuildercoreTrop(base.BaseCase):
         )
         self.assertIn('IntDNS2', list(resources.keys()))
 
+        self.assertIn('ExtDNS1', list(resources.keys()))
+        self.assertEqual(
+            {
+                'ResourceRecords': [{'Fn::GetAtt': ['EC2Instance1', 'PublicIp']}],
+                'HostedZoneName': 'example.org.',
+                'Name': 'prod--project-with-cluster--1.example.org',
+                'TTL': '60',
+                'Type': 'A',
+                'Comment': 'External DNS record for EC2 primary',
+            },
+            resources['ExtDNS1']['Properties']
+        )
+
     def test_clustered_template_suppressing_some_nodes(self):
         extra = {
             'stackname': 'project-with-cluster-suppressed--prod',


### PR DESCRIPTION
A primary node is defined as node 1 of a cluster of N identical, which are usually behind a load balancer. Sometimes this node is special as it runs processes like a testing database or a unique process that should not be running on other nodes.

This adds support for `dns-external-primary`, which adds a public DNS for node 1 of a cluster. This makes the primary node accessible to the outside world, for example to `elife-spectrum` tests.

- Create with the `ExtDNS1` DNS resource in CloudFormation
- Maintain after reboots in `update_dns`