### PR TITLE
Switch test cluster to use elifesciences.org

### DIFF
--- a/projects/elife.yaml
+++ b/projects/elife.yaml
@@ -2144,7 +2144,7 @@ kubernetes-aws:
                 desired-capacity: 3
             helm: true
             external-dns:
-                domain-filter: "elifesciences.net"
+                domain-filter: "elifesciences.org"
 
 large-repo-wrangler:
     description: when elife-publications requires a large git repository to be wrangled. adhoc instances only.


### PR DESCRIPTION
For https://github.com/elifesciences/issues/issues/4572

Required for wildcard HTTPS certificate to be used.