### PR TITLE
Remove Vault access from masterless servers

### DIFF
--- a/scripts/init-masterless-formulas.sh
+++ b/scripts/init-masterless-formulas.sh
@@ -11,8 +11,6 @@ set -x
 formula_list=$1
 pillar_repo=$2 # what secrets do I know?
 configuration_repo=$3 # what configuration do I know?
-vault_addr="${4:-}" # where is Vault?
-vault_token="${5:-}" # how do I authenticate with Vault?
 
 # clone the private repo (whatever it's name is) into /opt/builder-private/
 # REQUIRES CREDENTIALS!
@@ -82,16 +80,6 @@ echo "pillar_roots:
 # this won't do anything but put the two top.sls files closer to each other
 cd /srv/salt/pillar
 ln -sfT /opt/builder-private/pillar/top.sls top.sls
-
-if [ ! -z "$vault_addr" ]; then
-    # sets up connection to Vault
-    echo "vault:
-        url: $vault_addr
-        auth:
-            method: token
-            token: $vault_token
-    "> /etc/salt/minion.d/vault.conf
-fi
 
 clone_update() {
     repo=$1

--- a/src/buildercore/bootstrap.py
+++ b/src/buildercore/bootstrap.py
@@ -507,16 +507,6 @@ def update_ec2_stack(stackname, context, concurrency=None, formula_revisions=Non
             envvars = {
                 'BUILDER_TOPFILE': os.environ.get('BUILDER_TOPFILE', ''),
             }
-            # TODO: only do this if is_master is False, and then leave the self-connection of the masterless master-server to itself to the formula?
-            # or do it here through the scripts for consistency?
-            # since Vault is not running at this time, we have to do it in the formula
-            if not is_master:
-                vault_addr = context['vault']['address']
-                # TODO: reduce scope to a project if possible?
-                vault_token = vault.token_create(context['vault']['address'], vault.SALT_MASTERLESS_POLICY, display_name=context['stackname'])
-                vault_arguments = [vault_addr, vault_token]
-            else:
-                vault_arguments = []
 
             # Vagrant's equivalent is 'init-vagrant-formulas.sh'
             run_script(
@@ -524,7 +514,6 @@ def update_ec2_stack(stackname, context, concurrency=None, formula_revisions=Non
                 formula_list,
                 fdata['private-repo'],
                 fdata['configuration-repo'],
-                *vault_arguments,
                 **envvars
             )
 

--- a/src/buildercore/bootstrap.py
+++ b/src/buildercore/bootstrap.py
@@ -8,7 +8,7 @@ import os, json, re
 from os.path import join
 from collections import OrderedDict
 from datetime import datetime
-from . import utils, config, bvars, core, context_handler, project, cloudformation, terraform, vault, sns as snsmod, command
+from . import utils, config, bvars, core, context_handler, project, cloudformation, terraform, sns as snsmod, command
 from .context_handler import only_if as updates
 from .core import stack_all_ec2_nodes, project_data_for_stackname, stack_conn
 from .utils import first, ensure, subdict, yaml_dumps, lmap

--- a/src/buildercore/vault.py
+++ b/src/buildercore/vault.py
@@ -3,8 +3,6 @@
 import json
 from buildercore import external
 
-SALT_MASTERLESS_POLICY = 'master-server'
-
 def token_create(vault_addr, policy, display_name):
     # TODO: put a default of 24h for token lifetime rather than 768h?
     cmd = ["vault", "token", "create", "-address=%s" % vault_addr, "-policy=%s" % policy, "-display-name=%s" % display_name, "-format=json"]


### PR DESCRIPTION
It's not used, because we currently use Vault to provide pillars through https://github.com/elifesciences/master-server-formula/blob/master/salt/master-server/config/opt-salt-extension-modules-pillar-elife_vault.py which is only deployed to the `master-server`.

What this allows is to access Vault directly with `{{
salt['vault.read_secret'](...) }}` which we don't use, in favor of
pillars.

Tested with:
- [x] `bldr masterless.launch:basebox,test-masterless-without-vault,standalone`
- [x] `bldr masterless.launch:master-server,test-masterless-master-server,standalone`