### PR TITLE
Feature: fabric "tasks" replacement 

### DIFF
--- a/bldr
+++ b/bldr
@@ -15,4 +15,4 @@ if [ -f .aws-credentials.env ]; then
     source ./.aws-credentials.env
 fi
 
-python src/__init__.py "$*"
+python src/taskrunner.py "$*"

--- a/bldr
+++ b/bldr
@@ -9,12 +9,10 @@ fi
 
 source ./venv/bin/activate
 
+# TODO: remove
 # ad-hoc permissions if they exist
 if [ -f .aws-credentials.env ]; then
     source ./.aws-credentials.env
 fi
 
-# a wrapper around fabric that activates the elife-builder virtualenv
-
-fabric=$(which fab)
-exec $fabric "$*" -f src/fabfile.py
+python src/__init__.py "$*"

--- a/src/__init__.py
+++ b/src/__init__.py
@@ -14,9 +14,9 @@ unqualified_task_list = [
     cfn.download_file,
     cfn.upload_file,
     cfn.cmd,
-    
+
     deploy.switch_revision_update_instance,
-    
+
     lifecycle.start,
     lifecycle.stop,
     lifecycle.restart,
@@ -68,7 +68,7 @@ unqualified_debug_task_list = [
 debug_task_list = [
     aws.rds_snapshots,
     aws.detailed_stack_list,
-    
+
     tasks.diff_builder_config,
 
     master.write_missing_keypairs_to_s3,
@@ -98,13 +98,13 @@ def task_map(task, qualified=True):
 
 def generate_task_list(show_debug_tasks):
     """returns a collated list of maps with task information.
-    
+
     [{"name": "fn", "fn": pathto.fn1, "description": "foo bar baz"}, ...]
      {"name": "pathto.fn", "fn": pathto.fn2, "description": "foo bar baz"}, ...]"""
 
     def to_list(task_list, qualified=True):
         return [task_map(task, qualified) for task in task_list]
-    
+
     new_task_list = to_list(unqualified_task_list, qualified=False) + to_list(task_list)
     if show_debug_tasks:
         new_task_list = to_list(unqualified_task_list, qualified=False) + \
@@ -124,20 +124,20 @@ def parse_kv_pairs(text, item_sep=",", value_sep="="):
     # (the lexer will use this character to separate words)
     lexer.whitespace = item_sep
 
-    # include '=' as a word character 
+    # include '=' as a word character
     # (this is done so that the lexer returns a list of key-value pairs)
     # (if your option key or value contains any unquoted special character, you will need to add it here)
     # https://docs.python.org/2/library/shlex.html#shlex.shlex.wordchars
     lexer.wordchars += value_sep
     lexer.wordchars += "-"
-    
+
     # then we separate option keys and values to build the resulting dictionary
     # (maxsplit is required to make sure that '=' in value will not be a problem)
 
     # "param" => "param", "key=val" => ["key" "val"]
     def split_word_or_not(word):
         if value_sep in word:
-            maxsplit=1
+            maxsplit = 1
             return word.split(value_sep, maxsplit)
         return word
 
@@ -151,7 +151,7 @@ def parse_task_string(task_str):
     a pair of [args, kwargs] is returned. both may be empty."""
     args = []
     kwargs = {}
-    
+
     task_arg_separator_pos = task_str.find(":")
     if task_arg_separator_pos == -1:
         return task_str, args, kwargs
@@ -160,7 +160,7 @@ def parse_task_string(task_str):
     task_args = task_str[task_arg_separator_pos + 1:] # => "foo,bar"
     args, kwargs = parse_kv_pairs(task_args)
 
-    #print('task',task_str)
+    # print('task',task_str)
     #print('task args', args)
     #print('task kwargs', kwargs)
 
@@ -169,7 +169,7 @@ def parse_task_string(task_str):
 def exec_task(task_str, task_map_list):
 
     task_name, task_args, task_kwargs = parse_task_string(task_str)
-    
+
     return_map = {
         'task': task_name,
         'task_args': task_args,
@@ -200,10 +200,10 @@ def main(arg_list):
 
     if not arg_list or arg_list[1:]:
         print("builder should be called from the 'bldr' script") # or with a single double quoted argument string
-        return 1              
+        return 1
 
     command_string = arg_list[0].strip()
-    
+
     if not command_string:
         for tm in task_map_list:
             path_len = len(tm['name'])

--- a/src/__init__.py
+++ b/src/__init__.py
@@ -1,0 +1,140 @@
+import sys, os
+import cfn, lifecycle, masterless, vault, aws, metrics, tasks, master, askmaster, buildvars, project, deploy
+
+unqualified_task_list = [
+    cfn.destroy,
+    cfn.ensure_destroyed,
+    cfn.update,
+    cfn.update_infrastructure,
+    cfn.launch,
+    cfn.ssh,
+    cfn.owner_ssh,
+    cfn.download_file,
+    cfn.upload_file,
+    cfn.cmd,
+    
+    deploy.switch_revision_update_instance,
+    
+    lifecycle.start,
+    lifecycle.stop,
+    lifecycle.restart,
+    lifecycle.stop_if_running_for,
+    lifecycle.update_dns,
+]
+
+task_list = [
+    metrics.regenerate_results, # todo: remove
+
+    tasks.create_ami,
+    tasks.repair_cfn_info,
+    tasks.repair_context,
+    tasks.remove_minion_key,
+    tasks.restart_all_running_ec2,
+
+    master.update,
+
+    askmaster.fail2ban_running,
+    askmaster.installed_linux_kernel,
+    askmaster.linux_distro,
+    askmaster.update_kernel,
+
+    buildvars.switch_revision,
+
+    project.data,
+    project.context,
+    project.new,
+
+    masterless.launch,
+    masterless.set_versions,
+
+    vault.login,
+    vault.logout,
+    vault.policies_update,
+    vault.token_lookup,
+    vault.token_list_accessors,
+    vault.token_lookup_accessor,
+    vault.token_create,
+    vault.token_revoke,
+]
+
+unqualified_debug_task_list = [
+    cfn.highstate,
+    cfn.pillar,
+    cfn.aws_stack_list,
+]
+
+debug_task_list = [
+    aws.rds_snapshots,
+    aws.detailed_stack_list,
+    
+    tasks.diff_builder_config,
+
+    master.write_missing_keypairs_to_s3,
+    master.download_keypair,
+    master.server_access,
+    master.remaster,
+    master.update_salt,
+    master.update_salt_master,
+    master.remaster_all,
+
+    buildvars.read,
+    buildvars.valid,
+    buildvars.fix,
+    buildvars.force,
+]
+
+def generate_task_list(show_debug_tasks):
+    """returns a collated list of maps with task information 
+    
+    [{"name": "fn", "fn": pathto.fn1, "desc": "foo bar baz"}, ...]
+     {"name": "pathto.fn", "fn": pathto.fn2, "desc": "foo bar baz"}, ...]"""
+
+    def task_map(task, qualified=True):
+        path = "%s.%s" % (task.__module__.split('.')[-1], task.__name__)
+        unqualified_path = task.__name__
+        description = (task.__doc__ or '').replace('    ', '').replace('\n', ' ')[:60]
+        return {
+            "name": path if qualified else unqualified_path,
+            "description": description,
+            "fn": task,
+        }
+
+    def to_list(task_list, qualified=True):
+        return [task_map(task, qualified) for task in task_list]
+    
+    new_task_list = to_list(unqualified_task_list, qualified=False) + to_list(task_list)
+    if show_debug_tasks:
+        new_task_list = to_list(unqualified_task_list, qualified=False) + \
+            to_list(unqualified_debug_task_list) + \
+            to_list(task_list) + \
+            to_list(debug_task_list)
+
+    return new_task_list
+
+def main(arg_list):
+    show_debug_tasks = os.environ.get("BLDR_ROLE") == "admin"
+    task_list = generate_task_list(show_debug_tasks)
+
+    task = arg_list[0]
+    
+    if not task:
+        for t in task_list:
+            path_len = len(t['name'])
+            max_path_len = 35
+            offset = (max_path_len - path_len) + 2
+            print("%s%s%s" % (t['name'], ' ' * offset, t['description']))
+            
+            #print((t['description'] or '')[:50 - tlen].ljust(70))
+            #print("%s%+40s" % (t['name'], str(t['description'] or '')[:30]))
+        return 0
+
+    print('got args',arg_list)
+    print('task:',task)
+
+    # find given task in list of tasks
+    # call task with list of parameters
+
+    return 0
+
+if __name__ == '__main__':
+    exit(main(sys.argv[1:]))

--- a/src/__init__.py
+++ b/src/__init__.py
@@ -1,5 +1,7 @@
+from shlex import shlex
 import sys, os
 import cfn, lifecycle, masterless, vault, aws, metrics, tasks, master, askmaster, buildvars, project, deploy
+from buildercore.utils import splitfilter
 
 unqualified_task_list = [
     cfn.destroy,
@@ -83,21 +85,22 @@ debug_task_list = [
     buildvars.force,
 ]
 
-def generate_task_list(show_debug_tasks):
-    """returns a collated list of maps with task information 
-    
-    [{"name": "fn", "fn": pathto.fn1, "desc": "foo bar baz"}, ...]
-     {"name": "pathto.fn", "fn": pathto.fn2, "desc": "foo bar baz"}, ...]"""
+def task_map(task, qualified=True):
+    path = "%s.%s" % (task.__module__.split('.')[-1], task.__name__)
+    unqualified_path = task.__name__
+    description = (task.__doc__ or '').replace('    ', '').replace('\n', ' ')[:60]
+    return {
+        "name": path if qualified else unqualified_path,
+        "path": path,
+        "description": description,
+        "fn": task,
+    }
 
-    def task_map(task, qualified=True):
-        path = "%s.%s" % (task.__module__.split('.')[-1], task.__name__)
-        unqualified_path = task.__name__
-        description = (task.__doc__ or '').replace('    ', '').replace('\n', ' ')[:60]
-        return {
-            "name": path if qualified else unqualified_path,
-            "description": description,
-            "fn": task,
-        }
+def generate_task_list(show_debug_tasks):
+    """returns a collated list of maps with task information.
+    
+    [{"name": "fn", "fn": pathto.fn1, "description": "foo bar baz"}, ...]
+     {"name": "pathto.fn", "fn": pathto.fn2, "description": "foo bar baz"}, ...]"""
 
     def to_list(task_list, qualified=True):
         return [task_map(task, qualified) for task in task_list]
@@ -111,30 +114,109 @@ def generate_task_list(show_debug_tasks):
 
     return new_task_list
 
+# taken from:
+# https://stackoverflow.com/questions/38737250/extracting-key-value-pairs-from-string-with-quotes#answer-38738997
+def parse_kv_pairs(text, item_sep=",", value_sep="="):
+    """Parse key-value pairs from a shell-like text."""
+    # initialize a lexer, in POSIX mode (to properly handle escaping)
+    lexer = shlex(text, posix=True)
+    # set ',' as whitespace for the lexer
+    # (the lexer will use this character to separate words)
+    lexer.whitespace = item_sep
+
+    # include '=' as a word character 
+    # (this is done so that the lexer returns a list of key-value pairs)
+    # (if your option key or value contains any unquoted special character, you will need to add it here)
+    # https://docs.python.org/2/library/shlex.html#shlex.shlex.wordchars
+    lexer.wordchars += value_sep
+    lexer.wordchars += "-"
+    
+    # then we separate option keys and values to build the resulting dictionary
+    # (maxsplit is required to make sure that '=' in value will not be a problem)
+
+    # "param" => "param", "key=val" => ["key" "val"]
+    def split_word_or_not(word):
+        if value_sep in word:
+            maxsplit=1
+            return word.split(value_sep, maxsplit)
+        return word
+
+    # => ["param1" "param2"],  [["key" "val"] ["foo" "bar"]]
+    args, kwargs = splitfilter(lambda x: not isinstance(x, list), map(split_word_or_not, lexer))
+    kwargs = dict(kwargs) # => {"key": "val", "foo": "bar"}
+    return args, kwargs
+
+def parse_task_string(task_str):
+    """given task will look like 'taskname' or 'taskname:param1,param2' and each parameter may be either 'value' or 'key=value'
+    a pair of [args, kwargs] is returned. both may be empty."""
+    args = []
+    kwargs = {}
+    
+    task_arg_separator_pos = task_str.find(":")
+    if task_arg_separator_pos == -1:
+        return task_str, args, kwargs
+
+    task_name = task_str[:task_arg_separator_pos] # "taskname:foo,bar" => "taskname"
+    task_args = task_str[task_arg_separator_pos + 1:] # => "foo,bar"
+    args, kwargs = parse_kv_pairs(task_args)
+
+    #print('task',task_str)
+    #print('task args', args)
+    #print('task kwargs', kwargs)
+
+    return task_name, args, kwargs
+
+def exec_task(task_str, task_map_list):
+
+    task_name, task_args, task_kwargs = parse_task_string(task_str)
+    
+    return_map = {
+        'task': task_name,
+        'task_args': task_args,
+        'task_kwargs': task_kwargs
+    }
+
+    task_map_list = [t for t in task_map_list if t['name'] == task_name]
+    if not task_map_list:
+        print("task %r not found" % task_name)
+        return_map['rc'] = 1
+        return return_map
+
+    try:
+        task_map = task_map_list[0]
+        task_map['fn'](*task_args, **task_kwargs)
+        return_map['rc'] = 0
+        return return_map
+
+    except BaseException as e:
+        print('exception while executing task %r: %s' % (task_name, str(e)))
+        # TODO: print stacktrace
+        return_map['rc'] = 2 # I guess?
+        return return_map
+
 def main(arg_list):
     show_debug_tasks = os.environ.get("BLDR_ROLE") == "admin"
-    task_list = generate_task_list(show_debug_tasks)
+    task_map_list = generate_task_list(show_debug_tasks)
 
-    task = arg_list[0]
+    if not arg_list or arg_list[1:]:
+        print("builder should be called from the 'bldr' script") # or with a single double quoted argument string
+        return 1              
+
+    command_string = arg_list[0].strip()
     
-    if not task:
-        for t in task_list:
-            path_len = len(t['name'])
+    if not command_string:
+        for tm in task_map_list:
+            path_len = len(tm['name'])
             max_path_len = 35
             offset = (max_path_len - path_len) + 2
-            print("%s%s%s" % (t['name'], ' ' * offset, t['description']))
-            
-            #print((t['description'] or '')[:50 - tlen].ljust(70))
-            #print("%s%+40s" % (t['name'], str(t['description'] or '')[:30]))
+            print("%s%s%s" % (tm['name'], ' ' * offset, tm['description']))
         return 0
 
-    print('got args',arg_list)
-    print('task:',task)
+    # TODO: do we have cases where we rely on running multiple tasks in one go?
+    task_list = command_string.split(' ')
+    task_result_list = [exec_task(task_str, task_map_list) for task_str in task_list]
 
-    # find given task in list of tasks
-    # call task with list of parameters
-
-    return 0
+    return sum([task_result['rc'] for task_result in task_result_list])
 
 if __name__ == '__main__':
     exit(main(sys.argv[1:]))

--- a/src/askmaster.py
+++ b/src/askmaster.py
@@ -3,7 +3,7 @@
 Requires access to the master server."""
 
 from buildercore import core
-from fabric.api import sudo, task
+from fabric.api import sudo
 from buildercore.core import stack_conn
 import utils
 
@@ -12,24 +12,20 @@ def salt_master_cmd(cmd, module='cmd.run', minions=r'\*'):
     with stack_conn(core.find_master(utils.find_region())):
         sudo("salt %(minions)s %(module)s %(cmd)s --timeout=30" % locals())
 
-@task
 def fail2ban_running():
     return salt_master_cmd(module="state.single", cmd="service.running name=fail2ban")
 
-@task
 def installed_linux_kernel():
     "prints the list of linux kernels installed (but not necessarily running)"
     # ii  linux-image-4.15.0-1019-aws          4.15.0-1019.19                             amd64        Linux kernel image for version 4.15.0 on 64 bit x86 SMP
     # ii  linux-image-aws                      4.15.0.1019.19                             amd64        Linux kernel image for Amazon Web Services (AWS) systems.
     return salt_master_cmd("'dpkg -l | grep -i linux-image | grep -i ii'")
 
-@task
 def linux_distro():
     "returns the version of the OS"
     # 'Description:    Ubuntu 18.04.1 LTS'
     return salt_master_cmd("'lsb_release -d'")
 
-@task
 def update_kernel():
     cmd = "'apt-get update && DEBIAN_FRONTEND=noninteractive apt-get install linux-image-aws -y'"
     # 16.04+ minions only

--- a/src/aws.py
+++ b/src/aws.py
@@ -1,10 +1,9 @@
 from buildercore import core
 import utils
-from decorators import requires_aws_stack, debugtask, echo_output
+from decorators import requires_aws_stack, echo_output
 import logging
 LOG = logging.getLogger(__name__)
 
-@debugtask
 @requires_aws_stack
 def rds_snapshots(stackname):
     "prints all snapshots for given stack, order by creation time"
@@ -18,7 +17,6 @@ def rds_snapshots(stackname):
     for row in data:
         print(row)
 
-@debugtask
 @echo_output
 def detailed_stack_list(project=None):
     region = utils.find_region()

--- a/src/buildvars.py
+++ b/src/buildvars.py
@@ -1,7 +1,7 @@
 from buildercore.bvars import encode_bvars, read_from_current_host
-from fabric.api import sudo, put, task
+from fabric.api import sudo, put
 from io import StringIO
-from decorators import requires_aws_stack, debugtask
+from decorators import requires_aws_stack
 from buildercore.config import BOOTSTRAP_USER
 from buildercore.core import stack_all_ec2_nodes, current_node_id
 from buildercore.context_handler import load_context
@@ -14,7 +14,6 @@ LOG = logging.getLogger(__name__)
 
 OLD, ABBREV, FULL = 'old', 'abbrev', 'full'
 
-@task
 @requires_aws_stack
 def switch_revision(stackname, revision=None, concurrency=None):
     if revision is None:
@@ -33,13 +32,11 @@ def switch_revision(stackname, revision=None, concurrency=None):
 
     stack_all_ec2_nodes(stackname, _switch_revision_single_ec2_node, username=BOOTSTRAP_USER, concurrency=concurrency)
 
-@debugtask
 @requires_aws_stack
 def read(stackname):
     "returns the unencoded build variables found on given instance"
     return stack_all_ec2_nodes(stackname, lambda: pprint(read_from_current_host()), username=BOOTSTRAP_USER)
 
-@debugtask
 @requires_aws_stack
 def valid(stackname):
     return stack_all_ec2_nodes(stackname, lambda: pprint(_retrieve_build_vars()), username=BOOTSTRAP_USER)
@@ -67,7 +64,6 @@ def _retrieve_build_vars():
         LOG.exception(ex)
         raise
 
-@debugtask
 @requires_aws_stack
 def fix(stackname):
     def _fix_single_ec2_node(stackname):
@@ -87,7 +83,6 @@ def fix(stackname):
     stack_all_ec2_nodes(stackname, (_fix_single_ec2_node, {'stackname': stackname}), username=BOOTSTRAP_USER)
 
 # TODO: deletion candidate. can only ever do a shallow update
-@debugtask
 @requires_aws_stack
 def force(stackname, field, value):
     "replace a specific key with a new value in the buildvars for all ec2 instances in stack"

--- a/src/cfn.py
+++ b/src/cfn.py
@@ -292,8 +292,7 @@ def _interactive_ssh(command):
 @task
 @requires_aws_stack
 def download_file(stackname, path, destination='.', node=None, allow_missing="False", use_bootstrap_user="False"):
-    """
-    Downloads `path` from `stackname` putting it into the `destination` folder, or the `destination` file if it exists and it is a file.
+    """Downloads `path` from `stackname` putting it into the `destination` folder, or the `destination` file if it exists and it is a file.
 
     If `allow_missing` is "True", a non-existant `path` will be skipped without errors.
 

--- a/src/decorators.py
+++ b/src/decorators.py
@@ -45,7 +45,7 @@ def rtask(*roles):
 
 # pylint: disable=invalid-name
 debugtask = rtask('admin')
-#mastertask = rtask('master') # unused, remove
+# mastertask = rtask('master') # unused, remove
 
 def requires_filtered_project(filterfn=None):
     def wrap1(func):

--- a/src/decorators.py
+++ b/src/decorators.py
@@ -4,7 +4,6 @@ import utils
 from buildercore import core, project, config
 from buildercore.utils import first, remove_ordereddict, errcho, lfilter, lmap, isstr
 from functools import wraps
-from fabric.api import task
 from pprint import pformat
 import logging
 
@@ -32,21 +31,6 @@ def setdefault(fname, value):
     "writes the given value to the given default file"
     open(deffile(fname), 'w').write(value)
 
-def rtask(*roles):
-    "role task. this task is only available for certain roles specified in the BLDR_ROLE env var"
-    def wrapper(func):
-        role_env = os.getenv('BLDR_ROLE')
-        if role_env in roles:
-            # a role has been set
-            return task(func)
-        return func
-    return wrapper
-
-
-# pylint: disable=invalid-name
-debugtask = rtask('admin')
-# mastertask = rtask('master') # unused, remove
-
 def requires_filtered_project(filterfn=None):
     def wrap1(func):
         @wraps(func)
@@ -58,7 +42,6 @@ def requires_filtered_project(filterfn=None):
             return func(pname, *args, **kwargs)
         return wrap2
     return wrap1
-
 
 # pylint: disable=invalid-name
 requires_project = requires_filtered_project(None)
@@ -120,31 +103,15 @@ def requires_steady_stack(func):
         return func(stackname, *args[1:], **kwargs)
     return call
 
-def _sole_task(nom):
-    '''
-    task_list = env.tasks
-    if len(task_list) > 0:
-        final_task = task_list[-1]
-        final_task = final_task.split(':', 1)[0] # ignore any args
-        final_task = final_task.split('.')[-1] # handles namespaced tasks like: webserver.vhost
-        return final_task == nom
-    '''
-    return True
-
 def echo_output(func):
-    """if the wrapped function is the sole task being run, then it's output is
-    printed to stdout. this wrapper first attempts to pass the keyword
-    'verbose' to the function and, if it fails, calls it without.
-    """
+    "pretty-prints the return value of the task(s) being run to stdout"
     @wraps(func)
     def _wrapper(*args, **kwargs):
-        if _sole_task(func.__name__):
-            res = func(*args, **kwargs)
-            errcho('output:') # printing to stderr avoids corrupting structured data
-            if isstr(res):
-                print(res)
-            else:
-                print(pformat(remove_ordereddict(res)))
-            return res
-        return func(*args, **kwargs)
+        res = func(*args, **kwargs)
+        errcho('output:') # printing to stderr avoids corrupting structured data
+        if isstr(res):
+            print(res)
+        else:
+            print(pformat(remove_ordereddict(res)))
+        return res
     return _wrapper

--- a/src/decorators.py
+++ b/src/decorators.py
@@ -45,7 +45,7 @@ def rtask(*roles):
 
 # pylint: disable=invalid-name
 debugtask = rtask('admin')
-mastertask = rtask('master')
+#mastertask = rtask('master') # unused, remove
 
 def requires_filtered_project(filterfn=None):
     def wrap1(func):

--- a/src/decorators.py
+++ b/src/decorators.py
@@ -4,7 +4,7 @@ import utils
 from buildercore import core, project, config
 from buildercore.utils import first, remove_ordereddict, errcho, lfilter, lmap, isstr
 from functools import wraps
-from fabric.api import env, task
+from fabric.api import task
 from pprint import pformat
 import logging
 
@@ -51,7 +51,7 @@ def requires_filtered_project(filterfn=None):
     def wrap1(func):
         @wraps(func)
         def wrap2(_pname=None, *args, **kwargs):
-            pname = os.environ.get('PROJECT', _pname)
+            pname = os.environ.get('PROJECT', _pname) # used by Vagrant ...?
             project_list = project.filtered_projects(filterfn)
             if not pname or not pname.strip() or pname not in project_list:
                 pname = utils._pick("project", sorted(project_list), default_file=deffile('.project'))
@@ -121,12 +121,15 @@ def requires_steady_stack(func):
     return call
 
 def _sole_task(nom):
+    '''
     task_list = env.tasks
     if len(task_list) > 0:
         final_task = task_list[-1]
         final_task = final_task.split(':', 1)[0] # ignore any args
         final_task = final_task.split('.')[-1] # handles namespaced tasks like: webserver.vhost
         return final_task == nom
+    '''
+    return True
 
 def echo_output(func):
     """if the wrapped function is the sole task being run, then it's output is

--- a/src/deploy.py
+++ b/src/deploy.py
@@ -1,6 +1,5 @@
 """module concerns itself with tasks involving branch deployments of projects."""
 
-from fabric.api import task
 from decorators import requires_aws_stack
 from buildercore import bootstrap
 from buildercore.concurrency import concurrency_for
@@ -10,7 +9,6 @@ import logging
 
 LOG = logging.getLogger(__name__)
 
-@task
 @requires_aws_stack
 def switch_revision_update_instance(stackname, revision=None, concurrency='serial'):
     buildvars.switch_revision(stackname, revision)

--- a/src/deploy.py
+++ b/src/deploy.py
@@ -1,8 +1,10 @@
 """module concerns itself with tasks involving branch deployments of projects."""
 
-from fabric.api import task
+from pprint import pformat
 from decorators import requires_aws_stack
-from buildercore import bootstrap
+from buildercore import bootstrap, cloudformation, context_handler
+from buildercore.bluegreen import BlueGreenConcurrency
+from buildercore.core import boto_client, all_node_params
 from buildercore.concurrency import concurrency_for
 import buildvars
 
@@ -15,7 +17,6 @@ def switch_revision_update_instance(stackname, revision=None, concurrency='seria
     buildvars.switch_revision(stackname, revision)
     bootstrap.update_stack(stackname, service_list=['ec2'], concurrency=concurrency_for(stackname, concurrency))
 
-@debugtask
 @requires_aws_stack
 def load_balancer_status(stackname):
     context = context_handler.load_context(stackname)
@@ -28,7 +29,6 @@ def load_balancer_status(stackname):
     LOG.info("Load balancer name: %s", elb_name)
     LOG.info("Health: %s", pformat(health))
 
-@debugtask
 @requires_aws_stack
 def load_balancer_register_all(stackname):
     context = context_handler.load_context(stackname)

--- a/src/lifecycle.py
+++ b/src/lifecycle.py
@@ -1,15 +1,12 @@
-from fabric.api import task
 from buildercore import lifecycle
-from decorators import requires_aws_stack, timeit, debugtask, echo_output
+from decorators import requires_aws_stack, timeit, echo_output
 
-@task
 @requires_aws_stack
 @timeit
 def start(stackname):
     "Starts the nodes of 'stackname'. Idempotent"
     lifecycle.start(stackname)
 
-@task
 @requires_aws_stack
 @timeit
 def stop(stackname, *services):
@@ -21,14 +18,12 @@ def stop(stackname, *services):
 
     lifecycle.stop(stackname, services)
 
-@task
 @requires_aws_stack
 @timeit
 @echo_output
 def restart(stackname):
     return lifecycle.restart(stackname)
 
-@task
 @requires_aws_stack
 @timeit
 def stop_if_running_for(stackname, minimum_minutes='30'):
@@ -37,7 +32,6 @@ def stop_if_running_for(stackname, minimum_minutes='30'):
     The assumption is that stacks where this command is used are not needed for long parts of the day/week, and that who needs them will call the start task first."""
     return lifecycle.stop_if_running_for(stackname, int(minimum_minutes))
 
-@debugtask
 @requires_aws_stack
 def update_dns(stackname):
     """Updates the public DNS entry of the EC2 nodes.

--- a/src/masterless.py
+++ b/src/masterless.py
@@ -2,13 +2,12 @@ import os
 from os.path import join
 from collections import OrderedDict
 from pprint import pformat
-from fabric.api import task, lcd, settings
+from fabric.api import lcd, settings
 from fabric.operations import local
 from decorators import requires_project
 from buildercore import bootstrap, checks, core, context_handler, config
 from buildercore.utils import ensure, subdict
 import logging
-# TODO: import only what's needed from cfn, to avoid masterless.cfn.* tasks showing up in  ./bldr -l
 import cfn
 from functools import wraps
 
@@ -79,7 +78,6 @@ def parse_validate_repolist(fdata, *repolist):
 #
 #
 
-@task
 @requires_project
 @requires_master_server_access
 def launch(pname, instance_id=None, alt_config='standalone', *repolist):
@@ -110,7 +108,6 @@ def launch(pname, instance_id=None, alt_config='standalone', *repolist):
 #
 #
 
-@task
 @requires_master_server_access
 @requires_masterless
 def set_versions(stackname, *repolist):

--- a/src/metrics.py
+++ b/src/metrics.py
@@ -1,8 +1,7 @@
-from fabric.api import task, cd, run
+from fabric.api import cd, run
 from buildercore.core import stack_conn
 from decorators import requires_aws_project_stack
 
-@task
 @requires_aws_project_stack('elife-metrics')
 def regenerate_results(stackname):
     with stack_conn(stackname):

--- a/src/project.py
+++ b/src/project.py
@@ -1,10 +1,9 @@
-from fabric.api import task, local
+from fabric.api import local
 from buildercore import project, utils as core_utils, core, cfngen
 from buildercore.utils import ensure
 from decorators import requires_project, echo_output
 import utils
 
-@task
 @requires_project
 @echo_output
 def data(pname, output_format=None):
@@ -19,7 +18,6 @@ def data(pname, output_format=None):
     formatter = formatters.get(output_format)
     return formatter(project.project_data(pname))
 
-@task
 @requires_project
 @echo_output
 def context(pname, output_format=None):
@@ -33,7 +31,6 @@ def context(pname, output_format=None):
     formatter = formatters.get(output_format)
     return formatter(cfngen.build_context(pname, stackname=core.mk_stackname(pname, "test")))
 
-@task
 def new():
     "creates a new project formula"
     pname = utils.uin('project name')

--- a/src/taskrunner.py
+++ b/src/taskrunner.py
@@ -1,5 +1,5 @@
 import shlex
-import sys, os
+import sys, os, traceback
 import cfn, lifecycle, masterless, vault, aws, metrics, tasks, master, askmaster, buildvars, project, deploy
 from buildercore.utils import splitfilter
 from decorators import echo_output
@@ -203,17 +203,17 @@ def exec_task(task_str, task_map_list):
         return return_map
 
     except BaseException as e:
-        # TODO: stderr?
-        print('exception while executing task %r: %s' % (task_name, str(e)))
-        # TODO: print stacktrace
-        return_map['rc'] = 2 # I guess?
+        print('exception while executing task %r: %s\n' % (task_name, str(e)))
+        print(traceback.format_exc())
+        return_map['rc'] = 2 # arbitrary
         return return_map
 
 def exec_many(command_string, task_map_list):
     "splits a string up into multiple command strings and passes each to `exec_task`"
 
     # note: I just could not get the lexer to work here,
-    # too much python convenience-magic going on
+    # too much python convenience-magic going on.
+    # this section tokenises the whole input by whitespace, preserving singly quoted values
 
     task_list = []
     skipping = False
@@ -237,7 +237,7 @@ def main(arg_list):
     task_map_list = generate_task_list(show_debug_tasks)
 
     if not arg_list or arg_list[1:]:
-        print("builder should be called from the 'bldr' script") # or with a single double quoted argument string
+        print("`taskrunner.main` must be called from the ./bldr script")
         return 1
 
     command_string = arg_list[0].strip()

--- a/src/taskrunner.py
+++ b/src/taskrunner.py
@@ -88,7 +88,7 @@ DEBUG_TASK_LIST = [
 def mk_task_map(task, qualified=True):
     path = "%s.%s" % (task.__module__.split('.')[-1], task.__name__)
     unqualified_path = task.__name__
-    description = (task.__doc__ or '').replace('    ', '').replace('\n', ' ')[:60]
+    description = (task.__doc__ or '').strip().replace('\n', ' ')[:60]
     return {
         "name": path if qualified else unqualified_path,
         "path": path,
@@ -204,7 +204,7 @@ def main(arg_list):
 
     command_string = arg_list[0].strip()
 
-    if not command_string:
+    if not command_string or command_string in ["-l", "--list", "-h", "--help", "-?"]:
         for tm in task_map_list:
             path_len = len(tm['name'])
             max_path_len = 35
@@ -212,7 +212,8 @@ def main(arg_list):
             print("%s%s%s" % (tm['name'], ' ' * offset, tm['description']))
         return 0
 
-    # TODO: do we have cases where we rely on running multiple tasks in one go?
+    # note: we don't seem to have any cases where we rely on running multiple tasks
+    # todo: this is a naive split, there may be quoted whitespace in the commands
     task_list = command_string.split(' ')
     task_result_list = [exec_task(task_str, task_map_list) for task_str in task_list]
 

--- a/src/taskrunner.py
+++ b/src/taskrunner.py
@@ -113,8 +113,8 @@ def mk_task_map(task, qualified=True):
 def generate_task_list(show_debug_tasks=False):
     """returns a collated list of maps with task information.
 
-    [{"name": "fn", "fn": pathto.fn1, "description": "foo bar baz"}, ...]
-     {"name": "pathto.fn", "fn": pathto.fn2, "description": "foo bar baz"}, ...]"""
+    [{"name": "ssh", "fn": cfn.ssh, "description": "foobar baz"}, ...]
+     {"name": "cfn.deploy", "fn": cfn.deploy, "description": "bar barbar"}, ...]"""
 
     def to_list(task_list, qualified=True):
         return [mk_task_map(task, qualified) for task in task_list]

--- a/src/taskrunner.py
+++ b/src/taskrunner.py
@@ -224,7 +224,10 @@ def main(arg_list):
     # bash hands us an escaped string value via ./bldr
     command_string = arg_list[0].strip()
 
-    if not command_string or command_string in ["-l", "--list", "-h", "--help", "-?"]:
+    # print('this is what we see after bash:')
+    # print(command_string)
+
+    if not command_string or command_string in ["-l", "--list"]:
         print("Available commands:\n")
         indent = 4
         for tm in task_map_list:
@@ -232,7 +235,9 @@ def main(arg_list):
             max_path_len = 35
             offset = (max_path_len - path_len) + 2
             print("%s%s%s%s" % (' ' * indent, tm['name'], ' ' * offset, tm['description']))
-        return 0
+
+        # no explicit invocation of help gets you an error code
+        return 0 if command_string else 1
 
     task_result = exec_task(command_string, task_map_list)
     return task_result['rc']

--- a/src/taskrunner.py
+++ b/src/taskrunner.py
@@ -197,6 +197,11 @@ def exec_task(task_str, task_map_list):
         return_map['rc'] = 0
         return return_map
 
+    except KeyboardInterrupt:
+        print('\nStopped.') # mimic fabric
+        return_map['rc'] = 1
+        return return_map
+
     except BaseException as e:
         # TODO: stderr?
         print('exception while executing task %r: %s' % (task_name, str(e)))
@@ -238,8 +243,7 @@ def main(arg_list):
     command_string = arg_list[0].strip()
 
     if not command_string or command_string in ["-l", "--list", "-h", "--help", "-?"]:
-        print("Available commands:")
-        print("")
+        print("Available commands:\n")
         indent = 4
         for tm in task_map_list:
             path_len = len(tm['name'])

--- a/src/taskrunner.py
+++ b/src/taskrunner.py
@@ -155,7 +155,7 @@ def parse_kv_pairs(text, item_sep=",", value_sep="="):
         return word
 
     # => ["param1" "param2"],  [["key" "val"] ["foo" "bar"]]
-    args, kwargs = splitfilter(lambda x: not isinstance(x, list), map(split_word_or_not, lexer))
+    args, kwargs = splitfilter(lambda x: not isinstance(x, list), list(map(split_word_or_not, lexer)))
     kwargs = dict(kwargs) # => {"key": "val", "foo": "bar"}
     return args, kwargs
 

--- a/src/taskrunner.py
+++ b/src/taskrunner.py
@@ -2,10 +2,13 @@ import shlex
 import sys, os
 import cfn, lifecycle, masterless, vault, aws, metrics, tasks, master, askmaster, buildvars, project, deploy
 from buildercore.utils import splitfilter
+from decorators import echo_output
 
+@echo_output
 def ping():
     return "pong"
 
+@echo_output
 def echo(msg, *args, **kwargs):
     if args or kwargs:
         return "received: %s with args: %s and kwargs: %s" % (msg, args, kwargs)
@@ -184,7 +187,7 @@ def exec_task(task_str, task_map_list):
 
     task_map_list = [t for t in task_map_list if t['name'] == task_name]
     if not task_map_list:
-        print("task %r not found" % task_name)
+        print("Command not found: %r" % task_name)
         return_map['rc'] = 1
         return return_map
 
@@ -235,11 +238,14 @@ def main(arg_list):
     command_string = arg_list[0].strip()
 
     if not command_string or command_string in ["-l", "--list", "-h", "--help", "-?"]:
+        print("Available commands:")
+        print("")
+        indent = 4
         for tm in task_map_list:
             path_len = len(tm['name'])
             max_path_len = 35
             offset = (max_path_len - path_len) + 2
-            print("%s%s%s" % (tm['name'], ' ' * offset, tm['description']))
+            print("%s%s%s%s" % (' ' * indent, tm['name'], ' ' * offset, tm['description']))
         return 0
 
     task_result_list = exec_many(command_string, task_map_list)

--- a/src/taskrunner.py
+++ b/src/taskrunner.py
@@ -3,7 +3,12 @@ import sys, os
 import cfn, lifecycle, masterless, vault, aws, metrics, tasks, master, askmaster, buildvars, project, deploy
 from buildercore.utils import splitfilter
 
+def ping():
+    return "pong"
+
 UNQUALIFIED_TASK_LIST = [
+    ping,
+
     cfn.destroy,
     cfn.ensure_destroyed,
     cfn.update,
@@ -96,7 +101,7 @@ def mk_task_map(task, qualified=True):
         "fn": task,
     }
 
-def generate_task_list(show_debug_tasks):
+def generate_task_list(show_debug_tasks=False):
     """returns a collated list of maps with task information.
 
     [{"name": "fn", "fn": pathto.fn1, "description": "foo bar baz"}, ...]
@@ -184,11 +189,12 @@ def exec_task(task_str, task_map_list):
 
     try:
         task_map = task_map_list[0]
-        task_map['fn'](*task_args, **task_kwargs)
+        return_map['result'] = task_map['fn'](*task_args, **task_kwargs)
         return_map['rc'] = 0
         return return_map
 
     except BaseException as e:
+        # TODO: stderr?
         print('exception while executing task %r: %s' % (task_name, str(e)))
         # TODO: print stacktrace
         return_map['rc'] = 2 # I guess?

--- a/src/taskrunner.py
+++ b/src/taskrunner.py
@@ -3,7 +3,7 @@ import sys, os
 import cfn, lifecycle, masterless, vault, aws, metrics, tasks, master, askmaster, buildvars, project, deploy
 from buildercore.utils import splitfilter
 
-unqualified_task_list = [
+UNQUALIFIED_TASK_LIST = [
     cfn.destroy,
     cfn.ensure_destroyed,
     cfn.update,
@@ -24,7 +24,7 @@ unqualified_task_list = [
     lifecycle.update_dns,
 ]
 
-task_list = [
+TASK_LIST = [
     metrics.regenerate_results, # todo: remove
 
     tasks.create_ami,
@@ -59,13 +59,13 @@ task_list = [
     vault.token_revoke,
 ]
 
-unqualified_debug_task_list = [
+UNQUALIFIED_DEBUG_TASK_LIST = [
     cfn.highstate,
     cfn.pillar,
     cfn.aws_stack_list,
 ]
 
-debug_task_list = [
+DEBUG_TASK_LIST = [
     aws.rds_snapshots,
     aws.detailed_stack_list,
 
@@ -85,7 +85,7 @@ debug_task_list = [
     buildvars.force,
 ]
 
-def task_map(task, qualified=True):
+def mk_task_map(task, qualified=True):
     path = "%s.%s" % (task.__module__.split('.')[-1], task.__name__)
     unqualified_path = task.__name__
     description = (task.__doc__ or '').replace('    ', '').replace('\n', ' ')[:60]
@@ -103,14 +103,14 @@ def generate_task_list(show_debug_tasks):
      {"name": "pathto.fn", "fn": pathto.fn2, "description": "foo bar baz"}, ...]"""
 
     def to_list(task_list, qualified=True):
-        return [task_map(task, qualified) for task in task_list]
+        return [mk_task_map(task, qualified) for task in task_list]
 
-    new_task_list = to_list(unqualified_task_list, qualified=False) + to_list(task_list)
+    new_task_list = to_list(UNQUALIFIED_TASK_LIST, qualified=False) + to_list(TASK_LIST)
     if show_debug_tasks:
-        new_task_list = to_list(unqualified_task_list, qualified=False) + \
-            to_list(unqualified_debug_task_list) + \
-            to_list(task_list) + \
-            to_list(debug_task_list)
+        new_task_list = to_list(UNQUALIFIED_TASK_LIST, qualified=False) + \
+            to_list(UNQUALIFIED_DEBUG_TASK_LIST) + \
+            to_list(TASK_LIST) + \
+            to_list(DEBUG_TASK_LIST)
 
     return new_task_list
 

--- a/src/taskrunner.py
+++ b/src/taskrunner.py
@@ -84,6 +84,9 @@ DEBUG_TASK_LIST = [
 
     tasks.diff_builder_config,
 
+    deploy.load_balancer_status,
+    deploy.load_balancer_register_all,
+
     master.write_missing_keypairs_to_s3,
     master.download_keypair,
     master.server_access,

--- a/src/tasks.py
+++ b/src/tasks.py
@@ -5,16 +5,15 @@ better off in their own module. This module really is for stuff
 that has no home."""
 import os
 from buildercore import core, bootstrap, bakery, lifecycle
-from fabric.api import local, task
+from fabric.api import local
 from utils import confirm, errcho, get_input
-from decorators import requires_aws_stack, debugtask
+from decorators import requires_aws_stack
 from buildercore.core import stack_conn
 from buildercore.context_handler import load_context
 import logging
 
 LOG = logging.getLogger(__name__)
 
-@task
 @requires_aws_stack
 def create_ami(stackname, name=None):
     pname = core.project_name_from_stackname(stackname)
@@ -29,7 +28,6 @@ def create_ami(stackname, name=None):
 #
 #
 
-@debugtask
 def diff_builder_config():
     "helps keep three"
     file_sets = [
@@ -46,25 +44,21 @@ def diff_builder_config():
     for paths in file_sets:
         local("meld " + " ".join(paths))
 
-@task
 @requires_aws_stack
 def repair_cfn_info(stackname):
     with stack_conn(stackname):
         bootstrap.write_environment_info(stackname, overwrite=True)
 
-@task
 @requires_aws_stack
 def repair_context(stackname):
     # triggers the workaround of downloading it from EC2 and persisting it
     load_context(stackname)
 
-@task
 @requires_aws_stack
 def remove_minion_key(stackname):
     bootstrap.remove_minion_key(stackname)
 
 
-@task
 def restart_all_running_ec2(statefile):
     "restarts all running ec2 instances. multiple nodes are restarted serially and failures prevent the rest of the node from being restarted"
 

--- a/src/tests/test_taskrunner.py
+++ b/src/tests/test_taskrunner.py
@@ -32,7 +32,7 @@ class TaskRunner(base.BaseCase):
         list_tasks_invocations = [
             "", # no args
             "-l", "--list",
-            "", "-h", "--help", "-?"]
+            "-h", "--help", "-?"]
         for invocation in list_tasks_invocations:
             response = capture_stdout(lambda: tr.main([invocation]))
             self.assertEqual(response["result"], SUCCESS_RC)
@@ -98,7 +98,7 @@ class TaskRunner(base.BaseCase):
             'task_kwargs': {}}
         self.assertEqual(expected, result_map)
 
-    def test_commend_short_circuited_by_comment(self):
+    def test_command_short_circuited_by_comment(self):
         task_list = tr.generate_task_list()
         result_map = tr.exec_task("echo:hell#o-world", task_list)
         expected = {

--- a/src/tests/test_taskrunner.py
+++ b/src/tests/test_taskrunner.py
@@ -64,3 +64,106 @@ class TaskRunner(base.BaseCase):
             'result': 'pong',
             'rc': SUCCESS_RC}
         self.assertEqual(expected, result_map)
+
+    def test_commands_with_args_can_be_called(self):
+        task_list = tr.generate_task_list()
+        result_map = tr.exec_task("echo:zulu", task_list)
+        expected = {
+            'rc': 0,
+            'result': 'received: zulu',
+            'task': 'echo',
+            'task_args': ['zulu'],
+            'task_kwargs': {}}
+        self.assertEqual(expected, result_map)
+
+    def test_commands_with_args_and_kwargs_can_be_called(self):
+        task_list = tr.generate_task_list()
+        result_map = tr.exec_task("echo:zulu,gamma,a=b,y=z", task_list)
+        expected = {
+            'rc': 0,
+            'result': "received: zulu with args: ('gamma',) and kwargs: {'a': 'b', 'y': 'z'}",
+            'task': 'echo',
+            'task_args': ['zulu', 'gamma'],
+            'task_kwargs': {'a': 'b', 'y': 'z'}}
+        self.assertEqual(expected, result_map)
+
+    def test_commands_with_special_chars_can_be_called_without_quoting(self):
+        task_list = tr.generate_task_list()
+        result_map = tr.exec_task("echo:hello-world!@$%^&*()-;?/", task_list)
+        expected = {
+            'rc': 0,
+            'result': 'received: hello-world!@$%^&*()-;?/',
+            'task': 'echo',
+            'task_args': ['hello-world!@$%^&*()-;?/'],
+            'task_kwargs': {}}
+        self.assertEqual(expected, result_map)
+
+    def test_commend_short_circuited_by_comment(self):
+        task_list = tr.generate_task_list()
+        result_map = tr.exec_task("echo:hell#o-world", task_list)
+        expected = {
+            'rc': 0,
+            'result': 'received: hell',
+            'task': 'echo',
+            'task_args': ['hell'],
+            'task_kwargs': {}}
+        self.assertEqual(expected, result_map)
+
+    def test_quoted_commands_can_be_called(self):
+        task_list = tr.generate_task_list()
+        result_map = tr.exec_task("echo:'hello, world'", task_list)
+        expected = {
+            'rc': 0,
+            'result': 'received: hello, world',
+            'task': 'echo',
+            'task_args': ['hello, world'],
+            'task_kwargs': {}}
+        self.assertEqual(expected, result_map)
+
+    def test_multiple_commands_can_be_called(self):
+        task_list = tr.generate_task_list()
+        result_map_list = tr.exec_many("echo:hello echo:world", task_list)
+        expected = [
+            {'rc': 0,
+             'result': 'received: hello',
+             'task': 'echo',
+             'task_args': ['hello'],
+             'task_kwargs': {}},
+            {'rc': 0,
+             'result': 'received: world',
+             'task': 'echo',
+             'task_args': ['world'],
+             'task_kwargs': {}}]
+        self.assertEqual(expected, result_map_list)
+
+    def test_multiple_commands_can_be_called_with_different_sets_of_params(self):
+        task_list = tr.generate_task_list()
+        result_map_list = tr.exec_many("echo:hello echo:world,world=round", task_list)
+        expected = [
+            {'rc': 0,
+             'result': 'received: hello',
+             'task': 'echo',
+             'task_args': ['hello'],
+             'task_kwargs': {}},
+            {'rc': 0,
+             'result': "received: world with args: () and kwargs: {'world': 'round'}",
+             'task': 'echo',
+             'task_args': ['world'],
+             'task_kwargs': {'world': 'round'}}]
+        self.assertEqual(expected, result_map_list)
+
+    def test_multiple_quoted_commands_can_be_called(self):
+        task_list = tr.generate_task_list()
+        result_map_list = tr.exec_many("echo:'hello, world' echo:'fine, thank you',also,response='how are you?'", task_list)
+        expected = [
+            {'rc': 0,
+             'result': 'received: hello, world',
+             'task': 'echo',
+             'task_args': ['hello, world'],
+             'task_kwargs': {}},
+            {'rc': 0,
+             'result': "received: fine, thank you with args: ('also',) and kwargs: {'response': 'how are you?'}",
+             'task': 'echo',
+             'task_args': ['fine, thank you', 'also'],
+             'task_kwargs': {'response': 'how are you?'}}]
+        self.assertEqual(expected, result_map_list)

--- a/src/tests/test_taskrunner.py
+++ b/src/tests/test_taskrunner.py
@@ -1,0 +1,57 @@
+import os, sys
+from . import base
+try:
+    from StringIO import StringIO
+except ImportError:
+    from io import StringIO
+import taskrunner as tr
+#from buildercore import cfngen, context_handler
+#from cfn import ssh, owner_ssh, generate_stack_from_input
+from mock import patch
+#from contextlib import redirect_stdout # py3 only
+
+def capture_stdout(f):
+    strbuffer = StringIO()
+    sys.stdout = strbuffer
+    try:
+        return {"result": f(),
+                "stdout": strbuffer.getvalue()}
+    except BaseException as e:
+        return {"result": e,
+                "stdout": strbuffer.getvalue()}
+    finally:
+        sys.stdout = sys.__stdout__
+
+class TaskRunner(base.BaseCase):
+    def setUp(self):
+        pass
+
+    def tearDown(self):
+        pass
+
+    def test_list_tasks(self):
+        "printing the list of commands can be invoked in many different ways"
+        list_tasks_invocations = [
+            "", # no args
+            "-l", "--list", 
+            "", "-h", "--help", "-?"]
+        for invocation in list_tasks_invocations:
+            result = capture_stdout(lambda: tr.main([invocation]))
+            self.assertEqual(result["result"], 0)
+
+    def test_commands_are_present(self):
+        "some common commands we always use are in the list and qualified as necessary"
+        expected = [
+            "ssh", "master.download_keypair",
+            "launch", "masterless.launch",
+            "start", "stop", "restart",
+            "buildvars.switch_revision"
+        ]
+        result = capture_stdout(lambda: tr.main(["--list"]))
+        for case in expected:
+            present = False
+            for row in result["stdout"].splitlines():
+                if row.startswith(case):
+                    present = True
+                    break
+            self.assertTrue(present, "task %r not present in task listing" % case)

--- a/src/tests/test_taskrunner.py
+++ b/src/tests/test_taskrunner.py
@@ -89,7 +89,7 @@ class TaskRunner(base.BaseCase):
 
     def test_commands_with_whitespace_can_be_called(self):
         task_list = tr.generate_task_list()
-        #result_map = tr.exec_task("echo:msg,'echo hello world'", task_list) # this is what we give bash
+        # result_map = tr.exec_task("echo:msg,'echo hello world'", task_list) # this is what we give bash
         result_map = tr.exec_task("echo:msg,echo hello world", task_list) # this is what we see after bash
         expected = {
             'task': 'echo',
@@ -112,7 +112,7 @@ class TaskRunner(base.BaseCase):
 
     def test_quoted_commands_can_be_called(self):
         task_list = tr.generate_task_list()
-        #result_map = tr.exec_task("echo:'hello\, world'", task_list) # this is what we give bash
+        # result_map = tr.exec_task("echo:'hello\, world'", task_list) # this is what we give bash
         result_map = tr.exec_task("echo:hello\\, world", task_list) # this is what we see after bash
         expected = {
             'rc': 0,

--- a/src/tests/test_taskrunner.py
+++ b/src/tests/test_taskrunner.py
@@ -5,10 +5,8 @@ try:
 except ImportError:
     from io import StringIO
 import taskrunner as tr
-#from buildercore import cfngen, context_handler
-#from cfn import ssh, owner_ssh, generate_stack_from_input
-#from mock import patch
-# from contextlib import redirect_stdout # py3 only
+
+SUCCESS_RC = 0
 
 def capture_stdout(f):
     strbuffer = StringIO()
@@ -37,8 +35,7 @@ class TaskRunner(base.BaseCase):
             "", "-h", "--help", "-?"]
         for invocation in list_tasks_invocations:
             response = capture_stdout(lambda: tr.main([invocation]))
-            success = 0
-            self.assertEqual(response["result"], success)
+            self.assertEqual(response["result"], SUCCESS_RC)
 
     def test_commands_are_present(self):
         "some common commands we always use are in the list and qualified as necessary"
@@ -56,3 +53,14 @@ class TaskRunner(base.BaseCase):
                     present = True
                     break
             self.assertTrue(present, "task %r not present in task listing" % case)
+
+    def test_commands_can_be_called(self):
+        task_list = tr.generate_task_list()
+        result_map = tr.exec_task("ping", task_list)
+        expected = {
+            'task': 'ping',
+            'task_args': [],
+            'task_kwargs': {},
+            'result': 'pong',
+            'rc': SUCCESS_RC}
+        self.assertEqual(expected, result_map)

--- a/src/tests/test_taskrunner.py
+++ b/src/tests/test_taskrunner.py
@@ -40,7 +40,7 @@ class TaskRunner(base.BaseCase):
     def test_commands_are_present(self):
         "some common commands we always use are in the list and qualified as necessary"
         expected = [
-            "ssh", "master.download_keypair",
+            "ssh", # "master.download_keypair", # requires BLDR_ROLE envvar
             "launch", "masterless.launch",
             "start", "stop", "restart",
             "buildvars.switch_revision"
@@ -78,13 +78,13 @@ class TaskRunner(base.BaseCase):
 
     def test_commands_with_args_and_kwargs_can_be_called(self):
         task_list = tr.generate_task_list()
-        result_map = tr.exec_task("echo:zulu,gamma,a=b,y=z", task_list)
+        result_map = tr.exec_task("echo:zulu,gamma,a=b", task_list)
         expected = {
             'rc': 0,
-            'result': "received: zulu with args: ('gamma',) and kwargs: {'a': 'b', 'y': 'z'}",
+            'result': "received: zulu with args: ('gamma',) and kwargs: {'a': 'b'}",
             'task': 'echo',
             'task_args': ['zulu', 'gamma'],
-            'task_kwargs': {'a': 'b', 'y': 'z'}}
+            'task_kwargs': {'a': 'b'}}
         self.assertEqual(expected, result_map)
 
     def test_commands_with_special_chars_can_be_called_without_quoting(self):

--- a/src/tests/test_taskrunner.py
+++ b/src/tests/test_taskrunner.py
@@ -1,4 +1,4 @@
-import os, sys
+import sys
 from . import base
 try:
     from StringIO import StringIO
@@ -7,8 +7,8 @@ except ImportError:
 import taskrunner as tr
 #from buildercore import cfngen, context_handler
 #from cfn import ssh, owner_ssh, generate_stack_from_input
-from mock import patch
-#from contextlib import redirect_stdout # py3 only
+#from mock import patch
+# from contextlib import redirect_stdout # py3 only
 
 def capture_stdout(f):
     strbuffer = StringIO()
@@ -33,11 +33,12 @@ class TaskRunner(base.BaseCase):
         "printing the list of commands can be invoked in many different ways"
         list_tasks_invocations = [
             "", # no args
-            "-l", "--list", 
+            "-l", "--list",
             "", "-h", "--help", "-?"]
         for invocation in list_tasks_invocations:
-            result = capture_stdout(lambda: tr.main([invocation]))
-            self.assertEqual(result["result"], 0)
+            response = capture_stdout(lambda: tr.main([invocation]))
+            success = 0
+            self.assertEqual(response["result"], success)
 
     def test_commands_are_present(self):
         "some common commands we always use are in the list and qualified as necessary"

--- a/src/tests/test_taskrunner.py
+++ b/src/tests/test_taskrunner.py
@@ -87,9 +87,21 @@ class TaskRunner(base.BaseCase):
             'task_kwargs': {'a': 'b'}}
         self.assertEqual(expected, result_map)
 
+    def test_commands_with_whitespace_can_be_called(self):
+        task_list = tr.generate_task_list()
+        #result_map = tr.exec_task("echo:msg,'echo hello world'", task_list) # this is what we give bash
+        result_map = tr.exec_task("echo:msg,echo hello world", task_list) # this is what we see after bash
+        expected = {
+            'task': 'echo',
+            'task_args': ['msg', 'echo hello world'],
+            'task_kwargs': {},
+            'result': "received: msg with args: ('echo hello world',) and kwargs: {}",
+            'rc': SUCCESS_RC}
+        self.assertEqual(expected, result_map)
+
     def test_commands_with_special_chars_can_be_called_without_quoting(self):
         task_list = tr.generate_task_list()
-        result_map = tr.exec_task("echo:hello-world!@$%^&*()-;?/", task_list)
+        result_map = tr.exec_task("echo:hello-world!@$%^&*()-;?/", task_list) # '!@' makes bash cry and doesn't work without quoting
         expected = {
             'rc': 0,
             'result': 'received: hello-world!@$%^&*()-;?/',
@@ -98,20 +110,10 @@ class TaskRunner(base.BaseCase):
             'task_kwargs': {}}
         self.assertEqual(expected, result_map)
 
-    def test_command_short_circuited_by_comment(self):
-        task_list = tr.generate_task_list()
-        result_map = tr.exec_task("echo:hell#o-world", task_list)
-        expected = {
-            'rc': 0,
-            'result': 'received: hell',
-            'task': 'echo',
-            'task_args': ['hell'],
-            'task_kwargs': {}}
-        self.assertEqual(expected, result_map)
-
     def test_quoted_commands_can_be_called(self):
         task_list = tr.generate_task_list()
-        result_map = tr.exec_task("echo:'hello, world'", task_list)
+        #result_map = tr.exec_task("echo:'hello\, world'", task_list) # this is what we give bash
+        result_map = tr.exec_task("echo:hello\\, world", task_list) # this is what we see after bash
         expected = {
             'rc': 0,
             'result': 'received: hello, world',
@@ -119,51 +121,3 @@ class TaskRunner(base.BaseCase):
             'task_args': ['hello, world'],
             'task_kwargs': {}}
         self.assertEqual(expected, result_map)
-
-    def test_multiple_commands_can_be_called(self):
-        task_list = tr.generate_task_list()
-        result_map_list = tr.exec_many("echo:hello echo:world", task_list)
-        expected = [
-            {'rc': 0,
-             'result': 'received: hello',
-             'task': 'echo',
-             'task_args': ['hello'],
-             'task_kwargs': {}},
-            {'rc': 0,
-             'result': 'received: world',
-             'task': 'echo',
-             'task_args': ['world'],
-             'task_kwargs': {}}]
-        self.assertEqual(expected, result_map_list)
-
-    def test_multiple_commands_can_be_called_with_different_sets_of_params(self):
-        task_list = tr.generate_task_list()
-        result_map_list = tr.exec_many("echo:hello echo:world,world=round", task_list)
-        expected = [
-            {'rc': 0,
-             'result': 'received: hello',
-             'task': 'echo',
-             'task_args': ['hello'],
-             'task_kwargs': {}},
-            {'rc': 0,
-             'result': "received: world with args: () and kwargs: {'world': 'round'}",
-             'task': 'echo',
-             'task_args': ['world'],
-             'task_kwargs': {'world': 'round'}}]
-        self.assertEqual(expected, result_map_list)
-
-    def test_multiple_quoted_commands_can_be_called(self):
-        task_list = tr.generate_task_list()
-        result_map_list = tr.exec_many("echo:'hello, world' echo:'fine, thank you',also,response='how are you?'", task_list)
-        expected = [
-            {'rc': 0,
-             'result': 'received: hello, world',
-             'task': 'echo',
-             'task_args': ['hello, world'],
-             'task_kwargs': {}},
-            {'rc': 0,
-             'result': "received: fine, thank you with args: ('also',) and kwargs: {'response': 'how are you?'}",
-             'task': 'echo',
-             'task_args': ['fine, thank you', 'also'],
-             'task_kwargs': {'response': 'how are you?'}}]
-        self.assertEqual(expected, result_map_list)

--- a/src/tests/test_taskrunner.py
+++ b/src/tests/test_taskrunner.py
@@ -49,7 +49,7 @@ class TaskRunner(base.BaseCase):
         for case in expected:
             present = False
             for row in result["stdout"].splitlines():
-                if row.startswith(case):
+                if row.strip().startswith(case):
                     present = True
                     break
             self.assertTrue(present, "task %r not present in task listing" % case)

--- a/src/vault.py
+++ b/src/vault.py
@@ -1,4 +1,4 @@
-from fabric.api import task, local
+from fabric.api import local
 from buildercore import project
 import utils
 import sys
@@ -12,40 +12,33 @@ def vault_addr():
 def vault_policy():
     return 'builder-user'
 
-@task
 def login():
     cmd = "VAULT_ADDR=%s vault login" % vault_addr()
     local(cmd)
 
-@task
 def logout():
     cmd = "rm -f ~/.vault-token"
     local(cmd)
 
-@task
 def policies_update():
     _warning_root_token()
     cmd = "VAULT_ADDR=%s vault policy write %s .vault/%s.hcl" % (vault_addr(), vault_policy(), vault_policy())
     local(cmd)
 
-@task
 def token_lookup(token):
     cmd = "VAULT_ADDR=%s VAULT_TOKEN=%s vault token lookup" % (vault_addr(), token)
     local(cmd)
 
-@task
 def token_list_accessors():
     _warning_root_token()
     cmd = "VAULT_ADDR=%s vault list auth/token/accessors" % (vault_addr())
     local(cmd)
 
-@task
 def token_lookup_accessor(accessor):
     _warning_root_token()
     cmd = "VAULT_ADDR=%s vault token lookup -accessor %s" % (vault_addr(), accessor)
     local(cmd)
 
-@task
 def token_create():
     _warning_root_token()
     token = utils.get_input('token display name: ')
@@ -55,7 +48,6 @@ def token_create():
     cmd = "VAULT_ADDR=%s vault token create -policy=%s -display-name=%s" % (vault_addr(), vault_policy(), token)
     local(cmd)
 
-@task
 def token_revoke(token):
     cmd = "VAULT_ADDR=%s vault token revoke %s" % (vault_addr(), token)
     local(cmd)


### PR DESCRIPTION
todo:
- [x] remove the `task` decorator, it doesn't seem to be necessary
- [x] investigate all extant incantations of builder that are out there (alfred, master-server, etc)
    - [github search results 1](https://github.com/search?q=org%3Aelifesciences+%2Fsrv%2Fbuilder%2Fbldr&type=Code)
    - [github search results 2](https://github.com/search?q=org%3Aelifesciences+.%2Fbldr&type=Code)
    - `./bldr -l`
    - `BUILDER_NON_INTERACTIVE=1 /srv/builder/bldr`
    - `sh "${env.BUILDER_PATH}bldr cmd:${stackname},'cd ${remoteTestArtifactFolder}/..; rm -rf artifact.tar; tar -cf artifact.tar $remoteTestArtifactFolderBasename'"`
- [x] tests
- [x] review (self)
- [x] review (others)