### PR TITLE
Feature: upgrades paramiko to remove cryptography warning

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -4,6 +4,7 @@ boto==2.48.0
 boto3==1.6.8
 botocore==1.9.8
 coverage==4.5.1
+paramiko==2.6.0
 Fabric3==1.14.post1
 green==2.12.1
 ipython==5.5.0


### PR DESCRIPTION
Unfortunately this is not the 'make paramiko fast' patch we've all been waiting for, it just fixes all the deprecated cryptography warnings we were getting