### PR TITLE
Switch elife-xpub ELB healthcheck to dedicated path

### DIFF
--- a/projects/elife.yaml
+++ b/projects/elife.yaml
@@ -1934,6 +1934,10 @@ elife-xpub:
             elb:
                 protocol:
                     - 443
+                healthcheck:
+                    protocol: http
+                    port: 80
+                    path: /ping-elb
         staging:
             s3:
                 "{instance}-elife-xpub":
@@ -1953,6 +1957,10 @@ elife-xpub:
             elb:
                 protocol:
                     - 443
+                healthcheck:
+                    protocol: http
+                    port: 80
+                    path: /ping-elb
         prod:
             subdomains:
                 - reviewer
@@ -1977,6 +1985,10 @@ elife-xpub:
             elb:
                 protocol:
                     - 443
+                healthcheck:
+                    protocol: http
+                    port: 80
+                    path: /ping-elb
     vagrant:
         ram: 2048
         ports:


### PR DESCRIPTION
For https://github.com/elifesciences/elife-xpub/issues/1409

Still to be applied as it depends on https://github.com/elifesciences/elife-xpub-formula/pull/70