### PR TITLE
downgrade pip and reduce docker image size for python 3

### DIFF
--- a/Dockerfile.py3
+++ b/Dockerfile.py3
@@ -1,7 +1,23 @@
-FROM python:3.5-slim-jessie
+FROM python:3.5-alpine3.8
 
-RUN pip install virtualenv
-RUN mkdir /venv && virtualenv --python=python3 /venv
+RUN apk add --no-cache \
+    libressl-dev \
+    musl-dev \
+    libffi-dev
+
 COPY requirements.txt /requirements.txt
-RUN /venv/bin/pip install -r /requirements.txt
+
+RUN apk add --no-cache --virtual build-deps \
+    curl \
+    gcc \
+    make \
+    && \
+    curl https://bootstrap.pypa.io/get-pip.py -o get-pip.py && \
+    python get-pip.py pip==9.0.2 && \
+    pip install virtualenv && \
+    mkdir /venv && \
+    virtualenv --python=python3 /venv && \
+    /venv/bin/pip install -r /requirements.txt && \
+    apk del build-deps
+
 CMD /venv/bin/python


### PR DESCRIPTION
This should resolve the issues relating to the errors [here](https://github.com/elifesciences/builder/pull/465)