### PR TITLE
Add reproducible-document-stack infrastructure

### DIFF
--- a/projects/elife.yaml
+++ b/projects/elife.yaml
@@ -2115,6 +2115,7 @@ reproducible-document-stack:
                     hostname: "{instance}-elife-reproducible-document-stack.s3.amazonaws.com"
             subdomains:
                 - "{instance}--cdn-repro"
+            default-ttl: 60 # seconds
             # doesn't work and there's no information about why
             # https://community.fastly.com/t/monitoring-health-status-from-fastly-health-checks/516
             #healthcheck:

--- a/projects/elife.yaml
+++ b/projects/elife.yaml
@@ -2097,3 +2097,13 @@ bastion:
             - bastion
     vagrant:
         ram: 512
+
+reproducible-document-stack:
+    description: Reproducible Document Stack example
+    subdomain: rds
+    repo: https://github.com/elifesciences/rds-example
+    aws: 
+        ec2: false
+        s3:
+            "{instance}-elife-reproducible-document-stack":
+                public: true

--- a/projects/elife.yaml
+++ b/projects/elife.yaml
@@ -2129,9 +2129,9 @@ reproducible-document-stack:
             #    fallbacks:
             #        4xx: "4xx.html"
             #        5xx: "5xx.html"
-            #vcl:
-            #    - "original-host"
-            #    - "ping-status"
+            vcl:
+                - "original-host"
+                - "ping-status"
             gcslogging:
                 bucket: "{instance}-elife-fastly"
                 path: "reproducible-document-stack--{instance}/"

--- a/projects/elife.yaml
+++ b/projects/elife.yaml
@@ -2013,6 +2013,8 @@ fastly-logs:
                         schema: ./src/buildercore/bigquery/schemas/fastly-logs-201810.json
                     iiif:
                         schema: ./src/buildercore/bigquery/schemas/fastly-logs-201810.json
+                    reproducible_document_stack:
+                        schema: ./src/buildercore/bigquery/schemas/fastly-logs-201810.json
     aws-alt: {}
 
 data-pipeline:

--- a/projects/elife.yaml
+++ b/projects/elife.yaml
@@ -2115,6 +2115,8 @@ reproducible-document-stack:
                     hostname: "{instance}-elife-reproducible-document-stack.s3.amazonaws.com"
             subdomains:
                 - "{instance}--cdn-rds"
+            # doesn't work and there's no information about why
+            # https://community.fastly.com/t/monitoring-health-status-from-fastly-health-checks/516
             #healthcheck:
             #    path: /ping-fastly
             #    check-interval: 10000

--- a/projects/elife.yaml
+++ b/projects/elife.yaml
@@ -2108,3 +2108,35 @@ reproducible-document-stack:
         s3:
             "{instance}-elife-reproducible-document-stack":
                 public: true
+        fastly:
+            backends:
+                # first is default
+                default:
+                    hostname: "{instance}-elife-reproducible-document-stack.s3.amazonaws.com"
+            subdomains:
+                - "{instance}--cdn-rds"
+            healthcheck:
+                path: /ping-fastly
+                check-interval: 10000
+                timeout: 2000
+            #errors:
+            #    # always prod for simplicity
+            #    url: https://prod-elife-error-pages.s3.amazonaws.com/
+            #    codes:
+            #        404: "404.html"
+            #        410: "410.html"
+            #        503: "503.html"
+            #    fallbacks:
+            #        4xx: "4xx.html"
+            #        5xx: "5xx.html"
+            #vcl:
+            #    - "original-host"
+            #    - "ping-status"
+            gcslogging:
+                bucket: "{instance}-elife-fastly"
+                path: "reproducible-document-stack--{instance}/"
+                period: 600
+            bigquerylogging:
+                project: "elife-fastly"
+                dataset: "{instance}"
+                table: "reproducible_document_stack"

--- a/projects/elife.yaml
+++ b/projects/elife.yaml
@@ -2125,8 +2125,6 @@ reproducible-document-stack:
                 # always prod for simplicity
                 url: https://prod-elife-error-pages.s3.amazonaws.com/
                 codes:
-                    404: "404.html"
-                    410: "410.html"
                     503: "503.html"
                 fallbacks:
                     4xx: "4xx.html"

--- a/projects/elife.yaml
+++ b/projects/elife.yaml
@@ -2100,7 +2100,6 @@ bastion:
 
 reproducible-document-stack:
     description: Reproducible Document Stack example
-    subdomain: rds
     repo: https://github.com/elifesciences/rds-example
     aws: 
         ec2: false

--- a/projects/elife.yaml
+++ b/projects/elife.yaml
@@ -2114,7 +2114,7 @@ reproducible-document-stack:
                 default:
                     hostname: "{instance}-elife-reproducible-document-stack.s3.amazonaws.com"
             subdomains:
-                - "{instance}--cdn-rds"
+                - "{instance}--cdn-repro"
             # doesn't work and there's no information about why
             # https://community.fastly.com/t/monitoring-health-status-from-fastly-health-checks/516
             #healthcheck:

--- a/projects/elife.yaml
+++ b/projects/elife.yaml
@@ -2140,3 +2140,9 @@ reproducible-document-stack:
                 project: "elife-fastly"
                 dataset: "{instance}"
                 table: "reproducible_document_stack"
+    aws-alt:
+        prod:
+            fastly:
+                subdomains:
+                    - "{instance}--cdn-repro"
+                    - repro

--- a/projects/elife.yaml
+++ b/projects/elife.yaml
@@ -2115,20 +2115,20 @@ reproducible-document-stack:
                     hostname: "{instance}-elife-reproducible-document-stack.s3.amazonaws.com"
             subdomains:
                 - "{instance}--cdn-rds"
-            healthcheck:
-                path: /ping-fastly
-                check-interval: 10000
-                timeout: 2000
-            #errors:
-            #    # always prod for simplicity
-            #    url: https://prod-elife-error-pages.s3.amazonaws.com/
-            #    codes:
-            #        404: "404.html"
-            #        410: "410.html"
-            #        503: "503.html"
-            #    fallbacks:
-            #        4xx: "4xx.html"
-            #        5xx: "5xx.html"
+            #healthcheck:
+            #    path: /ping-fastly
+            #    check-interval: 10000
+            #    timeout: 2000
+            errors:
+                # always prod for simplicity
+                url: https://prod-elife-error-pages.s3.amazonaws.com/
+                codes:
+                    404: "404.html"
+                    410: "410.html"
+                    503: "503.html"
+                fallbacks:
+                    4xx: "4xx.html"
+                    5xx: "5xx.html"
             vcl:
                 - "original-host"
                 - "ping-status"


### PR DESCRIPTION
For https://github.com/elifesciences/rds-example/pull/1

Used to create:
- https://staging-elife-reproducible-document-stack.s3.amazonaws.com/example.html (`reproducible-document-stack--staging`)
- https://staging--cdn-repro.elifesciences.org/example.html  (`reproducible-document-stack--staging`)
- https://prod-elife-reproducible-document-stack.s3.amazonaws.com/example.html (`reproducible-document-stack--prod`)
- https://repro.elifesciences.org/example.html (also responding to `prod--cdn-repro.elifesciences.org`) ( (`reproducible-document-stack--prod`)