### PR TITLE
Use Vault to authenticate to GCP

### DIFF
--- a/docs/vault.md
+++ b/docs/vault.md
@@ -72,3 +72,16 @@ Non-`master-server` stacks can pull secrets from Vault through the Salt master, 
 | Vagrant         | Masterless?        | No             | -             |
 | EC2             | Masterful          | Only for tests | Itself        |
 | EC2             | Masterless         | Only for tests | Itself        |
+
+## Builder secrets dependencies
+
+```
+VAULT_ADDR=https://master-server.elifesciences.org:8200 vault kv list secret/builder/apikey
+```
+gives the following:
+
+- `fastly`: API key for Fastly `it-admin@elifesciences.org` user, with permission to modify the CDN
+- `fastly-gcp-logging`: API key for Fastly to write logs to GCP (BigQuery)
+- `fastly-gcs-logging`: API key for Fastly to write logs to GCS (Google Cloud Storage buckets)
+- `gcp`: JSON credentials for the `builder@elife-infrastructure.iam.gserviceaccount.com` Service Account
+- `github`: Github token for accessing private repositories

--- a/src/buildercore/terraform.py
+++ b/src/buildercore/terraform.py
@@ -20,6 +20,7 @@ DATA_TYPE_TEMPLATE = 'template_file'
 DATA_NAME_VAULT_GCS_LOGGING = 'fastly-gcs-logging'
 DATA_NAME_VAULT_GCP_LOGGING = 'fastly-gcp-logging'
 DATA_NAME_VAULT_FASTLY_API_KEY = 'fastly'
+DATA_NAME_VAULT_GCP_API_KEY = 'gcp'
 DATA_NAME_VAULT_GITHUB = 'github'
 
 # keys to lookup in Vault
@@ -28,6 +29,7 @@ DATA_NAME_VAULT_GITHUB = 'github'
 VAULT_PATH_FASTLY = 'secret/builder/apikey/fastly'
 VAULT_PATH_FASTLY_GCS_LOGGING = 'secret/builder/apikey/fastly-gcs-logging'
 VAULT_PATH_FASTLY_GCP_LOGGING = 'secret/builder/apikey/fastly-gcp-logging'
+VAULT_PATH_GCP = 'secret/builder/apikey/gcp'
 VAULT_PATH_GITHUB = 'secret/builder/apikey/github'
 
 FASTLY_GZIP_TYPES = ['text/html', 'application/x-javascript', 'text/css', 'application/javascript',
@@ -705,6 +707,7 @@ def init(stackname, context):
                 'google': {
                     'version': "= %s" % '1.20.0',
                     'region': 'us-east4',
+                    'credentials': "${data.%s.%s.data[\"credentials\"]}" % (DATA_TYPE_VAULT_GENERIC_SECRET, DATA_NAME_VAULT_GCP_API_KEY),
                     # TODO: the system-wide authentication is being used
                     # to provision through this provider (see `gcloud auth list`)
                     # It could be possible to create a Service Account for
@@ -720,13 +723,17 @@ def init(stackname, context):
                     'version': "= %s" % PROVIDER_VAULT_VERSION,
                 },
             },
-            # TODO: this should not be used unless Fastly is involved
             'data': {
                 DATA_TYPE_VAULT_GENERIC_SECRET: {
+                    # TODO: this should not be used unless Fastly is involved
                     DATA_NAME_VAULT_FASTLY_API_KEY: {
                         'path': VAULT_PATH_FASTLY,
-                    }
-                }
+                    },
+                    # TODO: this should not be used unless GCP is involved
+                    DATA_NAME_VAULT_GCP_API_KEY: {
+                        'path': VAULT_PATH_GCP,
+                    },
+                },
             },
         }))
     terraform.init(input=False, capture_output=False, raise_on_error=True)

--- a/src/buildercore/terraform.py
+++ b/src/buildercore/terraform.py
@@ -708,14 +708,6 @@ def init(stackname, context):
                     'version': "= %s" % '1.20.0',
                     'region': 'us-east4',
                     'credentials': "${data.%s.%s.data[\"credentials\"]}" % (DATA_TYPE_VAULT_GENERIC_SECRET, DATA_NAME_VAULT_GCP_API_KEY),
-                    # TODO: the system-wide authentication is being used
-                    # to provision through this provider (see `gcloud auth list`)
-                    # It could be possible to create a Service Account for
-                    # a certain project and put it in Vault to allow more
-                    # people to run `update_infrastructure`
-                    # This is not ideal anyway, as it would be a set of credentials
-                    # with large powers (but maybe limited to the single GCP project)
-                    # TODO: definitely do the above
                 },
                 'vault': {
                     'address': context['vault']['address'],


### PR DESCRIPTION
For https://github.com/elifesciences/issues/issues/4833

Run successfully:
```
bldr update_infrastructure:fastly-logs--end2end,skip=ec2
bldr update_infrastructure:data-pipeline--ci,skip=ec2
```
after having revoked my local `gcloud` authentication.

The providers look like:
```
$ cat .cfn/terraform/fastly-logs--end2end/providers.tf.json | jq .provider
{
  "fastly": {
    "api_key": "${data.vault_generic_secret.fastly.data[\"api_key\"]}",
    "version": "= 0.4.0"
  },
  "google": {
    "credentials": "${data.vault_generic_secret.gcp.data[\"credentials\"]}",
    "region": "us-east4",
    "version": "= 1.20.0"
  },
  "vault": {
    "version": "= 1.3",
    "address": "https://master-server.elifesciences.org:8200"
  }
}
```
so this is now using the same pattern as Fastly.