### PR TITLE
Add EFS IAM policy to Kubernetes workers

### DIFF
--- a/projects/elife.yaml
+++ b/projects/elife.yaml
@@ -2168,6 +2168,7 @@ kubernetes-aws:
             helm: true
             external-dns:
                 domain-filter: "elifesciences.org"
+            efs: true
 
 large-repo-wrangler:
     description: when elife-publications requires a large git repository to be wrangled. adhoc instances only.

--- a/src/buildercore/terraform.py
+++ b/src/buildercore/terraform.py
@@ -808,6 +808,32 @@ def _render_eks_workers_role(context, template):
             'role': "${aws_iam_role.worker.name}",
         })
 
+    if context['eks']['efs']:
+        template.populate_resource('aws_iam_policy', 'kubernetes_efs', block={
+            'name': '%s--AmazonEFSKubernetes' % context['stackname'],
+            'path': '/',
+            'description': 'Allows management of EFS resources',
+            'policy': json.dumps({
+                "Version": "2012-10-17",
+                "Statement": [
+                    {
+                        "Effect": "Allow",
+                        "Action": [
+                            "elasticfilesystem:*",
+                        ],
+                        "Resource": [
+                            "*",
+                        ],
+                    },
+                ],
+            }),
+        })
+
+        template.populate_resource('aws_iam_role_policy_attachment', 'worker_efs', block={
+            'policy_arn': "${aws_iam_policy.kubernetes_efs.arn}",
+            'role': "${aws_iam_role.worker.name}",
+        })
+
 def _render_eks_workers_autoscaling_group(context, template):
     template.populate_resource('aws_iam_instance_profile', 'worker', block={
         'name': '%s--worker' % context['stackname'],

--- a/src/buildercore/terraform.py
+++ b/src/buildercore/terraform.py
@@ -819,7 +819,10 @@ def _render_eks_workers_role(context, template):
                     {
                         "Effect": "Allow",
                         "Action": [
-                            "elasticfilesystem:*",
+                            "elasticfilesystem:DescribeFileSystems",
+                            "elasticfilesystem:DescribeMountTargets",
+                            "elasticfilesystem:DescribeMountTargetSecurityGroups",
+                            "elasticfilesystem:DescribeTags",
                         ],
                         "Resource": [
                             "*",

--- a/src/tests/fixtures/projects/dummy-project.yaml
+++ b/src/tests/fixtures/projects/dummy-project.yaml
@@ -103,6 +103,7 @@ defaults:
                 max-size: 3
             helm: false
             external-dns: false
+            efs: false
         cloudfront:
             # cloudfront defaults only used if a 'cloudfront' section present in project
             subdomains-without-dns: []
@@ -762,7 +763,7 @@ project-with-eks:
                 max-size: 3
 
 project-with-eks-helm:
-    description: project managing an EKS cluster and various extensions
+    description: project managing an EKS cluster with Helm for chart installation
     domain: False
     intdomain: False
     aws:
@@ -770,7 +771,7 @@ project-with-eks-helm:
             helm: true
 
 project-with-eks-external-dns:
-    description: project managing an EKS cluster and various extensions
+    description: project managing an EKS cluster with external-dns for Route53 entries creation
     domain: False
     intdomain: False
     aws:
@@ -778,3 +779,11 @@ project-with-eks-external-dns:
             helm: true  # required
             external-dns:
                 domain-filter: "elifesciences.net"
+
+project-with-eks-efs:
+    description: project managing an EKS cluster with EFS support
+    domain: False
+    intdomain: False
+    aws:
+        eks:
+            efs: true

--- a/src/tests/test_buildercore_project.py
+++ b/src/tests/test_buildercore_project.py
@@ -14,7 +14,7 @@ ALL_PROJECTS = [
     'project-with-cluster-integration-tests', 'project-with-db-params', 'project-with-rds-only', 'project-with-rds-encryption', 'project-with-rds-major-version-upgrade',
     'project-with-elasticache-redis', 'project-with-multiple-elasticaches', 'project-with-fully-overridden-elasticaches',
     'project-on-gcp', 'project-with-bigquery-datasets-only', 'project-with-bigquery', 'project-with-bigquery-remote-schemas',
-    'project-with-eks', 'project-with-eks-helm', 'project-with-eks-external-dns',
+    'project-with-eks', 'project-with-eks-helm', 'project-with-eks-external-dns', 'project-with-eks-efs',
 ]
 
 class TestProject(base.BaseCase):

--- a/src/tests/test_buildercore_terraform.py
+++ b/src/tests/test_buildercore_terraform.py
@@ -1369,7 +1369,10 @@ class TestBuildercoreTerraform(base.BaseCase):
                     {
                         "Effect": "Allow",
                         "Action": [
-                            "elasticfilesystem:*",
+                            "elasticfilesystem:DescribeFileSystems",
+                            "elasticfilesystem:DescribeMountTargets",
+                            "elasticfilesystem:DescribeMountTargetSecurityGroups",
+                            "elasticfilesystem:DescribeTags",
                         ],
                         "Resource": [
                             "*",


### PR DESCRIPTION
Allows EFS usage, to share volumes between containers.