### PR TITLE
Use a basic SSD as part of the AMI

### DIFF
--- a/projects/elife.yaml
+++ b/projects/elife.yaml
@@ -1114,7 +1114,8 @@ elife-libraries:
 
 containers:
     description: run any Docker-based workload
-    subdomain: containers
+    domain: false
+    intdomain: false
     formula-repo: https://github.com/elifesciences/containers-formula
     aws:
         ec2:

--- a/projects/elife.yaml
+++ b/projects/elife.yaml
@@ -1136,6 +1136,7 @@ containers:
             ec2:
                 root:
                     size: 100 # GB
+                    type: gp2
         xlarge:
             type: t2.xlarge # 4 CPUs
             ec2:

--- a/src/buildercore/trop.py
+++ b/src/buildercore/trop.py
@@ -223,6 +223,8 @@ echo %s > /etc/build-vars.json.b64
             'Ebs': {
                 'VolumeSize': context['ec2']['root']['size'],
                 'VolumeType': context['ec2']['root'].get('type', 'standard'),
+                # unfortunately root volumes do not support Tags:
+                # https://blog.cloudability.com/two-solutions-for-tagging-elusive-aws-ebs-volumes/
             }
         }]
     return ec2.Instance(EC2_TITLE_NODE % node, **project_ec2)


### PR DESCRIPTION
This allow Jenkins to launch EC2 instances using a single big SSD volume, starting from this AMI.