### PR TITLE
Add internal DNS to lax single-node instances

### DIFF
--- a/projects/elife.yaml
+++ b/projects/elife.yaml
@@ -352,7 +352,6 @@ master-server:
 lax:
     description: article-json store
     subdomain: lax # lax.elifesciences.org
-    intdomain: False
     repo: https://github.com/elifesciences/lax.git
     formula-repo: https://github.com/elifesciences/lax-formula
     aws:


### PR DESCRIPTION
To solve https://alfred.elifesciences.org/blue/organizations/jenkins/dependencies-lax-update-bot-lax-adaptor/detail/dependencies-lax-update-bot-lax-adaptor/267/pipeline

The removal probably got applied only now with the Salt update_infrastructure commands.

This DNS can't be added to all instances because sometimes there's 2 (lax--prod) and the DNS entry can only point to one. This build really depends on it, however, so we need it for `lax--ci` only. 

Turns out the `trop` module is now smarted and will skip this in case there are multiple nodes behind an ELB. So I applied this to `lax--ci` and `lax--continuumtest`; the other stacks `end2end` and `prod` have no outstanding changes.