### PR TITLE
project config, updates elife-dashboard to use 18.04

### DIFF
--- a/projects/elife.yaml
+++ b/projects/elife.yaml
@@ -972,13 +972,12 @@ journal-cms:
 
 
 elife-dashboard:
+    salt: '2017.7.8'
     subdomain: ppp-dash # ppp-dash.elifesciences.org
     repo: https://github.com/elifesciences/elife-dashboard
     formula-repo: https://github.com/elifesciences/elife-dashboard-formula
     default-branch: develop
     aws:
-        ec2:
-            ami: ami-92002785 # Ubuntu 14.04, deprecated
         ports:
             - 22
             - 80 # dashboard
@@ -1013,7 +1012,6 @@ elife-dashboard:
                     subscriptions:
                         - elife-bot-event-property--prod
     vagrant:
-        box: ubuntu/trusty64 # Ubuntu 14.04, deprecated
         ports:
             1324: 80
             8080: 8080 # scheduler (blocked on AWS)


### PR DESCRIPTION
elife dashboard works nicely on 16.04 and 18.04 with the npm fix here: https://github.com/elifesciences/builder-base-formula/pull/209