### PR TITLE
Do not reboot on persistent SSH access problems

### DIFF
--- a/src/buildercore/lifecycle.py
+++ b/src/buildercore/lifecycle.py
@@ -165,7 +165,12 @@ def _some_node_is_not_ready(stackname, **kwargs):
         LOG.info("No running instances yet: %s", e)
         return True
     except config.FabricException as e:
-        LOG.info("Generic failure of _daemons_ready execution: %s", e)
+        # login problem is a legitimate error for booting servers,
+        # but also a signal the SSH private key is not allowed if it persists
+        if "Needed to prompt for a connection or sudo password" in e.message:
+            LOG.error("SSH access problem: %s", e)
+            return True
+        LOG.info("Generic failure of _some_node_is_not_ready execution: %s (class %s)", e, type(e))
         return True
     return False
 

--- a/src/buildercore/lifecycle.py
+++ b/src/buildercore/lifecycle.py
@@ -124,7 +124,7 @@ def start(stackname):
     try:
         wait_for_ec2_steady_state(stackname, ec2_to_be_checked)
     except EC2Timeout as e:
-        # a persistent login problem won't be solved be a reboot
+        # a persistent login problem won't be solved by a reboot
         if "Needed to prompt for a connection or sudo password" in e.message:
             raise
         # in case of botched boot and/or inability to

--- a/src/buildercore/lifecycle.py
+++ b/src/buildercore/lifecycle.py
@@ -125,7 +125,7 @@ def start(stackname):
         wait_for_ec2_steady_state(stackname, ec2_to_be_checked)
     except EC2Timeout as e:
         # a persistent login problem won't be solved by a reboot
-        if "Needed to prompt for a connection or sudo password" in e.message:
+        if "Needed to prompt for a connection or sudo password" in str(e):
             raise
         # in case of botched boot and/or inability to
         # access through SSH, try once to stop and
@@ -169,7 +169,7 @@ def _some_node_is_not_ready(stackname, **kwargs):
     except config.FabricException as e:
         # login problem is a legitimate error for booting servers,
         # but also a signal the SSH private key is not allowed if it persists
-        if "Needed to prompt for a connection or sudo password" in e.message:
+        if "Needed to prompt for a connection or sudo password" in str(e):
             LOG.info("SSH access problem in _some_node_is_not_ready execution: %s", e)
             return e
         LOG.info("Generic failure of _some_node_is_not_ready execution: %s (class %s)", e, type(e))

--- a/src/buildercore/lifecycle.py
+++ b/src/buildercore/lifecycle.py
@@ -123,7 +123,10 @@ def start(stackname):
 
     try:
         wait_for_ec2_steady_state(stackname, ec2_to_be_checked)
-    except EC2Timeout:
+    except EC2Timeout as e:
+        # a persistent login problem won't be solved be a reboot
+        if "Needed to prompt for a connection or sudo password" in e.message:
+            raise
         # in case of botched boot and/or inability to
         # access through SSH, try once to stop and
         # start the instances again
@@ -168,7 +171,7 @@ def _some_node_is_not_ready(stackname, **kwargs):
         # but also a signal the SSH private key is not allowed if it persists
         if "Needed to prompt for a connection or sudo password" in e.message:
             LOG.error("SSH access problem: %s", e)
-            return True
+            return e
         LOG.info("Generic failure of _some_node_is_not_ready execution: %s (class %s)", e, type(e))
         return True
     return False

--- a/src/buildercore/lifecycle.py
+++ b/src/buildercore/lifecycle.py
@@ -172,9 +172,8 @@ def _some_node_is_not_ready(stackname, **kwargs):
         if "Needed to prompt for a connection or sudo password" in e.message:
             LOG.info("SSH access problem in _some_node_is_not_ready execution: %s", e)
             return e
-        else:
-            LOG.info("Generic failure of _some_node_is_not_ready execution: %s (class %s)", e, type(e))
-            return True
+        LOG.info("Generic failure of _some_node_is_not_ready execution: %s (class %s)", e, type(e))
+        return True
     return False
 
 def stop(stackname, services=None):

--- a/src/buildercore/lifecycle.py
+++ b/src/buildercore/lifecycle.py
@@ -170,10 +170,11 @@ def _some_node_is_not_ready(stackname, **kwargs):
         # login problem is a legitimate error for booting servers,
         # but also a signal the SSH private key is not allowed if it persists
         if "Needed to prompt for a connection or sudo password" in e.message:
-            LOG.error("SSH access problem: %s", e)
+            LOG.info("SSH access problem in _some_node_is_not_ready execution: %s", e)
             return e
-        LOG.info("Generic failure of _some_node_is_not_ready execution: %s (class %s)", e, type(e))
-        return True
+        else:
+            LOG.info("Generic failure of _some_node_is_not_ready execution: %s (class %s)", e, type(e))
+            return True
     return False
 
 def stop(stackname, services=None):

--- a/src/buildercore/lifecycle.py
+++ b/src/buildercore/lifecycle.py
@@ -151,7 +151,6 @@ def wait_for_ec2_steady_state(stackname, ec2_to_be_checked):
 
 def _some_node_is_not_ready(stackname, **kwargs):
     try:
-        # TODO: what if there are more than 1 node?
         ip_to_ready = stack_all_ec2_nodes(stackname, _daemons_ready, username=config.BOOTSTRAP_USER, **kwargs)
         LOG.info("_some_node_is_not_ready: %s", ip_to_ready)
         return len(ip_to_ready) == 0 or False in ip_to_ready.values()

--- a/src/buildercore/s3.py
+++ b/src/buildercore/s3.py
@@ -19,7 +19,7 @@ def builder_bucket():
         return bucket
     except ClientError as err:
         LOG.error("unhandled error attempting to find S3 bucket %r in region %r", nom, region,
-                  extra={'bucket': nom, 'region': region, 'error': err.message})
+                  extra={'bucket': nom, 'region': region, 'error': str(err)})
         raise
 
 def exists(key):

--- a/src/buildercore/utils.py
+++ b/src/buildercore/utils.py
@@ -175,7 +175,7 @@ def call_while(fn, interval=5, timeout=600, update_msg="waiting ...", done_msg="
     elapsed = 0
     while True:
         result = fn()
-        if not fn():
+        if not result:
             break
         if elapsed >= timeout:
             message = "Reached timeout %d while %s" % (timeout, update_msg)

--- a/src/buildercore/utils.py
+++ b/src/buildercore/utils.py
@@ -165,15 +165,23 @@ def firstnn(x):
 
 # pylint: disable=too-many-arguments
 def call_while(fn, interval=5, timeout=600, update_msg="waiting ...", done_msg="done.", exception_class=None):
-    "calls the given function `f` every `interval` until it returns False."
+    """calls the given function `fn` every `interval` seconds until it returns False.
+
+    An `exception_class` will be raised if `timeout` is reached.
+
+    Any truthy value will continue the polling, so might as well return an Exception from `fn` in order for his message to be propagated up."""
     if not exception_class:
         exception_class = RuntimeError
     elapsed = 0
     while True:
+        result = fn()
         if not fn():
             break
         if elapsed >= timeout:
-            raise exception_class("Reached timeout %d while %s" % (timeout, update_msg))
+            message = "Reached timeout %d while %s" % (timeout, update_msg)
+            if isinstance(result, BaseException):
+                message = message + (" (%s)" % result)
+            raise exception_class(message)
         LOG.info(update_msg)
         time.sleep(interval)
         elapsed = elapsed + interval

--- a/src/tests/test_buildercore_utils.py
+++ b/src/tests/test_buildercore_utils.py
@@ -137,6 +137,26 @@ class Simple(base.BaseCase):
         except BaseException as e:
             self.assertIn("(The answer is not 42)", e.message)
 
+    @patch('time.sleep')
+    def test_call_while_custom_exception(self, sleep):
+        check = MagicMock()
+        check.return_value = True
+        try:
+            utils.call_while(check, interval=5, timeout=15, exception_class=OSError)
+            self.fail("Should not return normally")
+        except OSError as e:
+            self.assertEqual("Reached timeout 15 while waiting ...", e.message)
+
+    @patch('time.sleep')
+    def test_call_while_custom_message(self, sleep):
+        check = MagicMock()
+        check.return_value = True
+        try:
+            utils.call_while(check, interval=5, timeout=15, update_msg="waiting for Godot")
+            self.fail("Should not return normally")
+        except BaseException as e:
+            self.assertEqual("Reached timeout 15 while waiting for Godot", e.message)
+
     def test_ensure(self):
         utils.ensure(True, "True should allow ensure() to continue")
         self.assertRaises(AssertionError, utils.ensure, False, "Error message")

--- a/src/tests/test_buildercore_utils.py
+++ b/src/tests/test_buildercore_utils.py
@@ -127,6 +127,16 @@ class Simple(base.BaseCase):
         except BaseException:
             self.assertEqual(3, len(sleep.mock_calls))
 
+    @patch('time.sleep')
+    def test_call_while_timeout_inner_exception_message(self, sleep):
+        check = MagicMock()
+        check.return_value = RuntimeError("The answer is not 42")
+        try:
+            utils.call_while(check, interval=5, timeout=15)
+            self.fail("Should not return normally")
+        except BaseException as e:
+            self.assertIn("(The answer is not 42)", e.message)
+
     def test_ensure(self):
         utils.ensure(True, "True should allow ensure() to continue")
         self.assertRaises(AssertionError, utils.ensure, False, "Error message")

--- a/src/tests/test_buildercore_utils.py
+++ b/src/tests/test_buildercore_utils.py
@@ -135,7 +135,7 @@ class Simple(base.BaseCase):
             utils.call_while(check, interval=5, timeout=15)
             self.fail("Should not return normally")
         except BaseException as e:
-            self.assertIn("(The answer is not 42)", e.message)
+            self.assertIn("(The answer is not 42)", str(e))
 
     @patch('time.sleep')
     def test_call_while_custom_exception(self, sleep):
@@ -145,7 +145,7 @@ class Simple(base.BaseCase):
             utils.call_while(check, interval=5, timeout=15, exception_class=OSError)
             self.fail("Should not return normally")
         except OSError as e:
-            self.assertEqual("Reached timeout 15 while waiting ...", e.message)
+            self.assertEqual("Reached timeout 15 while waiting ...", str(e))
 
     @patch('time.sleep')
     def test_call_while_custom_message(self, sleep):
@@ -155,7 +155,7 @@ class Simple(base.BaseCase):
             utils.call_while(check, interval=5, timeout=15, update_msg="waiting for Godot")
             self.fail("Should not return normally")
         except BaseException as e:
-            self.assertEqual("Reached timeout 15 while waiting for Godot", e.message)
+            self.assertEqual("Reached timeout 15 while waiting for Godot", str(e))
 
     def test_ensure(self):
         utils.ensure(True, "True should allow ensure() to continue")


### PR DESCRIPTION
New attempt for https://github.com/elifesciences/builder/pull/529 which got reverted.

Intentions:

- a login problem allows the polling to continue
- a generic SSH problem allows the polling to continue
- a persistent login problem doesn't cause a reboot
- a persistent generic SSH problem causes a reboot

Needs more test coverage for `buildercore.lifecycle`, I'll see what can be stubbed and covered there.