### PR TITLE
Immediately fail boot if SSH access is denied

### DIFF
--- a/src/buildercore/core.py
+++ b/src/buildercore/core.py
@@ -326,10 +326,8 @@ def stack_all_ec2_nodes(stackname, workfn, username=config.DEPLOY_USER, concurre
                     raise err
             except config.FabricException as err:
                 LOG.error(str(err).replace("\n", "    "))
-                # not useful to specify more, this will be printed out
-                # but we are already logging it (and printing it on stderr)
-                # which is better
-                raise SystemExit("")
+                # available as 'results' to fabric.tasks.error
+                raise err
 
     # something less stateful like a context manager?
     output['aborts'] = False

--- a/src/buildercore/lifecycle.py
+++ b/src/buildercore/lifecycle.py
@@ -153,7 +153,7 @@ def _some_node_is_not_ready(stackname, **kwargs):
     try:
         # TODO: what if there are more than 1 node?
         ip_to_ready = stack_all_ec2_nodes(stackname, _daemons_ready, username=config.BOOTSTRAP_USER, **kwargs)
-        LOG.info("_daemons_ready: %s", ip_to_ready)
+        LOG.info("_some_node_is_not_ready: %s", ip_to_ready)
         return len(ip_to_ready) == 0 or False in ip_to_ready.values()
     except NoPublicIps as e:
         LOG.info("No public ips available yet: %s", e)

--- a/src/buildercore/lifecycle.py
+++ b/src/buildercore/lifecycle.py
@@ -165,7 +165,12 @@ def _some_node_is_not_ready(stackname, **kwargs):
         LOG.info("No running instances yet: %s", e)
         return True
     except config.FabricException as e:
-        LOG.info("Generic failure of _daemons_ready execution: %s", e)
+        # no more specific exception to match for login problem
+        # remove if it is discovered to be a legitimate error for booting servers
+        if "Needed to prompt for a connection or sudo password" in e.message:
+            LOG.error("SSH access problem: %s", e)
+            raise e
+        LOG.info("Generic failure of _some_node_is_not_ready execution: %s (class %s)", e, type(e))
         return True
     return False
 


### PR DESCRIPTION
Should solve https://github.com/elifesciences/builder/pull/523#issuecomment-518715341 but unsure if there are false positive when servers that are booting would temporarily refuse access in this way.

Tested by removing my key from `medium--ci:/home/ubuntu/.ssh/authorized_keys` which causes the `start` code to fail when trying to connect to check that boot has been completed.