### PR TITLE
Repair journal-cms--continuumtest

### DIFF
--- a/src/buildercore/cfngen.py
+++ b/src/buildercore/cfngen.py
@@ -552,7 +552,7 @@ def generate_stack(pname, **more_context):
 
 
 # can't add ExtDNS: it changes dynamically when we start/stop instances and should not be touched after creation
-UPDATABLE_TITLE_PATTERNS = ['^CloudFront.*', '^ElasticLoadBalancer.*', '^EC2Instance.*', '.*Bucket$', '.*BucketPolicy', '^StackSecurityGroup$', '^ELBSecurityGroup$', '^CnameDNS.+$', 'FastlyDNS\\d+$', '^AttachedDB$', '^AttachedDBSubnet$', '^ExtraStorage.+$', '^MountPoint.+$', '^IntDNS.*$', '^ElastiCache.*$', '^AZ.+$', '^InstanceId.+$', '^PrivateIP.+$', '^DomainName$']
+UPDATABLE_TITLE_PATTERNS = ['^CloudFront.*', '^ElasticLoadBalancer.*', '^EC2Instance.*', '.*Bucket$', '.*BucketPolicy', '^StackSecurityGroup$', '^ELBSecurityGroup$', '^CnameDNS.+$', 'FastlyDNS\\d+$', '^AttachedDB$', '^AttachedDBSubnet$', '^ExtraStorage.+$', '^MountPoint.+$', '^IntDNS.*$', '^ElastiCache.*$', '^AZ.+$', '^InstanceId.+$', '^PrivateIP.+$', '^DomainName$', '^RDSHost$', '^RDSPort$']
 
 REMOVABLE_TITLE_PATTERNS = ['^CloudFront.*', '^CnameDNS\\d+$', 'FastlyDNS\\d+$', '^ExtDNS$', '^ExtDNS1$', '^ExtraStorage.+$', '^MountPoint.+$', '^.+Queue$', '^EC2Instance.+$', '^IntDNS.*$', '^ElastiCache.*$', '^.+Topic$', '^AttachedDB$', '^AttachedDBSubnet$', '^VPCSecurityGroup$', '^KeyName$']
 EC2_NOT_UPDATABLE_PROPERTIES = ['ImageId', 'Tags', 'UserData']

--- a/src/buildercore/keypair.py
+++ b/src/buildercore/keypair.py
@@ -32,9 +32,9 @@ def delete_keypair_from_s3(stackname):
     s3.delete(key)
     return s3.exists(key)
 
-def download_from_s3(stackname):
-    expected_path = stack_pem(stackname, die_if_exists=True)
-    s3.download(s3_keypair_key(stackname), expected_path)
+def download_from_s3(stackname, die_if_exists=True):
+    expected_path = stack_pem(stackname, die_if_exists=die_if_exists)
+    s3.download(s3_keypair_key(stackname), expected_path, overwrite=True)
     stack_pem(stackname, die_if_doesnt_exist=True)
     local('chmod 400 %s' % expected_path)
     return expected_path

--- a/src/buildercore/s3.py
+++ b/src/buildercore/s3.py
@@ -94,8 +94,9 @@ def simple_listing(prefix):
     "returns a realized list of the names of the keys from the `list` function. "
     return [key.key for key in listing(prefix)]
 
-def download(key, output_path):
-    ensure(not os.path.exists(output_path), "given output path exists, will not overwrite: %r" % output_path)
+def download(key, output_path, overwrite=False):
+    if not overwrite:
+        ensure(not os.path.exists(output_path), "given output path exists, will not overwrite: %r" % output_path)
     ensure(exists(key), "key %r not found in bucket %r" % (key, config.BUILDER_BUCKET))
     LOG.info("downloading key %s", key, extra={'key': key})
     builder_bucket().Object(key).download_file(output_path)

--- a/src/buildvars.py
+++ b/src/buildvars.py
@@ -149,6 +149,6 @@ def refresh(stackname, context):
 
     # lsh@2019-06: cfn.update_infrastructure fails to run highstate on new ec2 instance if keypair not present,
     # it prompts for a password for the deploy user. prompts when executing in parallel cause operation to fail
-    keypair.download_from_s3(stackname)
+    keypair.download_from_s3(stackname, die_if_exists=False)
 
     stack_all_ec2_nodes(stackname, _refresh_buildvars, username=BOOTSTRAP_USER)


### PR DESCRIPTION
For https://github.com/elifesciences/issues/issues/4946

Applying to `journal-cms--continuumtest` only, other stacks are fine.

The impact of the `Outputs` bug is only the scenario in which an RDS instance is added to an existing project, in that case the new outputs are not propagated. Creating the stack from scratch generates everything correctly.