### PR TITLE
Fix: fail hard when bootstrap user's private key doesn't exist on the fs

### DIFF
--- a/src/buildercore/core.py
+++ b/src/buildercore/core.py
@@ -246,12 +246,16 @@ def stack_pem(stackname, die_if_exists=False, die_if_doesnt_exist=False):
 
 def _ec2_connection_params(stackname, username, **kwargs):
     "returns a dictionary of settings to be used with Fabric's api.settings context manager"
+    # http://docs.fabfile.org/en/1.14/usage/env.html
     params = {'user': username}
     pem = stack_pem(stackname)
     # handles cases where we want to establish a connection to run a task
     # when machine has failed to provision correctly.
-    if os.path.exists(pem) and username == config.BOOTSTRAP_USER:
-        params['key_filename'] = pem
+    if username == config.BOOTSTRAP_USER:
+        if os.path.exists(pem):
+            params['key_filename'] = pem
+        else:
+            raise RuntimeError("private key for the bootstrap user for this host does not exist. I looked here: %s" % pem)
     params.update(kwargs)
     return params
 


### PR DESCRIPTION
encountered while updating the journal-cms instances

I *think* it may have to do with never having performed any action on that instance on my machine while doing the update, hence no opportunity to download the bootstrap key. I have a hack elsewhere that gets around that case that I'll add to this PR once I integrate it better