### PR TITLE
Remove requirement for aws-iam-authenticator

### DIFF
--- a/docs/eks.md
+++ b/docs/eks.md
@@ -9,7 +9,7 @@ A project can be configured to create a cluster with the `eks` configuration in 
 ### Prerequisites
 
 - Install [`kubectl`](https://kubernetes.io/docs/tasks/tools/install-kubectl/)
-- Install [`aws-iam-authenticator`](https://docs.aws.amazon.com/eks/latest/userguide/install-aws-iam-authenticator.html)
+- Do not install `aws-iam-authenticator`: it's [no longer necessary](https://docs.aws.amazon.com/cli/latest/reference/eks/get-token.html) in recent versions of the `aws` CLI
 
 ### Configure kubectl
 


### PR DESCRIPTION
Both @tayowonibi and @erezmus have been able to authenticate without this, turns out it's not needed anymore

To be precise, the `.kube/config` file that is created by `aws eks update-kubeconfig` does not contain references to `aws-iam-authenticator` anymore, in favor of delegating to itself:
```
- name: arn:aws:eks:us-east-1:512686554592:cluster/kubernetes-aws--test
  user:
    exec:
      apiVersion: client.authentication.k8s.io/v1alpha1
      args:
      - --region
      - us-east-1
      - eks
      - get-token
      - --cluster-name
      - kubernetes-aws--test
      - --role
      - arn:aws:iam::512686554592:role/kubernetes-aws--test--AmazonEKSUserRole
      command: aws
```