### PR TITLE
Use CloudFormation Outputs to discover the load balancer name

### DIFF
--- a/src/buildercore/bluegreen.py
+++ b/src/buildercore/bluegreen.py
@@ -7,7 +7,7 @@ TODO: make nodes_params a named tuple"""
 import logging
 from .core import boto_client, parallel_work
 from .cloudformation import read_output
-from .utils import ensure, call_while
+from .utils import call_while
 
 LOG = logging.getLogger(__name__)
 

--- a/src/buildercore/bluegreen.py
+++ b/src/buildercore/bluegreen.py
@@ -6,6 +6,7 @@ nodes_params is a data structure (dictionary) .
 TODO: make nodes_params a named tuple"""
 import logging
 from .core import boto_client, parallel_work
+from .cloudformation import read_output
 from .utils import ensure, call_while
 
 LOG = logging.getLogger(__name__)
@@ -37,12 +38,9 @@ class BlueGreenConcurrency(object):
         self.wait_registered_all(elb_name, nodes_params)
 
     def find_load_balancer(self, stackname):
-        names = [lb['LoadBalancerName'] for lb in self.conn.describe_load_balancers()['LoadBalancerDescriptions']]
-        ensure(len(names) >= 1, "No load balancers found")
-        tags = self.conn.describe_tags(LoadBalancerNames=names)['TagDescriptions']
-        balancers = [lb['LoadBalancerName'] for lb in tags if {'Key': 'Cluster', 'Value': stackname} in lb['Tags']]
-        ensure(len(balancers) == 1, "Expected to find exactly 1 load balancer, but found %s" % balancers)
-        return balancers[0]
+        elb_name = read_output(stackname, 'ElasticLoadBalancer')
+        LOG.info("Found load balancer: %s", elb_name)
+        return elb_name
 
     def divide_by_color(self, nodes_params):
         is_blue = lambda node: node % 2 == 1

--- a/src/buildercore/bootstrap.py
+++ b/src/buildercore/bootstrap.py
@@ -336,6 +336,7 @@ def master_data(region):
 def master(region, key):
     return master_data(region)[key]
 
+# TODO: move to buildercore.cloudformation?
 @core.requires_active_stack
 def template_info(stackname):
     "returns some useful information about the given stackname as a map"

--- a/src/buildercore/cloudformation.py
+++ b/src/buildercore/cloudformation.py
@@ -131,6 +131,7 @@ def _wait_until_in_progress(stackname):
 def read_template(stackname):
     "returns the contents of a cloudformation template as a python data structure"
     output_fname = os.path.join(config.STACK_DIR, stackname + ".json")
+    # TODO: use a context manager to close the file afterwards
     return json.load(open(output_fname, 'r'))
 
 def read_output(stackname, key):
@@ -169,6 +170,7 @@ def _merge_delta(stackname, delta):
 def write_template(stackname, contents):
     "writes a json version of the python cloudformation template to the stacks directory"
     output_fname = os.path.join(config.STACK_DIR, stackname + ".json")
+    # TODO: use a context manager to close the file afterwards
     open(output_fname, 'w').write(contents)
     return output_fname
 

--- a/src/buildercore/cloudformation.py
+++ b/src/buildercore/cloudformation.py
@@ -135,8 +135,10 @@ def read_template(stackname):
 
 def read_output(stackname, key):
     data = core.describe_stack(stackname).meta.data # boto3
+    ensure('Outputs' in data, "Outputs missing: %s" % data) 
     selected_outputs = [o for o in data['Outputs'] if o['OutputKey'] == key]
     ensure(len(selected_outputs) == 1, "Too many outputs selected: %s" % selected_outputs)
+    ensure('OutputValue' in selected_outputs[0], "Badly formed Output: %s" % selected_outputs[0])
     return selected_outputs[0]['OutputValue']
 
 def apply_delta(template, delta):

--- a/src/buildercore/cloudformation.py
+++ b/src/buildercore/cloudformation.py
@@ -133,6 +133,12 @@ def read_template(stackname):
     output_fname = os.path.join(config.STACK_DIR, stackname + ".json")
     return json.load(open(output_fname, 'r'))
 
+def read_output(stackname, key):
+    data = core.describe_stack(stackname).meta.data # boto3
+    selected_outputs = [o for o in data['Outputs'] if o['OutputKey'] == key]
+    ensure(len(selected_outputs) == 1, "Too many outputs selected: %s" % selected_outputs)
+    return selected_outputs[0]['OutputValue']
+
 def apply_delta(template, delta):
     for component in delta.plus:
         ensure(component in ["Resources", "Outputs", "Parameters"], "Template component %s not recognized" % component)

--- a/src/buildercore/cloudformation.py
+++ b/src/buildercore/cloudformation.py
@@ -136,7 +136,7 @@ def read_template(stackname):
 
 def read_output(stackname, key):
     data = core.describe_stack(stackname).meta.data # boto3
-    ensure('Outputs' in data, "Outputs missing: %s" % data) 
+    ensure('Outputs' in data, "Outputs missing: %s" % data)
     selected_outputs = [o for o in data['Outputs'] if o['OutputKey'] == key]
     ensure(len(selected_outputs) == 1, "Too many outputs selected: %s" % selected_outputs)
     ensure('OutputValue' in selected_outputs[0], "Badly formed Output: %s" % selected_outputs[0])

--- a/src/buildercore/concurrency.py
+++ b/src/buildercore/concurrency.py
@@ -21,4 +21,4 @@ def concurrency_for(stackname, concurrency_name):
     if concurrency_name is None:
         return 'parallel'
 
-    raise ValueError("Concurrency %s is not supported. Supported models: %s" % concurrency_name, concurrency_names)
+    raise ValueError("Concurrency %s is not supported. Supported models: %s" % (concurrency_name, concurrency_names))

--- a/src/buildercore/concurrency.py
+++ b/src/buildercore/concurrency.py
@@ -9,6 +9,8 @@ def concurrency_for(stackname, concurrency_name):
     - parallel: all together
     - blue-green: 50% at a time"""
 
+    concurrency_names = ['serial', 'parallel', 'blue-green']
+
     if concurrency_name == 'blue-green':
         context = context_handler.load_context(stackname)
         return bluegreen.BlueGreenConcurrency(context['aws']['region'])
@@ -19,4 +21,4 @@ def concurrency_for(stackname, concurrency_name):
     if concurrency_name is None:
         return 'parallel'
 
-    raise ValueError("Concurrency %s is not supported" % concurrency_name)
+    raise ValueError("Concurrency %s is not supported. Supported models: %s" % concurrency_name, concurrency_names)

--- a/src/buildercore/core.py
+++ b/src/buildercore/core.py
@@ -282,7 +282,13 @@ class NoPublicIps(Exception):
 def all_node_params(stackname):
     data = stack_data(stackname)
     public_ips = {ec2['InstanceId']: ec2.get('PublicIpAddress') for ec2 in data}
-    nodes = {ec2['InstanceId']: int(tags2dict(ec2['Tags'])['Node']) if 'Node' in tags2dict(ec2['Tags']) else 1 for ec2 in data}
+    tags_dict = tags2dict(ec2['Tags'])
+    nodes = {
+        ec2['InstanceId']: int(tags_dict['Node']) \
+        if 'Node' in tags_dict \
+        else 1 \
+        for ec2 in data
+    }
 
     # TODO: default copied from stack_all_ec2_nodes, but not the most robust probably
     params = _ec2_connection_params(stackname, config.DEPLOY_USER)

--- a/src/buildercore/core.py
+++ b/src/buildercore/core.py
@@ -282,11 +282,10 @@ class NoPublicIps(Exception):
 def all_node_params(stackname):
     data = stack_data(stackname)
     public_ips = {ec2['InstanceId']: ec2.get('PublicIpAddress') for ec2 in data}
-    tags_dict = tags2dict(ec2['Tags'])
     nodes = {
-        ec2['InstanceId']: int(tags_dict['Node']) \
-        if 'Node' in tags_dict \
-        else 1 \
+        ec2['InstanceId']: int(tags2dict(ec2['Tags'])['Node'])
+        if 'Node' in tags2dict(ec2['Tags'])
+        else 1
         for ec2 in data
     }
 

--- a/src/buildercore/core.py
+++ b/src/buildercore/core.py
@@ -279,6 +279,23 @@ def stack_conn(stackname, username=config.DEPLOY_USER, node=None, **kwargs):
 class NoPublicIps(Exception):
     pass
 
+def all_node_params(stackname):
+    data = stack_data(stackname)
+    public_ips = {ec2['InstanceId']: ec2.get('PublicIpAddress') for ec2 in data}
+    nodes = {ec2['InstanceId']: int(tags2dict(ec2['Tags'])['Node']) if 'Node' in tags2dict(ec2['Tags']) else 1 for ec2 in data}
+
+    # TODO: default copied from stack_all_ec2_nodes, but not the most robust probably
+    params = _ec2_connection_params(stackname, config.DEPLOY_USER)
+
+    # custom for builder, these are available as fabric.api.env.public_ips inside workfn
+    params.update({
+        'stackname': stackname,
+        'public_ips': public_ips,
+        'nodes': nodes
+    })
+
+    return params
+
 def stack_all_ec2_nodes(stackname, workfn, username=config.DEPLOY_USER, concurrency=None, node=None, instance_ids=None, **kwargs):
     """Executes work on all the EC2 nodes of stackname.
     Optionally connects with the specified username"""
@@ -287,6 +304,7 @@ def stack_all_ec2_nodes(stackname, workfn, username=config.DEPLOY_USER, concurre
         workfn, work_kwargs = workfn
 
     data = stack_data(stackname)
+    # TODO: reuse all_node_params?
     public_ips = {ec2['InstanceId']: ec2.get('PublicIpAddress') for ec2 in data}
     nodes = {ec2['InstanceId']: int(tags2dict(ec2['Tags'])['Node']) if 'Node' in tags2dict(ec2['Tags']) else 1 for ec2 in data}
     if node:

--- a/src/buildercore/trop.py
+++ b/src/buildercore/trop.py
@@ -725,6 +725,12 @@ def render_elb(context, template, ec2_instances):
         Tags=elb_tags(context)
     ))
 
+    template.add_output(mkoutput(
+        "ElasticLoadBalancer",
+        "Generated name of the ELB",
+        Ref(ELB_TITLE))
+    )
+
     template.add_resource(security_group(
         SECURITY_GROUP_ELB_TITLE,
         context['aws']['vpc-id'],

--- a/src/deploy.py
+++ b/src/deploy.py
@@ -1,8 +1,8 @@
 """module concerns itself with tasks involving branch deployments of projects."""
 
 from fabric.api import task
-from decorators import requires_aws_stack
-from buildercore import bootstrap
+from decorators import requires_aws_stack, debugtask
+from buildercore import bootstrap, cloudformation
 from buildercore.concurrency import concurrency_for
 import buildvars
 
@@ -15,3 +15,9 @@ LOG = logging.getLogger(__name__)
 def switch_revision_update_instance(stackname, revision=None, concurrency='serial'):
     buildvars.switch_revision(stackname, revision)
     bootstrap.update_stack(stackname, service_list=['ec2'], concurrency=concurrency_for(stackname, concurrency))
+
+@debugtask
+@requires_aws_stack
+def load_balancer_status(stackname):
+    load_balancer_name = cloudformation.read_output(stackname, 'ElasticLoadBalancer')
+    print(load_balancer_name)

--- a/src/deploy.py
+++ b/src/deploy.py
@@ -1,9 +1,12 @@
 """module concerns itself with tasks involving branch deployments of projects."""
 
+from pprint import pformat
 from fabric.api import task
 from decorators import requires_aws_stack, debugtask
+# TODO: import modules rather than functions
 from buildercore import bootstrap, cloudformation, context_handler
-from buildercore.core import boto_client
+from buildercore.bluegreen import BlueGreenConcurrency
+from buildercore.core import boto_client, all_node_params
 from buildercore.concurrency import concurrency_for
 import buildvars
 
@@ -21,10 +24,21 @@ def switch_revision_update_instance(stackname, revision=None, concurrency='seria
 @requires_aws_stack
 def load_balancer_status(stackname):
     context = context_handler.load_context(stackname)
+    # TODO: delegate to BlueGreenConcurrency?
     elb_name = cloudformation.read_output(stackname, 'ElasticLoadBalancer')
     conn = boto_client('elb', context['aws']['region'])
     health = conn.describe_instance_health(
         LoadBalancerName=elb_name,
     )['InstanceStates']
     LOG.info("Load balancer name: %s", elb_name)
-    LOG.info("Health: %s", health)
+    LOG.info("Health: %s", pformat(health))
+
+@debugtask
+@requires_aws_stack
+def load_balancer_register_all(stackname):
+    context = context_handler.load_context(stackname)
+    elb_name = cloudformation.read_output(stackname, 'ElasticLoadBalancer')
+    concurrency = BlueGreenConcurrency(context['aws']['region'])
+    node_params = all_node_params(stackname)
+    concurrency.register(elb_name, node_params)
+    concurrency.wait_registered_all(elb_name, node_params)

--- a/src/deploy.py
+++ b/src/deploy.py
@@ -38,7 +38,9 @@ def load_balancer_status(stackname):
 def load_balancer_register_all(stackname):
     context = context_handler.load_context(stackname)
     elb_name = cloudformation.read_output(stackname, 'ElasticLoadBalancer')
+    LOG.info("Load balancer name: %s", elb_name)
     concurrency = BlueGreenConcurrency(context['aws']['region'])
     node_params = all_node_params(stackname)
+    LOG.info("Register all: %s", pformat(node_params))
     concurrency.register(elb_name, node_params)
     concurrency.wait_registered_all(elb_name, node_params)

--- a/src/fabfile.py
+++ b/src/fabfile.py
@@ -16,7 +16,7 @@ import master
 import askmaster
 import buildvars
 import project
-from deploy import switch_revision_update_instance
+from deploy import switch_revision_update_instance, load_balancer_status
 from lifecycle import start, stop, restart, stop_if_running_for, update_dns
 import masterless
 import vault

--- a/src/fabfile.py
+++ b/src/fabfile.py
@@ -16,7 +16,7 @@ import master
 import askmaster
 import buildvars
 import project
-from deploy import switch_revision_update_instance, load_balancer_status
+from deploy import switch_revision_update_instance, load_balancer_status, load_balancer_register_all
 from lifecycle import start, stop, restart, stop_if_running_for, update_dns
 import masterless
 import vault

--- a/src/tests/test_buildercore_bluegreen.py
+++ b/src/tests/test_buildercore_bluegreen.py
@@ -18,25 +18,6 @@ class Primitives(base.BaseCase):
         elb_conn_factory.return_value = self.conn
         self.concurrency = bluegreen.BlueGreenConcurrency('us-east-1')
 
-    def test_find_load_balancer(self):
-        self.conn.describe_load_balancers.return_value = {
-            'LoadBalancerDescriptions': [
-                {'LoadBalancerName': 'dummy1-ElasticL-ABCDEFGHI'}
-            ]
-        }
-        self.conn.describe_tags.return_value = {
-            'TagDescriptions': [
-                {
-                    'LoadBalancerName': 'dummy1-ElasticL-ABCDEFGHI',
-                    'Tags': [
-                        {'Key': 'Cluster', 'Value': 'dummy1--test'},
-                    ]
-                }
-            ]
-        }
-        name = self.concurrency.find_load_balancer('dummy1--test')
-        self.assertEqual(name, 'dummy1-ElasticL-ABCDEFGHI')
-
     @patch('buildercore.bluegreen.call_while', side_effect=try_only_once)
     def test_wait_all_in_service_success(self, call_while):
         self.conn.describe_instance_health.return_value = {

--- a/src/tests/test_buildercore_cloudformation.py
+++ b/src/tests/test_buildercore_cloudformation.py
@@ -1,5 +1,6 @@
 from buildercore import cloudformation
 from . import base
+from mock import patch, MagicMock
 import botocore
 
 class StackCreationContextManager(base.BaseCase):
@@ -16,6 +17,26 @@ class StackCreationContextManager(base.BaseCase):
                 },
                 'CreateStack'
             )
+
+class StackInformation(base.BaseCase):
+    @patch('buildercore.cloudformation.core.describe_stack')
+    def test_read_output(self, describe_stack):
+        description = MagicMock()
+        description.meta.data = {
+            'Outputs': [
+                {
+                    'OutputKey': 'ElasticLoadBalancer',
+                    'OutputValue': 'dummy1--t-ElasticL-19CB72BN8E36S',
+                    # ...
+                }
+            ],
+        }
+        describe_stack.return_value = description
+
+        self.assertEqual(
+            cloudformation.read_output('dummy1--test', 'ElasticLoadBalancer'),
+            'dummy1--t-ElasticL-19CB72BN8E36S'
+        )
 
 class StackUpdate(base.BaseCase):
     def test_no_updates(self):

--- a/src/tests/test_buildercore_trop.py
+++ b/src/tests/test_buildercore_trop.py
@@ -229,6 +229,8 @@ class TestBuildercoreTrop(base.BaseCase):
             resources['EC2Instance1']['Properties']['Tags']
         )
         outputs = data['Outputs']
+        self.assertIn('ElasticLoadBalancer', list(outputs.keys()))
+        self.assertEqual({'Ref': 'ElasticLoadBalancer'}, outputs['ElasticLoadBalancer']['Value'])
         self.assertIn('InstanceId1', list(outputs.keys()))
         self.assertEqual({'Ref': 'EC2Instance1'}, outputs['InstanceId1']['Value'])
         self.assertEqual({'Ref': 'EC2Instance1'}, outputs['InstanceId1']['Value'])


### PR DESCRIPTION
For https://github.com/elifesciences/issues/issues/5137

The `ElasticLoadBalancer` name is generated by AWS, e.g.
```
Load balancer: elife-xpu-ElasticL-19CB72BN8E36S
DNS name: elife-xpu-ElasticL-19CB72BN8E36S-1360186739.us-east-1.elb.amazonaws.com
```

In order to perform blue-green deployment, we need to detach and re-attach instances from the load balancer. So we need to find out its name first, given an input like `elife-xpub--staging`.

Using the CloudFormation API when creating the infrastructure, we can add the generated name as an `Output` of the template. We then retrieve it at deployment time to use it.

Before this, we were listing all the load balancers and filtering them one by one checking their `Cluster` tag matched the input `elife-xpub--staging`. The ELB API we were using has a limit of 20 load balancers however, so it broke once we had too many.

Note: this requires `update_infrastructure` to be run on all ELB-related stacks to add the `Output`, otherwise deployments will still be failing because of the missing `Outputs` key.