### PR TITLE
Feature: moves elife-bot configuration over to 16.04

### DIFF
--- a/projects/elife.yaml
+++ b/projects/elife.yaml
@@ -720,7 +720,8 @@ elife-bot:
     subdomain: bot
     aws:
         ec2:
-            ami: ami-92002785 # Ubuntu 14.04, deprecated
+            ami: ami-14a1d06e # GENERATED created from basebox--1604
+                              # us-east-1, build date 20170811, hvm:ebs-ssd, AMI built on 20171215
         type: t2.medium
         ports:
             - 22
@@ -800,7 +801,7 @@ elife-bot:
                 #"{instance}-elife-ejp-poa-delivery":
                 #    deletion-policy: retain
     vagrant:
-        box: ubuntu/trusty64 # Ubuntu 14.04, deprecated
+        box: bento/ubuntu-16.04 # 16.04, deprecated
 
 generic-cdn:
     description: generic CDN for content like PDF, images

--- a/projects/elife.yaml
+++ b/projects/elife.yaml
@@ -719,6 +719,9 @@ elife-bot:
     formula-repo: https://github.com/elifesciences/elife-bot-formula
     subdomain: bot
     aws:
+        ec2:
+            ami: ami-14a1d06e # GENERATED created from basebox--1604
+                              # us-east-1, build date 20170811, hvm:ebs-ssd, AMI built on 20171215
         type: t2.medium
         ports:
             - 22
@@ -797,7 +800,8 @@ elife-bot:
                 # already existing bucket, do not uncomment
                 #"{instance}-elife-ejp-poa-delivery":
                 #    deletion-policy: retain
-    vagrant: {}
+    vagrant:
+        box: bento/ubuntu-16.04 # 16.04, deprecated
 
 generic-cdn:
     description: generic CDN for content like PDF, images

--- a/projects/elife.yaml
+++ b/projects/elife.yaml
@@ -719,9 +719,6 @@ elife-bot:
     formula-repo: https://github.com/elifesciences/elife-bot-formula
     subdomain: bot
     aws:
-        ec2:
-            ami: ami-14a1d06e # GENERATED created from basebox--1604
-                              # us-east-1, build date 20170811, hvm:ebs-ssd, AMI built on 20171215
         type: t2.medium
         ports:
             - 22
@@ -800,8 +797,7 @@ elife-bot:
                 # already existing bucket, do not uncomment
                 #"{instance}-elife-ejp-poa-delivery":
                 #    deletion-policy: retain
-    vagrant:
-        box: bento/ubuntu-16.04 # 16.04, deprecated
+    vagrant: {}
 
 generic-cdn:
     description: generic CDN for content like PDF, images


### PR DESCRIPTION
elife-bot has just a few too many issues to deal with right now for a straight 14.04 -> 18.04 upgrade. It works nicely on 16.04 however

* depends on https://github.com/elifesciences/elife-bot-formula/pull/7