### PR TITLE
Remove hardcoding of project names

### DIFF
--- a/src/buildercore/terraform.py
+++ b/src/buildercore/terraform.py
@@ -622,7 +622,7 @@ def render_eks(context, template):
 
 def _render_eks_master_security_group(context, template):
     template.populate_resource('aws_security_group', 'master', block={
-        'name': 'project-with-eks--%s--master' % context['instance_id'],
+        'name': '%s--master' % context['stackname'],
         'description': 'Cluster communication with worker nodes',
         'vpc_id': context['aws']['vpc-id'],
         'egress': {
@@ -691,7 +691,7 @@ def _render_eks_workers_security_group(context, template):
     security_group_tags = aws.generic_tags(context)
     security_group_tags['kubernetes.io/cluster/%s'] = 'owned'
     template.populate_resource('aws_security_group', 'worker', block={
-        'name': 'project-with-eks--%s--worker' % context['instance_id'],
+        'name': '%s--worker' % context['stackname'],
         'description': 'Security group for all worker nodes in the cluster',
         'vpc_id': context['aws']['vpc-id'],
         'egress': {


### PR DESCRIPTION
Unfortunately it seems changing the security groups requires to destroy and recreate the whole cluster, so can't be done immediately.