### PR TITLE
Feature: adds a 'restart all' command

### DIFF
--- a/src/askmaster.py
+++ b/src/askmaster.py
@@ -37,3 +37,13 @@ def fail2ban_running():
 @task
 def installed_linux():
     return salt_master_cmd("'dpkg -l | grep -i linux-image'")
+
+@task
+def update_kernel():
+    cmd = "'apt-get update && DEBIAN_FRONTEND=noninteractive apt-get install linux-image-aws -y'"
+    # 16.04+ minions only
+    minion_set = [
+        'G@osrelease:16.04',
+        'G@osrelease:18.04',
+    ]
+    [salt_master_cmd(cmd, minions="--compound '%s'" % m) for m in minion_set]

--- a/src/buildercore/core.py
+++ b/src/buildercore/core.py
@@ -522,10 +522,11 @@ def stack_triple(aws_stack):
 # lists of aws stacks
 #
 
-@cached # disable until finished debugging
+@cached
 def _aws_stacks(region, status=None, formatter=stack_triple):
     "returns all stacks, even stacks deleted in the last 90 days, optionally filtered by status"
-    # NOTE: uses client rather than resource. resource cannot filter by stack status
+    # NOTE: uses boto3 client interface rather than resource interface
+    # resource interface cannot filter by stack status
     paginator = boto_client('cloudformation', region).get_paginator('list_stacks')
     paginator = paginator.paginate(StackStatusFilter=status or [])
     results = utils.shallow_flatten([row['StackSummaries'] for row in paginator])

--- a/src/buildercore/lifecycle.py
+++ b/src/buildercore/lifecycle.py
@@ -42,12 +42,12 @@ def push(lst, rec):
     if not lst or lst[-1] != rec:
         lst.append(rec)
 
-def restart(stackname):
+def restart(stackname, initial_states='pending|running|stopping|stopped'):
     """for each ec2 node in given stack, ensure ec2 node is stopped, then start it, then repeat with next node.
     rds is started if stopped (if *exists*) but otherwise not affected"""
-    start_rds_nodes(stackname)
+    #start_rds_nodes(stackname) # something a bit buggy here
 
-    node_list = find_ec2_instances(stackname, state='pending|running|stopping|stopped')
+    node_list = find_ec2_instances(stackname, state=initial_states, allow_empty=True)
 
     history = []
 
@@ -74,7 +74,9 @@ def restart(stackname):
                 update_msg="waiting for nodes to be networked",
                 done_msg="all nodes have public ips"
             )
-        update_dns(stackname)
+        if history:
+            # only update dns if we have a history of affected nodes
+            update_dns(stackname)
         return history
     except Exception:
         LOG.info("Partial restart history of %s: %s", stackname, pformat(history))

--- a/src/buildercore/lifecycle.py
+++ b/src/buildercore/lifecycle.py
@@ -45,7 +45,7 @@ def push(lst, rec):
 def restart(stackname, initial_states='pending|running|stopping|stopped'):
     """for each ec2 node in given stack, ensure ec2 node is stopped, then start it, then repeat with next node.
     rds is started if stopped (if *exists*) but otherwise not affected"""
-    #start_rds_nodes(stackname) # something a bit buggy here
+    # start_rds_nodes(stackname) # something a bit buggy here
 
     node_list = find_ec2_instances(stackname, state=initial_states, allow_empty=True)
 

--- a/src/fabfile.py
+++ b/src/fabfile.py
@@ -17,6 +17,6 @@ import askmaster
 import buildvars
 import project
 from deploy import switch_revision_update_instance
-from lifecycle import start, stop, restart, stop_if_running_for, update_dns
+from lifecycle import start, stop, restart, restart_all, stop_if_running_for, update_dns
 import masterless
 import vault

--- a/src/fabfile.py
+++ b/src/fabfile.py
@@ -17,6 +17,6 @@ import askmaster
 import buildvars
 import project
 from deploy import switch_revision_update_instance
-from lifecycle import start, stop, restart, restart_all, stop_if_running_for, update_dns
+from lifecycle import start, stop, restart, stop_if_running_for, update_dns
 import masterless
 import vault

--- a/src/lifecycle.py
+++ b/src/lifecycle.py
@@ -1,12 +1,6 @@
-import os
-import json
 from fabric.api import task
-from buildercore import lifecycle, core
-from utils import get_input
+from buildercore import lifecycle
 from decorators import requires_aws_stack, timeit, debugtask, echo_output
-import logging
-
-LOG = logging.getLogger(__name__)
 
 @task
 @requires_aws_stack
@@ -33,72 +27,6 @@ def stop(stackname, *services):
 @echo_output
 def restart(stackname):
     return lifecycle.restart(stackname)
-
-
-@task
-def restart_all(statefile):
-    "restarts all running ec2 instances. multiple nodes are restarted serially and failures prevent the rest of the node from being restarted"
-
-    os.system("touch " + statefile)
-
-    results = core.active_stack_names(core.find_region())
-
-    u1404 = [
-        'api-gateway',
-        'journal',
-        'search',
-        'api-dummy',
-        'medium',
-    ]
-
-    legacy = [
-        'elife-api'
-    ]
-
-    dont_do = u1404 + legacy
-
-    # order not preserved
-    do_first = [
-        'master-server',
-        'bus',
-        'elife-alfred',
-        'elife-bot',
-        'iiif',
-    ]
-
-    pname = lambda stackname: core.parse_stackname(stackname)[0]
-    todo = sorted(results, key=pname in do_first, reverse=True)
-    todo = filter(lambda stackname: pname(stackname) not in dont_do, todo)
-
-    print('todo:')
-    print(json.dumps(todo, indent=4))
-
-    with open(statefile, 'r') as fh:
-        done = fh.read().split('\n')
-
-    with open(statefile, 'a') as fh:
-        print('writing state to', fh.name)
-
-        for stackname in todo:
-            if stackname in done:
-                print('skipping', stackname)
-                continue
-            try:
-                print('restarting', stackname)
-                # only restart instances that are currently running
-                # this will skip ci/end2end
-                lifecycle.restart(stackname, initial_states='running')
-                print('done', stackname)
-                fh.write(stackname + "\n")
-                fh.flush()
-
-            except BaseException:
-                LOG.exception("unhandled exception restarting %s", stackname)
-                print(stackname, "is in an unknown state")
-                get_input('pausing, any key to continue, ctrl+c to quit')
-
-        print
-        print('wrote state to', fh.name)
 
 @task
 @requires_aws_stack

--- a/src/lifecycle.py
+++ b/src/lifecycle.py
@@ -1,6 +1,14 @@
+import os
+import json
+import time, tempfile
 from fabric.api import task
-from buildercore import lifecycle
-from decorators import requires_aws_stack, timeit, debugtask
+from buildercore import lifecycle, core
+from utils import get_input
+from buildercore.utils import splitfilter
+from decorators import requires_aws_stack, timeit, debugtask, echo_output
+import logging
+
+LOG = logging.getLogger(__name__)
 
 @task
 @requires_aws_stack
@@ -24,8 +32,78 @@ def stop(stackname, *services):
 @task
 @requires_aws_stack
 @timeit
+@echo_output
 def restart(stackname):
-    lifecycle.restart(stackname)
+    return lifecycle.restart(stackname)
+
+
+@task
+def restart_all(statefile):
+    "restarts all running ec2 instances. multiple nodes are restarted serially and failures prevent the rest of the node from being restarted"
+
+    os.system("touch " + statefile)
+    
+    results = core.active_stack_names(core.find_region())
+
+    u1404 = [
+        'api-gateway',
+        'journal',
+        'search',
+        'api-dummy',
+        'medium',
+    ]
+
+    legacy = [
+        'elife-api'
+    ]
+    
+    dont_do = u1404 + legacy
+
+    # order not preserved
+    do_first = [
+        'master-server',
+        'bus',
+        'elife-alfred',
+        'elife-bot',
+        'iiif',
+    ]
+
+    pname = lambda stackname: core.parse_stackname(stackname)[0]
+    todo = sorted(results, key=lambda stackname: pname(stackname) in do_first, reverse=True)
+    todo = filter(lambda stackname: pname(stackname) not in dont_do, todo)
+
+    print('todo:')
+    print(json.dumps(todo,indent=4))
+
+    with open(statefile, 'r') as fh:
+        done = fh.read().split('\n')
+
+    todo = ['bioprotocol--end2end']
+        
+    with open(statefile, 'a') as fh:
+        print('writing state to',fh.name)
+
+        for stackname in todo:
+            if stackname in done:
+                print('skipping',stackname)
+                continue
+            try:
+                print('restarting',stackname)
+                # only restart instances that are currently running
+                # this will skip ci/end2end
+                lifecycle.restart(stackname, initial_states='running') 
+                #time.sleep(2)
+                print('done',stackname)
+                fh.write(stackname + "\n")
+                fh.flush()
+            
+            except:
+                LOG.exception("unhandled exception restarting %s", stackname)
+                print(stackname,"is in an unknown state")
+                get_input('pausing, any key to continue, ctrl+c to quit')
+
+        print
+        print('wrote state to',fh.name)                
 
 @task
 @requires_aws_stack

--- a/src/tasks.py
+++ b/src/tasks.py
@@ -96,7 +96,7 @@ def restart_all_running_ec2(statefile):
     ]
 
     pname = lambda stackname: core.parse_stackname(stackname)[0]
-    todo = sorted(results, key=pname in do_first, reverse=True)
+    todo = sorted(results, key=lambda stackname: pname(stackname) in do_first, reverse=True)
     todo = filter(lambda stackname: pname(stackname) not in dont_do, todo)
 
     with open(statefile, 'r') as fh:

--- a/src/tasks.py
+++ b/src/tasks.py
@@ -3,13 +3,16 @@
 If you find certain 'types' of tasks accumulating, they might be
 better off in their own module. This module really is for stuff
 that has no home."""
-from buildercore import core, bootstrap
+import os
+from buildercore import core, bootstrap, bakery, lifecycle
 from fabric.api import local, task
-from utils import confirm, errcho
+from utils import confirm, errcho, get_input
 from decorators import requires_aws_stack, debugtask
-from buildercore import bakery
 from buildercore.core import stack_conn
 from buildercore.context_handler import load_context
+import logging
+
+LOG = logging.getLogger(__name__)
 
 @task
 @requires_aws_stack
@@ -59,3 +62,66 @@ def repair_context(stackname):
 @requires_aws_stack
 def remove_minion_key(stackname):
     bootstrap.remove_minion_key(stackname)
+
+
+@task
+def restart_all_running_ec2(statefile):
+    "restarts all running ec2 instances. multiple nodes are restarted serially and failures prevent the rest of the node from being restarted"
+
+    os.system("touch " + statefile)
+
+    results = core.active_stack_names(core.find_region())
+
+    u1404 = [
+        'api-gateway',
+        'journal',
+        'search',
+        'api-dummy',
+        'medium',
+    ]
+
+    legacy = [
+        'elife-api'
+    ]
+
+    dont_do = u1404 + legacy
+
+    # order not preserved
+    do_first = [
+        'master-server',
+        'bus',
+        'elife-alfred',
+        'elife-bot',
+        'iiif',
+    ]
+
+    pname = lambda stackname: core.parse_stackname(stackname)[0]
+    todo = sorted(results, key=pname in do_first, reverse=True)
+    todo = filter(lambda stackname: pname(stackname) not in dont_do, todo)
+
+    with open(statefile, 'r') as fh:
+        done = fh.read().split('\n')
+
+    with open(statefile, 'a') as fh:
+        LOG.info('writing state to ' + fh.name)
+
+        for stackname in todo:
+            if stackname in done:
+                LOG.info('skipping ' + stackname)
+                continue
+            try:
+                LOG.info('restarting' + stackname)
+                # only restart instances that are currently running
+                # this will skip ci/end2end
+                lifecycle.restart(stackname, initial_states='running')
+                LOG.info('done' + stackname)
+                fh.write(stackname + "\n")
+                fh.flush()
+
+            except BaseException:
+                LOG.exception("unhandled exception restarting %s", stackname)
+                LOG.warn("%s is in an unknown state", stackname)
+                get_input('pausing, any key to continue, ctrl+c to quit')
+
+        print
+        print('wrote state to', fh.name)


### PR DESCRIPTION
adds `restart_all_running_ec2` command that will restart all ec2 instances that are running

* maintains state so problems that force the task to quit won't see instances restarted again
* supports project ordering, so certain projects go first
* supports project exclusion, so certain projects are not restarted 
* uses `buildercore.lifecycle.restart` that stops nodes in order
* prompt to continue restarting instances if an error occurs
* skips nodes that aren't running
* adds `askmaster.update_kernel` to update the kernel images on 16.04 and 18.04 machines