### PR TITLE
Feature: search, moves project from 16.04 to 18.04

### DIFF
--- a/projects/elife.yaml
+++ b/projects/elife.yaml
@@ -1295,9 +1295,6 @@ search:
     aws:
         type: t2.medium
         ec2:
-            # 16.04, deprecated
-            ami: ami-14a1d06e # GENERATED created from basebox--1604
-                              # us-east-1, build date 20170811, hvm:ebs-ssd, AMI built on 20171215
             cpu-credits: unlimited
         ports:
             - 22
@@ -1346,7 +1343,6 @@ search:
                 protocol: 
                     - http
     vagrant:
-        box: bento/ubuntu-16.04 # 16.04, deprecated
         ports:
             1244: 80
             1245: 8080


### PR DESCRIPTION
search has been building on 18.04 [for a while](https://github.com/elifesciences/search-formula/commit/315d8b857bcde7c20430fd6cdb926385a95add12#diff-58231b16fdee45a03a4ee3cf94a9f2c3) but the project config was updated to 16.04 early to resolve php issues with 14.04

fyi @giorgiosironi 

