### PR TITLE
Feature: threadbare integration

### DIFF
--- a/.activate-venv.sh
+++ b/.activate-venv.sh
@@ -35,7 +35,7 @@ fi
 if [ ! -f .use-python-3.flag ]; then
     virtualenv --python=$python venv
 else
-    python3 -m venv venv
+    "$python" -m venv venv
 fi
 source venv/bin/activate
 

--- a/.run-tests-ci.sh
+++ b/.run-tests-ci.sh
@@ -16,6 +16,9 @@ if [ "$envname" = "py27" ]; then
 else
     coverage_options=
 fi
+
+pip install -U execnet==1.1
+
 pytest \
     $coverage_options \
     -n 4 \

--- a/.run-tests-ci.sh
+++ b/.run-tests-ci.sh
@@ -17,13 +17,9 @@ else
     coverage_options=
 fi
 
-pip install -U execnet==1.1
-
 pytest \
     $coverage_options \
-    -n 4 \
-    --dist=loadscope \
-    -s \
+    --capture=no \
     --junitxml="build/pytest-$envname.xml" \
     src/tests src/integration_tests
 

--- a/Dockerfile.py3
+++ b/Dockerfile.py3
@@ -1,9 +1,13 @@
 FROM python:3.5-alpine3.8
 
+# cmake + zlib-dev for parallel-ssh dependencies
+# paramiko is pure python and never needed it
 RUN apk add --no-cache \
     libressl-dev \
     musl-dev \
-    libffi-dev
+    libffi-dev \
+    cmake \
+    zlib-dev
 
 COPY requirements.txt /requirements.txt
 
@@ -17,6 +21,7 @@ RUN apk add --no-cache --virtual build-deps \
     pip install virtualenv && \
     mkdir /venv && \
     virtualenv --python=python3 /venv && \
+    /venv/bin/pip install parallel-ssh && \
     /venv/bin/pip install -r /requirements.txt && \
     apk del build-deps
 

--- a/Dockerfile.py3
+++ b/Dockerfile.py3
@@ -21,7 +21,6 @@ RUN apk add --no-cache --virtual build-deps \
     pip install virtualenv && \
     mkdir /venv && \
     virtualenv --python=python3 /venv && \
-    /venv/bin/pip install parallel-ssh && \
     /venv/bin/pip install -r /requirements.txt && \
     apk del build-deps
 

--- a/py2-requirements.txt
+++ b/py2-requirements.txt
@@ -22,4 +22,4 @@ PyYAML==4.2b2
 requests==2.20.0
 troposphere==2.3.3
 unittest2==1.1.0
-parallel-ssh
+parallel-ssh==1.9.1

--- a/py2-requirements.txt
+++ b/py2-requirements.txt
@@ -15,7 +15,6 @@ pylint==1.8.2
 pytest==3.5.0
 pytest-cov==2.5.1
 pytest-forked==0.2
-pytest-xdist==1.22.2
 python-dateutil==2.6.0
 python-slugify==1.2.1
 python-terraform==0.10.0

--- a/py2-requirements.txt
+++ b/py2-requirements.txt
@@ -24,3 +24,4 @@ PyYAML==4.2b2
 requests==2.20.0
 troposphere==2.3.3
 unittest2==1.1.0
+-e git+ssh://git@github.com/elifesciences/threadbare@develop#egg=threadbare

--- a/py2-requirements.txt
+++ b/py2-requirements.txt
@@ -24,4 +24,4 @@ PyYAML==4.2b2
 requests==2.20.0
 troposphere==2.3.3
 unittest2==1.1.0
--e git+ssh://git@github.com/elifesciences/threadbare@develop#egg=threadbare
+parallel-ssh

--- a/requirements.txt
+++ b/requirements.txt
@@ -16,7 +16,6 @@ pylint==1.8.2
 pytest==3.5.0
 pytest-cov==2.5.1
 pytest-forked==0.2
-pytest-xdist==1.22.2
 python-dateutil==2.7.0
 python-slugify==1.2.4
 python-terraform==0.10.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -23,4 +23,4 @@ PyYAML==4.2b2
 requests==2.20.0
 troposphere==2.3.3
 unittest2==1.1.0
-parallel-ssh
+parallel-ssh==1.9.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -25,3 +25,4 @@ PyYAML==4.2b2
 requests==2.20.0
 troposphere==2.3.3
 unittest2==1.1.0
+-e git+ssh://git@github.com/elifesciences/threadbare@develop#egg=threadbare

--- a/requirements.txt
+++ b/requirements.txt
@@ -25,4 +25,4 @@ PyYAML==4.2b2
 requests==2.20.0
 troposphere==2.3.3
 unittest2==1.1.0
--e git+ssh://git@github.com/elifesciences/threadbare@develop#egg=threadbare
+parallel-ssh

--- a/src/buildercore/bootstrap.py
+++ b/src/buildercore/bootstrap.py
@@ -51,7 +51,8 @@ def run_script(script_filename, *script_params, **environment_variables):
 
     env_string = ['%s=%s' % (k, v) for k, v in environment_variables.items()]
     cmd = ["/bin/bash", remote_script] + lmap(escape_string_parameter, list(script_params))
-    retval = remote_sudo(" ".join(env_string + cmd))
+    result = remote_sudo(" ".join(env_string + cmd))
+    retval = result['return_code']
     remote_sudo("rm " + remote_script) # remove the script after executing it
     end = datetime.now()
     LOG.info("Executed script %s in %2.4f seconds", script_filename, (end - start).total_seconds())

--- a/src/buildercore/command.py
+++ b/src/buildercore/command.py
@@ -82,7 +82,7 @@ def fab_api_local_wrapper(*args, **kwargs):
     # https://github.com/mathiasertl/fabric/blob/master/fabric/operations.py#L1240-L1251
     result = fab_result.__dict__
     result['stdout'] = (fab_result or b"").splitlines()
-    result['stderr'] = (fab_result.stderr or b"").splitlines() 
+    result['stderr'] = (fab_result.stderr or b"").splitlines()
     return result
 
 local = api(fab_api_local_wrapper, threadbare.operations.local)

--- a/src/buildercore/command.py
+++ b/src/buildercore/command.py
@@ -7,10 +7,7 @@ import fabric.state
 import fabric.network
 import logging
 from io import BytesIO
-from . import utils
-import threadbare.operations
-import threadbare.state
-import threadbare.execute
+from . import utils, threadbare
 from functools import partial
 
 THREADBARE = 'threadbare'

--- a/src/buildercore/command.py
+++ b/src/buildercore/command.py
@@ -75,7 +75,17 @@ NetworkError = fab_exceptions.NetworkError
 # api
 #
 
-local = api(fab_api.local, threadbare.operations.local)
+def fab_api_local_wrapper(*args, **kwargs):
+    """Fabric returns the stdout of the command when capture=True, with stderr and some values also available as attributes.
+    This modifies the behaviour of Fabric's `local` to return a dictionary of results."""
+    fab_result = fab_api.local(*args, **kwargs)
+    # https://github.com/mathiasertl/fabric/blob/master/fabric/operations.py#L1240-L1251
+    result = fab_result.__dict__
+    result['stdout'] = (fab_result or b"").splitlines()
+    result['stderr'] = (fab_result.stderr or b"").splitlines() 
+    return result
+
+local = api(fab_api_local_wrapper, threadbare.operations.local)
 execute = api(fab_api.execute, partial(threadbare.execute.execute_with_hosts, env))
 parallel = api(fab_api.parallel, threadbare.execute.parallel)
 serial = api(fab_api.serial, threadbare.execute.serial)

--- a/src/buildercore/command.py
+++ b/src/buildercore/command.py
@@ -50,8 +50,11 @@ class CommandException(Exception):
     pass
 
 # no un-catchable errors from Fabric
-#env.abort_exception = CommandException
-env['abort_exception'] = CommandException # env is just a dictionary with attribute access
+#env.abort_exception = CommandException # env is just a dictionary with attribute access
+
+# TODO: how to handle this ...
+# with initial_settings() ... ? we could explicitly go from an empty environment to default settings
+#env['abort_exception'] = CommandException
 
 NetworkError = fab_exceptions.NetworkError
 

--- a/src/buildercore/command.py
+++ b/src/buildercore/command.py
@@ -59,7 +59,8 @@ NetworkError = fab_exceptions.NetworkError
 # api
 #
 
-local = spy(fab_api.local)
+#local = spy(fab_api.local)
+local = spy(threadbare.operations.local)
 #execute = spy(fab_api.execute)
 execute = partial(spy(threadbare.execute.execute_with_hosts), env)
 

--- a/src/buildercore/command.py
+++ b/src/buildercore/command.py
@@ -13,7 +13,7 @@ from functools import partial
 THREADBARE = 'threadbare'
 FABRIC = 'fabric'
 
-DEFAULT_BACKEND = FABRIC
+DEFAULT_BACKEND = THREADBARE
 
 BACKEND = os.environ.get('BLDR_BACKEND', DEFAULT_BACKEND)
 assert BACKEND in [FABRIC, THREADBARE]

--- a/src/buildercore/command.py
+++ b/src/buildercore/command.py
@@ -39,7 +39,7 @@ if BACKEND == FABRIC:
     # no un-catchable errors from Fabric
     fab_api.env['abort_exception'] = CommandException
 else:
-    threadbare.state.set_defaults({"abort_exception": CommandException
+    threadbare.state.set_defaults({"abort_exception": CommandException,
                                    "key_filename": os.path.expanduser("~/.ssh/id_rsa")})
 
 NetworkError = fab_exceptions.NetworkError

--- a/src/buildercore/command.py
+++ b/src/buildercore/command.py
@@ -20,7 +20,7 @@ def api(fabric_fn, threadbare_fn):
     "accepts two functions and returns the one matching the currently set BACKEND"
     return fabric_fn if BACKEND == FABRIC else threadbare_fn
 
-def no_match(msg):
+def no_op(msg):
     "used in rare circumstances when either a function in Fabric or Threadbare doesn't have a corollary in the other"
     def fn(*args, **kwargs):
         return None
@@ -39,7 +39,8 @@ if BACKEND == FABRIC:
     # no un-catchable errors from Fabric
     fab_api.env['abort_exception'] = CommandException
 else:
-    threadbare.state.set_defaults({"abort_exception": CommandException})
+    threadbare.state.set_defaults({"abort_exception": CommandException
+                                   "key_filename": os.path.expanduser("~/.ssh/id_rsa")})
 
 NetworkError = fab_exceptions.NetworkError
 
@@ -47,28 +48,23 @@ NetworkError = fab_exceptions.NetworkError
 # api
 #
 
-def fab_api_local_remote_wrapper(fab_result):
+# local:
+# - https://github.com/mathiasertl/fabric/blob/master/fabric/operations.py#L1240-L1251
+# run/sudo:
+# - https://github.com/mathiasertl/fabric/blob/master/fabric/operations.py#L898-L971
+def fab_api_results_wrapper(fab_fn):
     """Fabric returns the stdout of the command when capture=True, with stderr and some values also available as attributes.
-    This modifies the behaviour of Fabric's `local` to return a dictionary of results."""
-    # local:
-    # - https://github.com/mathiasertl/fabric/blob/master/fabric/operations.py#L1240-L1251
-    # run/sudo:
-    # - https://github.com/mathiasertl/fabric/blob/master/fabric/operations.py#L898-L971
-    result = fab_result.__dict__
-    result['stdout'] = (fab_result or b"").splitlines()
-    result['stderr'] = (fab_result.stderr or b"").splitlines()
-    return result
+    This modifies the behaviour of Fabric's `local`, `run` and `sudo` commands to return a dictionary of results."""
+    def wrapper(*args, **kwargs):
+        fab_result = fab_fn(*args, **kwargs)
+        result = fab_result.__dict__
+        result['stdout'] = (fab_result or b"").splitlines()
+        result['stderr'] = (fab_result.stderr or b"").splitlines()
+        return result
+    return wrapper
 
-def fab_api_local_wrapper(*args, **kwargs):
-    return fab_api_local_remote_wrapper(fab_api.local(*args, **kwargs))
-
-def fab_api_run_wrapper(*args, **kwargs):
-    return fab_api_local_remote_wrapper(fab_api.run(*args, **kwargs))
-
-def fab_api_sudo_wrapper(*args, **kwargs):
-    return fab_api_local_remote_wrapper(fab_api.sudo(*args, **kwargs))
-
-# https://github.com/mathiasertl/fabric/blob/master/fabric/context_managers.py#L158-L241
+# settings:
+# - https://github.com/mathiasertl/fabric/blob/master/fabric/context_managers.py#L158-L241
 def fab_api_settings_wrapper(*args, **kwargs):
     "a context manager that alters mutable application state for functions called within it's scope"
 
@@ -84,7 +80,7 @@ def fab_api_settings_wrapper(*args, **kwargs):
 
 env = api(fab_api.env, threadbare.state.ENV)
 
-local = api(fab_api_local_wrapper, threadbare.operations.local)
+local = api(fab_api_results_wrapper(fab_api.local), threadbare.operations.local)
 execute = api(fab_api.execute, threadbare.execute.execute_with_hosts)
 parallel = api(fab_api.parallel, threadbare.execute.parallel)
 serial = api(fab_api.serial, threadbare.execute.serial)
@@ -96,14 +92,14 @@ settings = api(fab_api_settings_wrapper, threadbare.state.settings)
 lcd = api(fab_api.lcd, threadbare.operations.lcd) # local change dir
 rcd = api(fab_api.cd, threadbare.operations.rcd) # remote change dir
 
-remote = api(fab_api_run_wrapper, threadbare.operations.remote)
-remote_sudo = api(fab_api_sudo_wrapper, threadbare.operations.remote_sudo)
+remote = api(fab_api_results_wrapper(fab_api.run), threadbare.operations.remote)
+remote_sudo = api(fab_api_results_wrapper(fab_api.sudo), threadbare.operations.remote_sudo)
 upload = api(fab_api.put, threadbare.operations.upload)
 download = api(fab_api.get, threadbare.operations.download)
 remote_file_exists = api(fab_files.exists, threadbare.operations.remote_file_exists)
 
 network_disconnect_all = api(fabric.network.disconnect_all,
-                             no_match("threadbare automatically closes ssh closes connections"))
+                             no_op("threadbare automatically closes ssh closes connections"))
 
 #
 # deprecated api

--- a/src/buildercore/command.py
+++ b/src/buildercore/command.py
@@ -143,10 +143,11 @@ def remote_listfiles(path=None, use_sudo=False):
     with fab_api.hide('output'):
         runfn = remote_sudo if use_sudo else remote
         path = "%s/*" % path.rstrip("/")
-        stdout = runfn("for i in %s; do echo $i; done" % path)
-        if stdout == path: # some kind of bash artifact where it returns `/path/*` when no matches
+        result = runfn("for i in %s; do echo $i; done" % path)
+        stdout = result['stdout']
+        if stdout and stdout[0] == path: # some kind of bash artifact where it returns `/path/*` when no matches
             return []
-        return stdout.splitlines()
+        return stdout
 
 def fab_get(remote_path, local_path=None, use_sudo=False, label=None, return_stream=False):
     "wrapper around fabric.operations.get"

--- a/src/buildercore/command.py
+++ b/src/buildercore/command.py
@@ -43,7 +43,7 @@ def spy(fn):
         print(lst)
         COMMAND_LOG.append(lst)
         with open('/tmp/command-log.jsonl', 'a') as fh:
-            msg = utils.json_dumps({"ts": timestamp, "fn": funcname, "args":args, "kwargs":kwargs, 'env': envdiff()}, dangerous=True)
+            msg = utils.json_dumps({"ts": timestamp, "fn": funcname, "args": args, "kwargs": kwargs, 'env': envdiff()}, dangerous=True)
             fh.write(msg + "\n")
         result = fn(*args, **kwargs)
         return result
@@ -66,7 +66,7 @@ class CommandException(Exception):
     pass
 
 # no un-catchable errors from Fabric
-#env.abort_exception = CommandException # env is just a dictionary with attribute access
+# env.abort_exception = CommandException # env is just a dictionary with attribute access
 
 # TODO: how to handle this ...
 # with initial_settings() ... ? we could explicitly go from an empty environment to default settings
@@ -109,7 +109,7 @@ upload = api(fab_api.put, threadbare.operations.upload)
 download = api(fab_api.get, threadbare.operations.download)
 remote_file_exists = api(fab_files.exists, threadbare.operations.remote_file_exists)
 
-network_disconnect_all = api(fabric.network.disconnect_all, \
+network_disconnect_all = api(fabric.network.disconnect_all,
                              no_match("threadbare automatically closes ssh closes connections"))
 
 #

--- a/src/buildercore/command.py
+++ b/src/buildercore/command.py
@@ -94,7 +94,8 @@ remote = spy(threadbare.operations.remote)
 remote_sudo = spy(threadbare.operations.remote_sudo)
 upload = spy(fab_api.put)
 download = spy(fab_api.get)
-remote_file_exists = spy(fab_files.exists)
+#remote_file_exists = spy(fab_files.exists)
+remote_file_exists = spy(threadbare.operations.remote_file_exists)
 network_disconnect_all = spy(fabric.network.disconnect_all)
 
 #

--- a/src/buildercore/config.py
+++ b/src/buildercore/config.py
@@ -119,7 +119,7 @@ CLOUD_EXCLUDING_DEFAULTS_IF_NOT_PRESENT = ['rds', 'ext', 'elb', 'cloudfront', 'e
 # believe it or not but buildercore.config is NOT the place for user config
 #
 
-PROJECTS_FILES = ['projects/elife.yaml']
+PROJECTS_FILES = ['projects/elife.yaml']  # , 'src/tests/fixtures/projects/']
 
 USER_PRIVATE_KEY = os.environ.get('CUSTOM_SSH_KEY', '~/.ssh/id_rsa')
 

--- a/src/buildercore/core.py
+++ b/src/buildercore/core.py
@@ -11,7 +11,7 @@ from .utils import ensure, first, lookup, lmap, lfilter, unique, isstr
 import boto3
 import botocore
 from contextlib import contextmanager
-from .command import settings, execute, parallel, serial, env, CommandException, NetworkError
+from .command import settings, execute, parallel, serial, env, CommandException, NetworkError, spy
 from slugify import slugify
 import logging
 from kids.cache import cache as cached
@@ -247,6 +247,8 @@ def _ec2_connection_params(stackname, username, **kwargs):
     # http://docs.fabfile.org/en/1.14/usage/env.html
     params = {'user': username}
     pem = stack_pem(stackname)
+    # todo: handle other non-rsa private keys
+    params['key_filename'] = os.path.expanduser("~/.ssh/id_rsa")
     # handles cases where we want to establish a connection to run a task
     # when machine has failed to provision correctly.
     if username == config.BOOTSTRAP_USER:

--- a/src/buildercore/core.py
+++ b/src/buildercore/core.py
@@ -11,7 +11,7 @@ from .utils import ensure, first, lookup, lmap, lfilter, unique, isstr
 import boto3
 import botocore
 from contextlib import contextmanager
-from .command import settings, execute, parallel, serial, env, CommandException, NetworkError, spy
+from .command import settings, execute, parallel, serial, env, CommandException, NetworkError
 from slugify import slugify
 import logging
 from kids.cache import cache as cached

--- a/src/buildercore/core.py
+++ b/src/buildercore/core.py
@@ -243,7 +243,7 @@ def stack_pem(stackname, die_if_exists=False, die_if_doesnt_exist=False):
     return expected_key
 
 def _ec2_connection_params(stackname, username, **kwargs):
-    "returns a dictionary of settings to be used with Fabric's api.settings context manager"
+    "returns a dictionary of settings to be used with `command.settings` context manager"
     # http://docs.fabfile.org/en/1.14/usage/env.html
     params = {'user': username}
     pem = stack_pem(stackname)
@@ -292,7 +292,7 @@ def all_node_params(stackname):
     # TODO: default copied from stack_all_ec2_nodes, but not the most robust probably
     params = _ec2_connection_params(stackname, config.DEPLOY_USER)
 
-    # custom for builder, these are available as fabric.api.env.public_ips inside workfn
+    # custom for builder, these are available inside workfn as `command.env['public_ips']`
     params.update({
         'stackname': stackname,
         'public_ips': public_ips,
@@ -322,7 +322,7 @@ def stack_all_ec2_nodes(stackname, workfn, username=config.DEPLOY_USER, concurre
     params = _ec2_connection_params(stackname, username)
     params.update(kwargs)
 
-    # custom for builder, these are available as fabric.api.env.public_ips inside workfn
+    # custom for builder, these are available inside workfn as `command.env['public_ips']`
     params.update({
         'stackname': stackname,
         'public_ips': public_ips,
@@ -394,11 +394,11 @@ def current_ec2_node_id():
 
     Sample value: 'i-0553487b4b6916bc9'"""
 
-    ensure(env.host is not None, "This is supposed to be called with settings for connecting to an EC2 instance")
-    current_public_ip = env.host
+    ensure(env['host'] is not None, "This is supposed to be called with settings for connecting to an EC2 instance")
+    current_public_ip = env['host']
 
     ensure('public_ips' in env, "This is supposed to be called by stack_all_ec2_nodes, which provides the correct configuration")
-    matching_instance_ids = [instance_id for (instance_id, public_ip) in env.public_ips.items() if current_public_ip == public_ip]
+    matching_instance_ids = [instance_id for (instance_id, public_ip) in env['public_ips'].items() if current_public_ip == public_ip]
 
     ensure(len(matching_instance_ids) == 1, "Too many instance ids (%s) pointing to this ip (%s)" % (matching_instance_ids, current_public_ip))
     return matching_instance_ids[0]
@@ -408,20 +408,20 @@ def current_node_id():
 
     Returns a number from 1 to N (usually a small number, like 2) indicating how the current node has been numbered on creation to distinguish it from the others"""
     ec2_id = current_ec2_node_id()
-    ensure(ec2_id in env.nodes, "Can't find %s in %s node map" % (ec2_id, env.nodes))
-    return env.nodes[ec2_id]
+    ensure(ec2_id in env['nodes'], "Can't find %s in %s node map" % (ec2_id, env['nodes']))
+    return env['nodes'][ec2_id]
 
 def current_ip():
     """Assumes it is called inside the 'workfn' of a 'stack_all_ec2_nodes'.
 
     Returns the ip address used to access the current host, e.g. '54.243.19.153'"""
-    return env.host
+    return env['host']
 
 def current_stackname():
     """Assumes it is called inside the 'workfn' of a 'stack_all_ec2_nodes'.
 
     Returns the name of the stack the task is working on, e.g. 'journal--end2end'"""
-    return env.stackname
+    return env['stackname']
 
 #
 # stackname wrangling

--- a/src/buildercore/core.py
+++ b/src/buildercore/core.py
@@ -394,8 +394,8 @@ def current_ec2_node_id():
 
     Sample value: 'i-0553487b4b6916bc9'"""
 
-    ensure(env['host'] is not None, "This is supposed to be called with settings for connecting to an EC2 instance")
-    current_public_ip = env['host']
+    ensure(env['host_string'] is not None, "This is supposed to be called with settings for connecting to an EC2 instance")
+    current_public_ip = env['host_string']
 
     ensure('public_ips' in env, "This is supposed to be called by stack_all_ec2_nodes, which provides the correct configuration")
     matching_instance_ids = [instance_id for (instance_id, public_ip) in env['public_ips'].items() if current_public_ip == public_ip]
@@ -415,7 +415,7 @@ def current_ip():
     """Assumes it is called inside the 'workfn' of a 'stack_all_ec2_nodes'.
 
     Returns the ip address used to access the current host, e.g. '54.243.19.153'"""
-    return env['host']
+    return env['host_string']
 
 def current_stackname():
     """Assumes it is called inside the 'workfn' of a 'stack_all_ec2_nodes'.

--- a/src/buildercore/core.py
+++ b/src/buildercore/core.py
@@ -247,8 +247,6 @@ def _ec2_connection_params(stackname, username, **kwargs):
     # http://docs.fabfile.org/en/1.14/usage/env.html
     params = {'user': username}
     pem = stack_pem(stackname)
-    # todo: handle other non-rsa private keys
-    params['key_filename'] = os.path.expanduser("~/.ssh/id_rsa")
     # handles cases where we want to establish a connection to run a task
     # when machine has failed to provision correctly.
     if username == config.BOOTSTRAP_USER:

--- a/src/buildercore/threadbare/__init__.py
+++ b/src/buildercore/threadbare/__init__.py
@@ -1,6 +1,6 @@
 # gevent is used by parallel-ssh which interferes with Python multiprocessing and futures
 # it can cause indefinite blocking.
-# this bit of magic appears to make everything work nicely with each
+# this bit of magic appears to make everything work nicely with each other.
 # - http://www.gevent.org/api/gevent.monkey.html
 from gevent import monkey
 

--- a/src/buildercore/threadbare/__init__.py
+++ b/src/buildercore/threadbare/__init__.py
@@ -7,4 +7,5 @@ from gevent import monkey
 monkey.patch_all()
 
 from . import state, operations, execute
-assert state and operations and execute # quieten pyflakes
+
+assert state and operations and execute  # quieten pyflakes

--- a/src/buildercore/threadbare/__init__.py
+++ b/src/buildercore/threadbare/__init__.py
@@ -7,4 +7,4 @@ from gevent import monkey
 monkey.patch_all()
 
 from . import state, operations, execute
-assert state and operations and execute
+assert state and operations and execute # quieten pyflakes

--- a/src/buildercore/threadbare/__init__.py
+++ b/src/buildercore/threadbare/__init__.py
@@ -6,6 +6,14 @@ from gevent import monkey
 
 monkey.patch_all()
 
+
 from . import state, operations, execute
 
 assert state and operations and execute  # quieten pyflakes
+
+import logging
+
+disable_these_handlers = ["pssh.host_logger", "pssh.clients.native.single"]
+for unwanted_logger in disable_these_handlers:
+    logger = logging.getLogger(unwanted_logger)
+    logger.setLevel(logging.CRITICAL)

--- a/src/buildercore/threadbare/__init__.py
+++ b/src/buildercore/threadbare/__init__.py
@@ -5,3 +5,6 @@
 from gevent import monkey
 
 monkey.patch_all()
+
+from . import state, operations, execute
+assert state and operations and execute

--- a/src/buildercore/threadbare/__init__.py
+++ b/src/buildercore/threadbare/__init__.py
@@ -1,0 +1,7 @@
+# gevent is used by parallel-ssh which interferes with Python multiprocessing and futures
+# it can cause indefinite blocking.
+# this bit of magic appears to make everything work nicely with each
+# - http://www.gevent.org/api/gevent.monkey.html
+from gevent import monkey
+
+monkey.patch_all()

--- a/src/buildercore/threadbare/common.py
+++ b/src/buildercore/threadbare/common.py
@@ -104,3 +104,11 @@ def pwd_wrap_command(command, working_dir):
     prefix = 'cd "%s" &&' % working_dir
     space = " "
     return prefix + space + command
+
+
+def isint(x):
+    try:
+        int(x)
+        return True
+    except:
+        return False

--- a/src/buildercore/threadbare/common.py
+++ b/src/buildercore/threadbare/common.py
@@ -1,3 +1,4 @@
+import six
 import os
 from functools import reduce
 
@@ -8,8 +9,11 @@ class PromptedException(BaseException):
 
 def has_type(x, t, msg=None):
     "raises TypeError if given `x` is not of type `t`"
+    msg = msg or "%r is not of expected type %r" % (x, t)
+    if t == str and not isinstance(x, six.string_types):
+        raise TypeError(msg)
+
     if not isinstance(x, t):
-        msg = msg or "%r is not of expected type %r" % (x, t)
         raise TypeError(msg)
 
 

--- a/src/buildercore/threadbare/common.py
+++ b/src/buildercore/threadbare/common.py
@@ -110,5 +110,5 @@ def isint(x):
     try:
         int(x)
         return True
-    except:
+    except BaseException:
         return False

--- a/src/buildercore/threadbare/common.py
+++ b/src/buildercore/threadbare/common.py
@@ -2,6 +2,10 @@ import os
 from functools import reduce
 
 
+class PromptedException(BaseException):
+    pass
+
+
 def first(x):
     "returns the first element in an collection of things"
     if x is None:

--- a/src/buildercore/threadbare/common.py
+++ b/src/buildercore/threadbare/common.py
@@ -1,5 +1,4 @@
-import six
-import os
+import os, sys
 from functools import reduce
 
 
@@ -9,8 +8,16 @@ class PromptedException(BaseException):
 
 def has_type(x, t, msg=None):
     "raises TypeError if given `x` is not of type `t`"
+
+    PY2 = sys.version_info[0] == 2
+
+    if PY2:
+        string_types = basestring
+    else:
+        string_types = str
+
     msg = msg or "%r is not of expected type %r" % (x, t)
-    if t == str and not isinstance(x, six.string_types):
+    if t == str and not isinstance(x, string_types):
         raise TypeError(msg)
 
     if not isinstance(x, t):

--- a/src/buildercore/threadbare/common.py
+++ b/src/buildercore/threadbare/common.py
@@ -1,0 +1,102 @@
+import os
+from functools import reduce
+
+
+def first(x):
+    "returns the first element in an collection of things"
+    if x is None:
+        return x
+    try:
+        if isinstance(x, dict):
+            return list(x.items())[0]
+        return x[0]
+    except (ValueError, IndexError):
+        return None
+
+
+def merge(*dict_list):
+    "non-destructively merges a series of dictionaries from left to right, returning a new dictionary"
+
+    def reduce_fn(d1, d2=None):
+        d3 = {}
+        d3.update(d1)
+        d3.update(d2 or {})
+        return d3
+
+    return reduce(reduce_fn, dict_list)
+
+
+def subdict(d, key_list):
+    "returns a subset of the given dictionary `d` for keys in `key_list`"
+    key_list = key_list or []
+    return {key: d[key] for key in key_list if key in d}
+
+
+def rename(d, pair_list):
+    "mutator. given a dictionary `d` and a list of (old-name, new-name) pairs, renames old-name to new-name, if it exists"
+    for old, new in pair_list:
+        if old in d:
+            d[new] = d[old]
+            del d[old]
+
+
+def cwd():
+    "returns the resolved path to the Current Working Dir (cwd)"
+    return os.path.realpath(os.curdir)
+
+
+# utils
+
+# direct copy from Fabric:
+# https://github.com/mathiasertl/fabric/blob/master/fabric/operations.py#L33-L46
+# TODO: adjust licence accordingly
+def _shell_escape(string):
+    """
+    Escape double quotes, backticks and dollar signs in given ``string``.
+    For example::
+        >>> _shell_escape('abc$')
+        'abc\\\\$'
+        >>> _shell_escape('"')
+        '\\\\"'
+    """
+    for char in ('"', "$", "`"):
+        string = string.replace(char, r"\%s" % char)
+    return string
+
+
+# https://github.com/mathiasertl/fabric/blob/master/fabric/state.py#L253-L256
+def shell_wrap_command(command):
+    """wraps the given command in a shell invocation.
+    default shell is /bin/bash (like Fabric)
+    no support for configurable shell at present"""
+
+    # '-l' is 'login' shell
+    # '-c' is 'run command'
+    shell_prefix = "/bin/bash -l -c"
+
+    escaped_command = _shell_escape(command)
+    escaped_wrapped_command = '"%s"' % escaped_command
+
+    space = " "
+    final_command = shell_prefix + space + escaped_wrapped_command
+
+    return final_command
+
+
+def sudo_wrap_command(command):
+    """adds a 'sudo' prefix to command to run as root.
+    no support for sudo'ing to configurable users/groups"""
+    # https://github.com/mathiasertl/fabric/blob/master/fabric/operations.py#L605-L623
+    # https://github.com/mathiasertl/fabric/blob/master/fabric/state.py#L374-L376
+    # note: differs from Fabric. they support interactive input of password, users and groups
+    # we use it exclusively to run commands as root
+    sudo_prefix = "sudo --non-interactive"
+    space = " "
+    return sudo_prefix + space + command
+
+
+def pwd_wrap_command(command, working_dir):
+    "adds a 'cd' prefix to command"
+    prefix = 'cd "%s" &&' % working_dir
+    space = " "
+    return prefix + space + command

--- a/src/buildercore/threadbare/execute.py
+++ b/src/buildercore/threadbare/execute.py
@@ -193,7 +193,8 @@ def execute(env, func, param_key=None, param_values=None):
 
 
 def execute_with_hosts(env, func, hosts=None):
-    "convenience wrapper around `execute` to match. calls `execute` on given `func` but uses `all_hosts`  "
+    """convenience wrapper around `execute`. calls `execute` on given `func` for each host in `hosts`.
+    The host is available within the worker function's `env` as `host_string`."""
     host_list = hosts or env.get("hosts") or []
     assert isinstance(host_list, list), "hosts must be a list"
     # Fabric may know about many hosts ('all_hosts') but only be acting upon a subset of them ('hosts')
@@ -206,4 +207,5 @@ def execute_with_hosts(env, func, hosts=None):
     # it says 'for informational purposes only' and nothing we use depends on it, so I'm disabling for now
     # env['all_hosts'] = env['hosts']
     results = execute(env, func, param_key="host_string", param_values=host_list)
-    return dict(zip(host_list, results)) # {'192.168.0.1': [], '192.169.0.3': []}
+    # results are ordered so we can do this
+    return dict(zip(host_list, results))  # {'192.168.0.1': [], '192.169.0.3': []}

--- a/src/buildercore/threadbare/execute.py
+++ b/src/buildercore/threadbare/execute.py
@@ -5,6 +5,7 @@ from .common import first
 from . import state
 
 
+# https://github.com/mathiasertl/fabric/blob/master/fabric/decorators.py#L148-L161
 def serial(func, pool_size=None):
     """Forces the given function to run `pool_size` times.
     when pool_size is None (default), executor decides how many instances of `func` to execute (1, probably).
@@ -17,10 +18,9 @@ def serial(func, pool_size=None):
     return inner
 
 
+# https://github.com/mathiasertl/fabric/blob/master/fabric/decorators.py#L164-L194
 def parallel(func, pool_size=None):
-    """Forces the wrapped function to run in parallel, instead of sequentially.
-    This is an opportunity for pre/post process work prior to calling a function in parallel."""
-    # https://github.com/mathiasertl/fabric/blob/master/fabric/decorators.py#L164-L194
+    """Forces the wrapped function to run in parallel, instead of sequentially."""
     wrapped_func = serial(func, pool_size)
     # `func` *must* be forced to run in parallel to main process
     wrapped_func.parallel = True
@@ -151,7 +151,6 @@ def _serial_execution(func, param_key, param_values):
     result_list = []
     if param_key and param_values:
         for x in param_values:
-            # TODO: this prevent ssh clients from being shared
             with state.settings(**{param_key: x}):
                 result_list.append(func())
     else:
@@ -177,12 +176,12 @@ def execute(func, param_key=None, param_values=None):
     parent process blocks until all child processes have completed.
     returns a map of execution data with the return values of the individual executions available under 'result'"""
 
-    # in Fabric, `execute` is a guard-type function that ensures the function and the function's environment is correct
-    # before passing it to `_execute` that does the actual magic.
+    # in Fabric, `execute` is a guard-type function that ensures the function and the function's environment is
+    # correct before passing it to `_execute` that does the actual magic.
     # `execute`: https://github.com/mathiasertl/fabric/blob/master/fabric/tasks.py#L372-L401
     # `_execute`: https://github.com/mathiasertl/fabric/blob/master/fabric/tasks.py#L213-L277
 
-    # the custom 'JobQueue' adds complexity but can be avoided (I hope):
+    # Fabric's custom 'JobQueue' adds complexity but can be avoided:
     # https://github.com/mathiasertl/fabric/blob/master/fabric/job_queue.py
 
     if (param_key and param_values is None) or (param_key is None and param_values):

--- a/src/buildercore/threadbare/execute.py
+++ b/src/buildercore/threadbare/execute.py
@@ -28,7 +28,7 @@ def parallel(func, pool_size=None):
 
 
 def _parallel_execution_worker_wrapper(env, worker_func, name, queue):
-    """this function is executed in another process. it wraps the given `worker_func`, initialising the `state.ENV` of 
+    """this function is executed in another process. it wraps the given `worker_func`, initialising the `state.ENV` of
     the new process and adds its results to the given `queue`"""
     try:
         assert isinstance(env, dict), "given environment must be a dictionary"

--- a/src/buildercore/threadbare/execute.py
+++ b/src/buildercore/threadbare/execute.py
@@ -1,0 +1,208 @@
+import copy
+from multiprocessing import Process, Queue
+import time
+from .common import first
+from . import state
+
+
+def serial(func, pool_size=None):
+    """Forces the given function to run `pool_size` times.
+    when pool_size is None (default), executor decides how many instances of `func` to execute (1, probably).
+    if set and executor is given a set of values to use instead, `pool_size` is ignored"""
+
+    def inner(*args, **kwargs):
+        return func(*args, **kwargs)
+
+    inner.pool_size = pool_size
+    return inner
+
+
+def parallel(func, pool_size=None):
+    """Forces the wrapped function to run in parallel, instead of sequentially.
+    This is an opportunity for pre/post process work prior to calling a function in parallel."""
+    # https://github.com/mathiasertl/fabric/blob/master/fabric/decorators.py#L164-L194
+    wrapped_func = serial(func, pool_size)
+    # `func` *must* be forced to run in parallel to main process
+    wrapped_func.parallel = True
+    return wrapped_func
+
+
+def _parallel_execution_worker_wrapper(env, worker_func, name, queue):
+    try:
+        # Fabric is nuking the child process's env dictionary
+        # https://github.com/mathiasertl/fabric/blob/master/fabric/tasks.py#L229-L237
+
+        # what we can do is say that worker functions executed in parallel must use the
+        # implicit `settings() as env` invocation rather than `settings(env)` as we have
+        # no reference to `env` unless the worker function accepts it as a parameter.
+        # and we can't rely on that.
+        state.ENV = state.init_state()
+        state.read_write(state.ENV)
+        state.ENV.update(env or {})
+        result = worker_func()
+        queue.put({"name": name, "result": result})
+    except BaseException as unhandled_exception:
+        # "Note that exit handlers and finally clauses, etc., will not be executed."
+        # - https://docs.python.org/2/library/multiprocessing.html#multiprocessing.Process.terminate
+        queue.put({"name": name, "result": unhandled_exception})
+
+
+def process_status(running_p):
+    # https://docs.python.org/2/library/multiprocessing.html#process-and-exceptions
+    result = {
+        "pid": running_p.pid,
+        "name": running_p.name,
+        "exitcode": running_p.exitcode,
+        "alive": running_p.is_alive(),
+        "killed": False,
+        "kill-signal": None,
+    }
+    if running_p.exitcode is not None and running_p.exitcode < 0:
+        result["killed"] = True
+        result["kill-signal"] = -running_p.exitcode
+    return result
+
+
+def _parallel_execution(env, func, param_key, param_values, return_process_pool=False):
+    "executes the given function in parallel to main process. blocks until processes are complete"
+    results_q = Queue()
+    kwargs = {
+        #'env': ..., # each process will get a new state dictionary
+        "worker_func": func,
+        #'name': ..., # a name is assigned on process start
+        "queue": results_q,
+    }
+    pool_size = getattr(func, "pool_size", None)
+    pool_size = pool_size if pool_size is not None else 1
+    pool_values = param_values or range(0, pool_size)
+
+    pool = []
+    for idx, nth_val in enumerate(pool_values):
+        kwargs["name"] = "process--" + str(idx + 1)  # process--1, process--2
+        new_env = {} if not env else copy.deepcopy(env)
+
+        # ssh clients are not shared between processes
+        if "ssh_client" in new_env:
+            del new_env["ssh_client"]
+
+        new_env[param_key] = nth_val
+        new_env["parallel"] = True
+        # https://github.com/mathiasertl/fabric/blob/master/fabric/tasks.py#L223-L227
+        # new_env['linewise'] = True # not set until needed
+
+        kwargs["env"] = new_env
+        p = Process(
+            name=kwargs["name"],
+            target=_parallel_execution_worker_wrapper,
+            kwargs=kwargs,
+        )
+        p.start()
+        pool.append(p)
+
+    if return_process_pool:
+        # don't poll for results, don't wait to finish, just return the list of running processes
+        return results_q, pool
+
+    result_map = {}  # {process-name: process-results, ...}
+
+    # poll the processes until all are complete
+    # remove process from pool when it is complete
+    while len(pool) > 0:
+        for idx, running_p in enumerate(pool):
+            result = process_status(running_p)
+            if not result["alive"]:
+                result_map[result["name"]] = result
+                del pool[idx]
+        time.sleep(0.1)
+
+    # all processes are complete
+    # empty the queue and marry the results to their process results using their 'name'
+
+    while not results_q.empty():
+        job_result = results_q.get()
+        job_name = job_result["name"]
+        result_map[job_name]["result"] = job_result["result"]
+
+    results_q.close()
+
+    # sort the results, drop the process name
+    return [b for a, b in sorted(result_map.items(), key=first)]
+
+
+def _serial_execution(env, func, param_key, param_values):
+    "executes the given function serially"
+    result_list = []
+    if param_key and param_values:
+        for x in param_values:
+            # TODO: this prevent ssh clients from being shared
+            with state.settings(env, **{param_key: x}):
+                result_list.append(func())
+    else:
+        # pretty boring :(
+        # I could set '_idx' or something in `env` I suppose ..
+        for _ in range(0, getattr(func, "pool_size", 1)):
+            # TODO: this prevent ssh clients from being shared
+            with state.settings(env):
+                result_list.append(func())
+    return result_list
+
+
+def execute(env, func, param_key=None, param_values=None):
+    """inspects a given function and then executes it either serially or in another process using Python's `multiprocessing` module.
+    `param` and `param_list` control the number of processes spawned and the name of the parameter passed to the function.
+
+    For example:
+
+        execute({}, somefunc, param_key='host', param_values=['127.0.0.1', '127.0.1.1', 'localhost'])
+
+    will ensure that `somefunc` has the (local) state property 'host' with a value of one of the above when executed.
+
+    `param` and `param_list` are optional, but if one is specified then so must the other.
+
+    parent process blocks until all child processes have completed.
+    returns a map of execution data with the return values of the individual executions available under 'result'"""
+
+    # in Fabric, `execute` is a guard-type function that ensures the function and the function's environment is correct
+    # before passing it to `_execute` that does the actual magic.
+    # `execute`: https://github.com/mathiasertl/fabric/blob/master/fabric/tasks.py#L372-L401
+    # `_execute`: https://github.com/mathiasertl/fabric/blob/master/fabric/tasks.py#L213-L277
+
+    # the custom 'JobQueue' adds complexity but can be avoided (I hope):
+    # https://github.com/mathiasertl/fabric/blob/master/fabric/job_queue.py
+
+    if (param_key and param_values is None) or (param_key is None and param_values):
+        raise ValueError(
+            "either a `param_key` AND `param_values` are provided OR neither are provided"
+        )
+
+    if param_values is not None and type(param_values) not in [list, tuple, set]:
+        raise ValueError(
+            "given value for `param_values` must be an iterable type, not %r"
+            % type(param_values)
+        )
+
+    if param_key is not None and not isinstance(param_key, str):
+        raise ValueError(
+            "given value for `param_key` must be a valid function parameter key"
+        )
+
+    if hasattr(func, "parallel") and func.parallel:
+        result_list = _parallel_execution(env, func, param_key, param_values)
+        return [result["result"] for result in result_list]
+    return _serial_execution(env, func, param_key, param_values)
+
+
+def execute_with_hosts(env, func, hosts=None):
+    "convenience wrapper around `execute`. calls `execute` on given `func` but uses `all_hosts`  "
+    with state.settings(env):
+        host_list = hosts or env.get("hosts") or []
+        # Fabric may know about many hosts ('all_hosts') but only be acting upon a subset of them ('hosts')
+        # - https://github.com/mathiasertl/fabric/blob/master/sites/docs/usage/env.rst#all_hosts
+        # set here:
+        # - https://github.com/mathiasertl/fabric/blob/master/fabric/tasks.py#L352
+        # in elife/builder we use a map of host information:
+        # - https://github.com/elifesciences/builder/blob/master/src/buildercore/core.py#L326-L327
+        # - https://github.com/elifesciences/builder/blob/master/src/buildercore/core.py#L386
+        # it says 'for informational purposes only' and nothing we use depends on it, so I'm disabling for now
+        # env['all_hosts'] = env['hosts']
+        return execute(env, func, param_key="host_string", param_values=host_list)

--- a/src/buildercore/threadbare/execute.py
+++ b/src/buildercore/threadbare/execute.py
@@ -193,16 +193,17 @@ def execute(env, func, param_key=None, param_values=None):
 
 
 def execute_with_hosts(env, func, hosts=None):
-    "convenience wrapper around `execute`. calls `execute` on given `func` but uses `all_hosts`  "
-    with state.settings(env):
-        host_list = hosts or env.get("hosts") or []
-        # Fabric may know about many hosts ('all_hosts') but only be acting upon a subset of them ('hosts')
-        # - https://github.com/mathiasertl/fabric/blob/master/sites/docs/usage/env.rst#all_hosts
-        # set here:
-        # - https://github.com/mathiasertl/fabric/blob/master/fabric/tasks.py#L352
-        # in elife/builder we use a map of host information:
-        # - https://github.com/elifesciences/builder/blob/master/src/buildercore/core.py#L326-L327
-        # - https://github.com/elifesciences/builder/blob/master/src/buildercore/core.py#L386
-        # it says 'for informational purposes only' and nothing we use depends on it, so I'm disabling for now
-        # env['all_hosts'] = env['hosts']
-        return execute(env, func, param_key="host_string", param_values=host_list)
+    "convenience wrapper around `execute` to match. calls `execute` on given `func` but uses `all_hosts`  "
+    host_list = hosts or env.get("hosts") or []
+    assert isinstance(host_list, list), "hosts must be a list"
+    # Fabric may know about many hosts ('all_hosts') but only be acting upon a subset of them ('hosts')
+    # - https://github.com/mathiasertl/fabric/blob/master/sites/docs/usage/env.rst#all_hosts
+    # set here:
+    # - https://github.com/mathiasertl/fabric/blob/master/fabric/tasks.py#L352
+    # in elife/builder we use a map of host information:
+    # - https://github.com/elifesciences/builder/blob/master/src/buildercore/core.py#L326-L327
+    # - https://github.com/elifesciences/builder/blob/master/src/buildercore/core.py#L386
+    # it says 'for informational purposes only' and nothing we use depends on it, so I'm disabling for now
+    # env['all_hosts'] = env['hosts']
+    results = execute(env, func, param_key="host_string", param_values=host_list)
+    return dict(zip(host_list, results)) # {'192.168.0.1': [], '192.169.0.3': []}

--- a/src/buildercore/threadbare/operations.py
+++ b/src/buildercore/threadbare/operations.py
@@ -1,0 +1,517 @@
+import tempfile
+import contextlib
+import subprocess
+from threading import Timer
+import getpass
+from pssh import exceptions as pssh_exceptions
+import os, sys
+from . import state
+from .common import (
+    merge,
+    subdict,
+    rename,
+    cwd,
+    sudo_wrap_command,
+    pwd_wrap_command,
+    shell_wrap_command,
+)
+from pssh.clients.native import SSHClient as PSSHClient
+
+
+class SSHClient(PSSHClient):
+    def __deepcopy__(self, memo):
+        # do not copy.deepcopy ourselves or the pssh SSHClient object, just
+        # return a reference to the object (self)
+        # - https://docs.python.org/3/library/copy.html
+        return self
+
+
+class NetworkError(BaseException):
+    """generic 'died while doing something ssh-related' catch-all exception class.
+    calling str() on this exception will return the results on calling str() on the
+    wrapped exception."""
+
+    def __init__(self, wrapped_exception_inst):
+        self.wrapped = wrapped_exception_inst
+
+    def __str__(self):
+        # we have the opportunity here to tweak the error messages to make them
+        # similar with their equivalents in Fabric.
+        # original error messages are still available via `str(exinst.wrapped)`
+        space = " "
+        custom_error_prefixes = {
+            # builder: https://github.com/elifesciences/builder/blob/master/src/buildercore/core.py#L345-L347
+            # pssh: https://github.com/ParallelSSH/parallel-ssh/blob/8b7bb4bcb94d913c3b7da77db592f84486c53b90/pssh/clients/native/parallel.py#L272-L274
+            pssh_exceptions.Timeout: "Timed out trying to connect.",
+            # builder: https://github.com/elifesciences/builder/blob/master/src/buildercore/core.py#L348-L350
+            # fabric: https://github.com/mathiasertl/fabric/blob/master/fabric/network.py#L601-L605
+            # pssh: https://github.com/ParallelSSH/parallel-ssh/blob/2e9668cf4b58b38316b1d515810d7e6c595c76f3/pssh/exceptions.py
+            pssh_exceptions.SSHException: "Low level socket error connecting to host.",
+            pssh_exceptions.SessionError: "Low level socket error connecting to host.",
+            pssh_exceptions.ConnectionErrorException: "Low level socket error connecting to host.",
+        }
+        new_error = custom_error_prefixes.get(type(self.wrapped)) or ""
+        original_error = str(self.wrapped)
+        return new_error + space + original_error
+
+
+def handle(base_kwargs, kwargs):
+    key_list = base_kwargs.keys()
+    global_kwargs = subdict(state.ENV, key_list)
+    user_kwargs = subdict(kwargs, key_list)
+    final_kwargs = merge(base_kwargs, global_kwargs, user_kwargs)
+    return global_kwargs, user_kwargs, final_kwargs
+
+
+# api
+
+
+@contextlib.contextmanager
+def lcd(local_dir):
+    "temporarily changes the local working directory"
+    assert os.path.isdir(local_dir), "not a directory: %s" % local_dir
+    with state.settings():
+        current_dir = cwd()
+        state.add_cleanup(lambda: os.chdir(current_dir))
+        os.chdir(local_dir)
+        yield
+
+
+@contextlib.contextmanager
+def rcd(remote_working_dir):
+    "ensures all commands run are done from the given remote directory. if remote directory doesn't exist, command will not be run"
+    # TODO: this will cause a new ssh connection to be created
+    with state.settings(remote_working_dir=remote_working_dir):
+        yield
+
+
+@contextlib.contextmanager
+def hide(what=None):
+    "hides *all* output, regardless of `what` type of output is to be hidden."
+    # TODO: this will cause a new ssh connection to be created
+    with state.settings(quiet=True):
+        yield
+
+
+def _ssh_client(**kwargs):
+    """returns an instance of pssh.clients.native.SSHClient
+    if within a state context, looks for a client already in use and returns that if found.
+    if not found, creates a new one and stores it for later use."""
+
+    # parameters we're interested in and their default values
+    base_kwargs = {
+        # current user. sensible default but probably not what you want
+        "user": getpass.getuser(),
+        "host_string": None,
+        "key_filename": os.path.expanduser("~/.ssh/id_rsa"),
+        "port": 22,
+    }
+    global_kwargs, user_kwargs, final_kwargs = handle(base_kwargs, kwargs)
+    final_kwargs["password"] = None  # always private keys
+    rename(final_kwargs, [("key_filename", "pkey"), ("host_string", "host")])
+
+    # if we're not using global state, return the new client as-is
+    env = state.ENV
+    if env.read_only:
+        return SSHClient(**final_kwargs)
+
+    client_map_key = "ssh_client"
+    client_key = subdict(final_kwargs, ["user", "host", "pkey", "port", "timeout"])
+    client_key = tuple(sorted(client_key.items()))
+
+    # otherwise, check to see if a previous client is available
+    client_map = env.get(client_map_key, {})
+    if client_key in client_map:
+        return client_map[client_key]
+
+    # if not, create a new one and store it in the state
+
+    # https://parallel-ssh.readthedocs.io/en/latest/native_single.html#pssh.clients.native.single.SSHClient
+    client = SSHClient(**final_kwargs)
+
+    # disconnect session when leaving context manager
+    state.add_cleanup(lambda: client.disconnect())
+
+    client_map[client_key] = client
+    env[client_map_key] = client_map
+
+    return client
+
+
+def _execute(command, user, key_filename, host_string, port, use_pty, timeout):
+    """creates an SSHClient object and executes given `command` with the given parameters."""
+    client = _ssh_client(
+        user=user, host_string=host_string, key_filename=key_filename, port=port
+    )
+
+    shell = False  # handled ourselves
+    sudo = False  # handled ourselves
+    user = None  # user to sudo to
+    encoding = "utf-8"  # used everywhere
+
+    try:
+        # https://parallel-ssh.readthedocs.io/en/latest/native_single.html#pssh.clients.native.single.SSHClient.run_command
+        channel, host_string, stdout, stderr, stdin = client.run_command(
+            command, sudo, user, use_pty, shell, encoding, timeout
+        )
+
+        def get_exit_code():
+            client.wait_finished(channel)
+            return channel.get_exit_status()
+
+        return {
+            # defer executing as it consumes output entirely before returning. this
+            # removes our chance to display/transform output as it is streamed to us
+            "return_code": get_exit_code,
+            "command": command,
+            "stdout": stdout,
+            "stderr": stderr,
+        }
+    except BaseException as ex:
+        # *probably* a network error:
+        # https://github.com/ParallelSSH/parallel-ssh/blob/master/pssh/exceptions.py
+        raise NetworkError(ex)
+
+
+def _print_line(output_pipe, quiet, discard_output, line):
+    """writes the given `line` (string) to the given `output_pipe` (file-like object)
+    if `quiet` is False, `line` is not written.
+    if `discard_output` is False, `line` is not returned.
+    `discard_output` should be set to `True` when you're expecting very large responses."""
+    if not quiet:
+        output_pipe.write(line + "\n")
+    if not discard_output:
+        return line
+
+
+def _process_output(output_pipe, result_list, quiet, discard_output):
+    "calls `_print_line` on each result in `result_list`."
+    kwargs = subdict(locals(), ["quiet", "discard_output"])
+
+    # always process the results as soon as we have them
+    # use `quiet` to hide the printing of output to stdout/stderr
+    # use `discard_output` to discard the results as soon as they are read
+    # stderr may be empty if `combine_stderr` in `remote` was `True`
+    new_results = [
+        _print_line(output_pipe, line=line, **kwargs) for line in result_list
+    ]
+    output_pipe.flush()
+    if not kwargs["discard_output"]:
+        return new_results
+
+
+# https://github.com/mathiasertl/fabric/blob/master/fabric/state.py#L338
+# https://github.com/mathiasertl/fabric/blob/master/fabric/operations.py#L898-L901
+# https://github.com/mathiasertl/fabric/blob/master/fabric/operations.py#L975
+def remote(command, **kwargs):
+    "preprocesses given `command` and options before sending it to `_execute` to be executed on remote host"
+
+    # Fabric function signature for `run`
+    # shell=True # done
+    # pty=True   # mutually exclusive with combine_stderr. not sure what Fabric/Paramiko is doing here
+    # combine_stderr=None # mutually exclusive with use_pty. 'True' in global env.
+    # quiet=False, # done
+    # warn_only=False # ignore
+    # stdout=None # done, stdout/stderr always available unless explicitly discarded. 'see discard_output'
+    # stderr=None # done, stderr not available when combine_stderr is `True`
+    # timeout=None # todo
+    # shell_escape=None # ignored. shell commands are always escaped
+    # capture_buffer_size=None # correlates to `ssh2.channel.read` and the `size` parameter. Ignored.
+
+    # parameters we're interested in and their default values
+    base_kwargs = {
+        # current user. sensible default but probably not what you want
+        "user": getpass.getuser(),
+        "host_string": None,
+        "key_filename": os.path.expanduser("~/.ssh/id_rsa"),
+        "port": 22,
+        "use_shell": True,
+        "use_sudo": False,
+        "combine_stderr": True,
+        "quiet": False,
+        "discard_output": False,
+        "remote_working_dir": None,
+        "timeout": None,
+    }
+    global_kwargs, user_kwargs, final_kwargs = handle(base_kwargs, kwargs)
+
+    # wrap the command up
+    # https://github.com/mathiasertl/fabric/blob/master/fabric/operations.py#L920-L925
+    if final_kwargs["remote_working_dir"]:
+        command = pwd_wrap_command(command, final_kwargs["remote_working_dir"])
+    if final_kwargs["use_shell"]:
+        command = shell_wrap_command(command)
+    if final_kwargs["use_sudo"]:
+        command = sudo_wrap_command(command)
+
+    # if use_pty is True, stdout and stderr are combined and stderr will yield nothing.
+    # - https://parallel-ssh.readthedocs.io/en/latest/advanced.html#combined-stdout-stderr
+    use_pty = final_kwargs["combine_stderr"]
+
+    # values `remote` specifically passes to `_execute`
+    execute_kwargs = {"command": command, "use_pty": use_pty}
+    execute_kwargs = merge(final_kwargs, execute_kwargs)
+    execute_kwargs = subdict(
+        execute_kwargs,
+        [
+            "command",
+            "user",
+            "key_filename",
+            "host_string",
+            "port",
+            "use_pty",
+            "timeout",
+        ],
+    )
+
+    # TODO: validate `_execute`s args. `host_string` can't be None for example
+
+    # run command
+    result = _execute(**execute_kwargs)
+
+    # handle stdout/stderr streams
+    output_kwargs = subdict(final_kwargs, ["quiet", "discard_output"])
+    stdout = _process_output(sys.stdout, result["stdout"], **output_kwargs)
+    stderr = _process_output(sys.stderr, result["stderr"], **output_kwargs)
+
+    # command must have finished before we have access to return code
+    return_code = result["return_code"]()
+    result.update(
+        {
+            "stdout": stdout,
+            "stderr": stderr,
+            "return_code": return_code,
+            "failed": return_code > 0,
+            "succeeded": return_code == 0,
+        }
+    )
+    return result
+
+
+# https://github.com/mathiasertl/fabric/blob/master/fabric/operations.py#L1100
+def remote_sudo(command, **kwargs):
+    "exactly the same as `remote`, but the given command is run as the root user"
+    # user=None  # ignore
+    # group=None # ignore
+    kwargs["use_sudo"] = True
+    return remote(command, **kwargs)
+
+
+# https://github.com/mathiasertl/fabric/blob/master/fabric/contrib/files.py#L15
+def remote_file_exists(path, **kwargs):
+    "returns True if given path exists on remote system"
+    # note: Fabric is doing something weird and clever here:
+    # - https://github.com/mathiasertl/fabric/blob/master/fabric/contrib/files.py#L474-L485
+    # but their examples don't work:
+
+    # $ /bin/sh
+    # sh-5.0$ foo="$(echo /usr/\*/share)"
+    # sh-5.0$ echo $foo
+    # /usr/*/share
+    # sh-5.0$ exit
+    # $ echo $SHELL
+    # $ /bin/bash
+    # $ foo="$(echo /usr/\*/share)"
+    # $ echo $foo
+    # /usr/*/share
+
+    base_kwargs = {
+        "use_sudo": False,
+    }
+    global_kwargs, user_kwargs, final_kwargs = handle(base_kwargs, kwargs)
+    remote_fn = remote_sudo if final_kwargs["use_sudo"] else remote
+    command = "test -e %s" % path
+    return remote_fn(command, **kwargs)["return_code"] == 0
+
+
+# https://github.com/mathiasertl/fabric/blob/master/fabric/operations.py#L1157
+def local(command, **kwargs):
+    base_kwargs = {
+        "use_shell": True,
+        "combine_stderr": True,
+        "capture": False,
+        "timeout": None,
+    }
+    global_kwargs, user_kwargs, final_kwargs = handle(base_kwargs, kwargs)
+
+    if final_kwargs["capture"]:
+        if final_kwargs["combine_stderr"]:
+            out_stream = subprocess.PIPE
+            err_stream = subprocess.STDOUT
+        else:
+            out_stream = subprocess.PIPE
+            err_stream = subprocess.PIPE
+    else:
+        out_stream = None
+        err_stream = None
+
+    if not final_kwargs["use_shell"] and not isinstance(command, list):
+        raise ValueError("when shell=False, given command *must* be a list")
+
+    if final_kwargs["use_shell"]:
+        command = shell_wrap_command(command)
+
+    proc = subprocess.Popen(
+        command, shell=final_kwargs["use_shell"], stdout=out_stream, stderr=err_stream
+    )
+    if final_kwargs["timeout"]:
+        timer = Timer(final_kwargs["timeout"], proc.kill)
+        try:
+            timer.start()  # proximity matters
+            stdout, stderr = proc.communicate()
+        finally:
+            timer.cancel()
+    else:
+        stdout, stderr = proc.communicate()
+
+    # https://github.com/mathiasertl/fabric/blob/master/fabric/operations.py#L1240-L1244
+    return {
+        "return_code": proc.returncode,
+        "failed": proc.returncode != 0,
+        "succeeded": proc.returncode == 0,
+        "command": command,
+        "stdout": (stdout or b"").decode("utf-8").splitlines(),
+        "stderr": (stderr or b"").decode("utf-8").splitlines(),
+    }
+
+
+def single_command(cmd_list):
+    """given a list of commands to run, returns a single command
+    `remote` and `local` are expected to do any escaping as necessary"""
+    if cmd_list in [None, []]:
+        return None
+    return " && ".join(map(str, cmd_list))
+
+
+# https://github.com/mathiasertl/fabric/blob/master/fabric/operations.py#L419
+# use_sudo hack: https://github.com/mathiasertl/fabric/blob/master/fabric/operations.py#L453-L458
+def _download_as_root_hack(remote_path, local_path, **kwargs):
+    """as root, creates a temporary copy of the file that can be downloaded by a
+    regular user and then removes the temporary file.
+    warning: don't try to download anything huge `with_sudo` as the file is duplicated.
+    warning: the privileged file will be available in /tmp until the download is complete"""
+
+    if not remote_file_exists(remote_path, use_sudo=True, **kwargs):
+        raise EnvironmentError("remote file does not exist: %s" % (remote_path,))
+    client = _ssh_client(**kwargs)
+
+    cmd = single_command(
+        [
+            # create a temporary file with the suffix '-threadbare'
+            'tempfile=$(mktemp --suffix "-threadbare")',
+            # copy the target file to this temporary file
+            'cp "%s" "$tempfile"' % remote_path,
+            # ensure it's readable by the user doing the downloading
+            'chmod +r "$tempfile"',
+            # emit the name of the temporary file so we can find it to download it
+            'echo "$tempfile"',
+        ]
+    )
+    result = remote_sudo(cmd, **kwargs)
+    remote_tempfile = result["stdout"][-1]
+    # assert remote_file_exists(remote_tempfile, use_sudo=True, **kwargs) # sanity check
+    remote_path = remote_tempfile
+    client.copy_remote_file(remote_tempfile, local_path)
+    remote_sudo('rm "%s"' % remote_tempfile, **kwargs)
+    return local_path
+
+
+# https://github.com/mathiasertl/fabric/blob/master/fabric/operations.py#L419
+# use_sudo hack: https://github.com/mathiasertl/fabric/blob/master/fabric/operations.py#L453-L458
+def download(remote_path, local_path, use_sudo=False, **kwargs):
+    """downloads file at `remote_path` to `local_path`, overwriting the local path if it exists.
+    avoid `use_sudo` if at all possible"""
+
+    with state.settings(quiet=True):
+        temp_file, bytes_buffer = None, None
+        if hasattr(local_path, "read"):
+            # given a file-like object to download file into.
+            # 1. write the remote file to local temporary file
+            # 2. read temporary file into the given buffer
+            # 3. delete the temporary file
+
+            bytes_buffer = local_path
+            temp_file, local_path = tempfile.mkstemp(suffix="-threadbare")
+
+        if use_sudo:
+            # return _download_as_root_hack(remote_path, local_path, **kwargs)
+            local_path = _download_as_root_hack(remote_path, local_path, **kwargs)
+
+        else:
+            if not remote_file_exists(remote_path, **kwargs):
+                raise EnvironmentError(
+                    "remote file does not exist: %s" % (remote_path,)
+                )
+            client = _ssh_client(**kwargs)
+            client.copy_remote_file(remote_path, local_path)
+
+        if temp_file:
+            bytes_buffer.write(open(local_path, "rb").read())
+            os.unlink(local_path)
+            return bytes_buffer
+
+        return local_path
+
+
+def _upload_as_root_hack(local_path, remote_path, **kwargs):
+    """uploads file at `local_path` to a remote temporary file then moves the file to `remote_path` as root.
+    does not alter any permissions or attributes on the file"""
+
+    client = _ssh_client(**kwargs)
+
+    cmd = single_command(
+        [
+            # create a temporary file with the suffix '-threadbare'
+            'tempfile=$(mktemp --suffix "-threadbare")',
+            'echo "$tempfile"',
+        ]
+    )
+    result = remote(cmd, **kwargs)
+    remote_temp_path = result["stdout"][-1]
+    assert remote_file_exists(remote_temp_path, **kwargs)  # sanity check
+
+    client.copy_file(local_path, remote_temp_path)
+    move_file_into_place = 'mv "%s" "%s"' % (remote_temp_path, remote_path)
+    remote_sudo(move_file_into_place, **kwargs)
+    assert remote_file_exists(remote_path, use_sudo=True, **kwargs)
+
+
+def _write_bytes_to_temporary_file(local_path):
+    """if `local_path` is a file-like object, write the contents to an *actual* file and
+    return a pair of new local filename and a function that removes the temporary file when called."""
+    if hasattr(local_path, "read"):
+        # `local_path` is a file-like object
+        local_bytes = local_path
+        local_bytes.seek(0)  # reset internal pointer
+        temp_file, local_path = tempfile.mkstemp(suffix="-threadbare")
+        with os.fdopen(temp_file, "wb") as fh:
+            fh.write(local_bytes.getvalue())
+        cleanup = lambda: os.unlink(local_path)
+        return local_path, cleanup
+    return local_path, None
+
+
+def upload(local_path, remote_path, use_sudo=False, **kwargs):
+    "uploads file at `local_path` to the given `remote_path`, overwriting anything that may be at that path"
+    with state.settings(quiet=True):
+
+        local_path, cleanup_fn = _write_bytes_to_temporary_file(local_path)
+        if cleanup_fn:
+            state.add_cleanup(cleanup_fn)
+
+        if use_sudo:
+            return _upload_as_root_hack(local_path, remote_path, **kwargs)
+
+        if not os.path.exists(local_path):
+            raise EnvironmentError("local file does not exist: %s" % (local_path,))
+
+        # you're not crazy, sftp is *exceptionally* slow:
+        # - https://github.com/ParallelSSH/parallel-ssh/issues/177
+        # local('du -sh %s' % local_path)
+        # client = _ssh_client(timeout=5, keepalive_seconds=1, num_retries=1, **kwargs)
+        client = _ssh_client(**kwargs)
+        # print('client',client)
+        client.copy_file(local_path, remote_path)
+        # client.pool.join()
+        # print('done')
+        # client.disconnect()

--- a/src/buildercore/threadbare/operations.py
+++ b/src/buildercore/threadbare/operations.py
@@ -446,8 +446,8 @@ def single_command(cmd_list):
 
 
 def prompt(msg):
-    """issues a prompt for input. 
-    raises a PromptedException if `abort_on_prompts` in `state.ENV` is `True` or executing within 
+    """issues a prompt for input.
+    raises a PromptedException if `abort_on_prompts` in `state.ENV` is `True` or executing within
     another process using `execute.parallel` where input can't be supplied.
     if `abort_exception` is set in `state.ENV`, then that exception is raised instead"""
     if state.ENV.get("abort_on_prompts", False):

--- a/src/buildercore/threadbare/operations.py
+++ b/src/buildercore/threadbare/operations.py
@@ -510,12 +510,13 @@ def upload(local_path, remote_path, use_sudo=False, **kwargs):
     "uploads file at `local_path` to the given `remote_path`, overwriting anything that may be at that path"
     with state.settings(quiet=True):
 
-        if os.path.isdir(local_path):
-            raise ValueError("folders cannot be uploaded")
-
+        # bytes handling
         local_path, cleanup_fn = _write_bytes_to_temporary_file(local_path)
         if cleanup_fn:
             state.add_cleanup(cleanup_fn)
+
+        if os.path.isdir(local_path):
+            raise ValueError("folders cannot be uploaded")
 
         if use_sudo:
             return _upload_as_root_hack(local_path, remote_path, **kwargs)

--- a/src/buildercore/threadbare/operations.py
+++ b/src/buildercore/threadbare/operations.py
@@ -433,6 +433,9 @@ def download(remote_path, local_path, use_sudo=False, **kwargs):
             bytes_buffer = local_path
             temp_file, local_path = tempfile.mkstemp(suffix="-threadbare")
 
+        if not os.path.isabs(local_path):
+            local_path = os.path.abspath(local_path)
+
         if use_sudo:
             # return _download_as_root_hack(remote_path, local_path, **kwargs)
             local_path = _download_as_root_hack(remote_path, local_path, **kwargs)

--- a/src/buildercore/threadbare/operations.py
+++ b/src/buildercore/threadbare/operations.py
@@ -446,8 +446,8 @@ def single_command(cmd_list):
 
 
 def prompt(msg):
-    """issues a prompt for input.
-    raises a PromptedException if `abort_on_prompts` in `state.ENV` is `True` or executing within
+    """issues a prompt for input. 
+    raises a PromptedException if `abort_on_prompts` in `state.ENV` is `True` or executing within 
     another process using `execute.parallel` where input can't be supplied.
     if `abort_exception` is set in `state.ENV`, then that exception is raised instead"""
     if state.ENV.get("abort_on_prompts", False):

--- a/src/buildercore/threadbare/operations.py
+++ b/src/buildercore/threadbare/operations.py
@@ -422,6 +422,9 @@ def download(remote_path, local_path, use_sudo=False, **kwargs):
     """downloads file at `remote_path` to `local_path`, overwriting the local path if it exists.
     avoid `use_sudo` if at all possible"""
 
+    if remote_path.endswith('/'):
+        raise ValueError("directory downloads are not supported")
+
     with state.settings(quiet=True):
         temp_file, bytes_buffer = None, None
         if hasattr(local_path, "read"):
@@ -436,8 +439,10 @@ def download(remote_path, local_path, use_sudo=False, **kwargs):
         if not os.path.isabs(local_path):
             local_path = os.path.abspath(local_path)
 
+        if os.path.isdir(local_path):
+            local_path = os.path.join(local_path, os.path.basename(remote_path))
+
         if use_sudo:
-            # return _download_as_root_hack(remote_path, local_path, **kwargs)
             local_path = _download_as_root_hack(remote_path, local_path, **kwargs)
 
         else:

--- a/src/buildercore/threadbare/state.py
+++ b/src/buildercore/threadbare/state.py
@@ -68,11 +68,10 @@ def add_cleanup(fn):
 
 
 @contextlib.contextmanager
-def settings(state=None, **kwargs):
+def settings(**kwargs):
     global DEPTH
 
-    if state is None:
-        state = ENV
+    state = ENV
     if not isinstance(state, dict):
         raise TypeError(
             "state map must be a dictionary-like object, not %r" % type(state)

--- a/src/buildercore/threadbare/state.py
+++ b/src/buildercore/threadbare/state.py
@@ -4,7 +4,7 @@ import contextlib
 CLEANUP_KEY = "_cleanup"
 
 
-class LockableDict(dict):
+class FreezeableDict(dict):
     def __init__(self, *args, **kwargs):
         dict.__init__(self, *args, **kwargs)
         self.read_only = False
@@ -39,11 +39,11 @@ def read_write(d):
 
 
 def initial_state():
-    """returns a new, empty, locked, LockableDict instance that is used as the initial `state.ENV` value.
+    """returns a new, empty, locked, FreezeableDict instance that is used as the initial `state.ENV` value.
 
     if you are thinking "it would be really convenient if 'some_setting' was 'some_value' by default",
     see `set_defaults`."""
-    new_env = LockableDict()
+    new_env = FreezeableDict()
     read_only(new_env)
     return new_env
 
@@ -55,7 +55,7 @@ DEPTH = 0  # used to determine how deeply nested we are
 
 def set_defaults(defaults_dict=None):
     """re-initialises the `state.ENV` dictionary with the given defaults.
-    with no arguments, the global state will be reverted to it's initial state (an empty LockableDict).
+    with no arguments, the global state will be reverted to it's initial state (an empty FreezeableDict).
 
     use `state.set_defaults` BEFORE using ANY other `state.*` functions are called."""
     global ENV, DEPTH
@@ -63,7 +63,7 @@ def set_defaults(defaults_dict=None):
         msg = "refusing to set initial `threadbare.state.ENV` state within a `threadbare.state.settings` context manager."
         raise EnvironmentError(msg)
 
-    new_env = LockableDict()
+    new_env = FreezeableDict()
     new_env.update(defaults_dict or {})
     read_only(new_env)
     ENV = new_env
@@ -103,7 +103,7 @@ def settings(**kwargs):
     # another approach would be to relax guarantees that the environment is completely reverted
 
     # call `read_write` here as `deepcopy` copies across attributes (like `read_only`) and
-    # then values using `__setitem__`, causing errors in LockableDict when 'set_defaults' used
+    # then values using `__setitem__`, causing errors in FreezeableDict when 'set_defaults' used
     read_write(state)
 
     original_values = copy.deepcopy(state)

--- a/src/buildercore/threadbare/state.py
+++ b/src/buildercore/threadbare/state.py
@@ -40,7 +40,7 @@ def read_write(d):
 
 def initial_state():
     """returns a new, empty, locked, LockableDict instance that is used as the initial `state.ENV` value.
-    
+
     if you are thinking "it would be really convenient if 'some_setting' was 'some_value' by default",
     see `set_defaults`."""
     new_env = LockableDict()

--- a/src/buildercore/threadbare/state.py
+++ b/src/buildercore/threadbare/state.py
@@ -124,7 +124,7 @@ def settings(**kwargs):
 
         DEPTH -= 1
 
-        # we're leaving the top-most context decorator
-        # ensure state dictionary is marked as read-only
         if DEPTH == 0:
+            # we're leaving the top-most context decorator
+            # ensure state dictionary is marked as read-only
             read_only(state)

--- a/src/buildercore/threadbare/state.py
+++ b/src/buildercore/threadbare/state.py
@@ -1,0 +1,108 @@
+import copy
+import contextlib
+
+CLEANUP_KEY = "_cleanup"
+
+
+class LockableDict(dict):
+    def __init__(self, *args, **kwargs):
+        dict.__init__(self, *args, **kwargs)
+        self.read_only = False
+
+    def update(self, new_dict):
+        if self.read_only:
+            raise ValueError(
+                "dictionary is locked attempting to `update` with %r" % new_dict
+            )
+        dict.update(self, new_dict)
+
+    def __setitem__(self, key, val):
+        # I suspect multiprocessing isn't copying the custom 'read_only' attribute back
+        # from the child process results. be aware of this weirdness
+        # print("self:",self.__dict__, "data:",self)
+        if hasattr(self, "read_only") and self.read_only:
+            raise ValueError(
+                "dictionary is locked attempting to `set` %r with %r" % (key, val)
+            )
+        dict.__setitem__(self, key, val)
+
+
+def read_only(d):
+    if hasattr(d, "read_only"):
+        d.read_only = True
+
+
+def read_write(d):
+    if hasattr(d, "read_only"):
+        d.read_only = False
+
+
+def init_state():
+    new_env = LockableDict()
+    read_only(new_env)
+    return new_env
+
+
+ENV = init_state()
+
+# used to determine how deeply nested we are
+DEPTH = 0
+
+
+def cleanup(old_state):
+    if CLEANUP_KEY in old_state:
+        for cleanup_fn in old_state[CLEANUP_KEY]:
+            cleanup_fn()
+        del old_state[CLEANUP_KEY]
+
+
+def _add_cleanup(state, fn):
+    cleanup_fn_list = state.get(CLEANUP_KEY, [])
+    cleanup_fn_list.append(fn)
+    state[CLEANUP_KEY] = cleanup_fn_list
+
+
+def add_cleanup(fn):
+    "add a function to a list of functions that are called after leaving the current scope of the context manager"
+    return _add_cleanup(ENV, fn)
+
+
+@contextlib.contextmanager
+def settings(state=None, **kwargs):
+    global DEPTH
+
+    if state is None:
+        state = ENV
+    if not isinstance(state, dict):
+        raise TypeError(
+            "state map must be a dictionary-like object, not %r" % type(state)
+        )
+
+    # deepcopy will attempt to pickle and unpickle all objects in state
+    # we can't guarantee what will live in state and if it's possible to pickle it or not
+    # the SSHClient is one such unserialisable object that has had to be subclassed
+    # another approach would be to relax guarantees that the environment is completely reverted
+
+    original_values = copy.deepcopy(state)
+    DEPTH += 1
+
+    read_write(state)
+    state.update(kwargs)
+
+    # ensure child context processors don't clean up their parents
+    if CLEANUP_KEY in state:
+        state.update({CLEANUP_KEY: []})
+
+    try:
+        yield state
+    finally:
+        cleanup(state)
+        state.clear()
+        state.update(original_values)
+
+        DEPTH -= 1
+
+        # we're leaving the top-most context decorator
+        # ensure state dictionary is marked as read-only
+        if DEPTH == 0:
+            read_only(state)

--- a/src/buildercore/utils.py
+++ b/src/buildercore/utils.py
@@ -294,7 +294,7 @@ def json_dumps(obj, dangerous=False, **kwargs):
         if hasattr(obj, 'isoformat'):
             return obj.isoformat()
         elif dangerous:
-            return '[unserializable]'
+            return '[unserializable: %s]' % (str(obj))
         else:
             raise TypeError('Object of type %s with value of %s is not JSON serializable' % (type(obj), repr(obj)))
     return json.dumps(obj, default=json_handler, **kwargs)

--- a/src/master.py
+++ b/src/master.py
@@ -64,7 +64,7 @@ def server_access():
     stackname = core.find_master(core.find_region())
     public_ip = core.stack_data(stackname, ensure_single_instance=True)[0]['PublicIpAddress']
     result = local('ssh -o "StrictHostKeyChecking no" %s@%s "exit"' % (config.BOOTSTRAP_USER, public_ip))
-    return result.return_code == 0
+    return result['succeeded']
 
 @cached
 def _cached_master_ip(master_stackname):

--- a/src/masterless.py
+++ b/src/masterless.py
@@ -69,8 +69,8 @@ def parse_validate_repolist(fdata, *repolist):
             continue
 
         with lcd(path), settings(warn_only=True):
-            ensure(local("git fetch --quiet").succeeded, "failed to fetch remote refs for %s" % path)
-            ensure(local("git cat-file -e %s^{commit}" % revision).succeeded, "failed to find ref %r in %s" % (revision, name))
+            ensure(local("git fetch --quiet")['succeeded'], "failed to fetch remote refs for %s" % path)
+            ensure(local("git cat-file -e %s^{commit}" % revision)['succeeded'], "failed to find ref %r in %s" % (revision, name))
 
     return arglist
 

--- a/src/utils.py
+++ b/src/utils.py
@@ -31,8 +31,8 @@ def git_remote_branches(url):
 
 def _git_remote_refs(url):
     cmd = "git ls-remote --heads %s" % url
-    output = local(cmd, capture=True)
-    return [line.split() for line in output.splitlines()]
+    output = local(cmd, capture=True)['stdout']
+    return [line.split() for line in output]
 
 def errcho(x):
     sys.stderr.write(x)


### PR DESCRIPTION
* adds a copy of threadbare
* adds ability to switch backend between fabric or threadbare
* wraps several Fabric commands to unify behaviour between the two libraries
* removes xdist for testing. It's asyncio usage was causing obscure errors with geventlet/multiprocessing

---

- [x] discrepancy between what threadbare `execute` is returning and what Fabric is returning (1)
- [x] `env` is being accessed as an object somewhere (see exception in results returned) (1)
- [x] `OSError` attempting to make a tempfile with threadbare while downloading. (2)
- [x] discrepancy between what threadbare `local` is returning when `capture=True` and what Fabric is returning (3)
- [x] `remote_list_files` is relying on `stdout` being returned instead of a dictionary (4)
- [x] `host` vs `host_string` confusion. investigation (5)
- [x] self review
- [ ] can `pytest-xdist` be re-introduced?

<details>
  <summary>outdated</summary>
---
(1)

```python
stackname = 'project-with-cluster-integration-tests--luke-20191204065616-172945'
kwargs = {'instance_ids': ['i-02ff6edd0df1cb414', 'i-0022ed6fe65bbe870']}
ip_to_ready = [AttributeError("'LockableDict' object has no attribute 'host'",), AttributeError("'LockableDict' object has no attribute 'host'",)]

    def _some_node_is_not_ready(stackname, **kwargs):
        try:
            ip_to_ready = stack_all_ec2_nodes(stackname, _daemons_ready, username=config.BOOTSTRAP_USER, **kwargs)
            LOG.info("_some_node_is_not_ready: %s", ip_to_ready)
>           return len(ip_to_ready) == 0 or False in ip_to_ready.values()
E           AttributeError: 'list' object has no attribute 'values'
```
---
(2)

```python
name = '/venv', mode = 511

    def makedirs(name, mode=0777):
        """makedirs(path [, mode=0777])
    
        Super-mkdir; create a leaf directory and all intermediate ones.
        Works like mkdir, except that any intermediate path segment (not
        just the rightmost) will be created if it does not exist.  This is
        recursive.
    
        """
        head, tail = path.split(name)
        if not tail:
            head, tail = path.split(head)
        if head and tail and not path.exists(head):
            try:
                makedirs(head, mode)
            except OSError, e:
                # be happy if someone already created the path
                if e.errno != errno.EEXIST:
                    raise
            if tail == curdir:           # xxx/newdir/. exists if xxx/newdir exists
                return
>       mkdir(name, mode)
E       OSError: [Errno 13] Permission denied: '/venv'
```
tracepath:

```python
src/decorators.py:80: in call
    return func(stackname, *args, **kwargs)
src/cfn.py:297: in download_file
    _download(path, destination)
venv/lib/python2.7/site-packages/backoff/_sync.py:99: in retry
    ret = target(*args, **kwargs)
src/cfn.py:295: in _download
    download(path, destination, use_sudo=True)
src/buildercore/threadbare/operations.py:438: in download
    local_path = _download_as_root_hack(remote_path, local_path, **kwargs)
src/buildercore/threadbare/operations.py:414: in _download_as_root_hack
    client.copy_remote_file(remote_tempfile, local_path)
venv/lib/python2.7/site-packages/pssh/clients/native/single.py:636: in copy_remote_file
    self._make_local_dir(destination)
venv/lib/python2.7/site-packages/pssh/clients/native/single.py:862: in _make_local_dir
    os.makedirs(dirpath)
```


---
(3)
```python
url = 'https://github.com/elifesciences/builder'

    def _git_remote_refs(url):
        cmd = "git ls-remote --heads %s" % url
        output = local(cmd, capture=True)
>       return [line.split() for line in output.splitlines()]
E       AttributeError: 'dict' object has no attribute 'splitlines'
```

---
(4)
```python
__________________________________________________ TestWithInstance.test_core_listfiles_remote ___________________________________________________

self = <integration_tests.test_with_instance.TestWithInstance testMethod=test_core_listfiles_remote>

    def test_core_listfiles_remote(self):
        with core.stack_conn(self.stackname, username=BOOTSTRAP_USER):
>           results = command.remote_listfiles('/')

src/integration_tests/test_with_instance.py:81: 
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 

path = '/*', use_sudo = False

    def remote_listfiles(path=None, use_sudo=False):
        """returns a list of files in a directory at `path` as absolute paths"""
        if not path:
            raise AssertionError("path to remote directory required")
        with fab_api.hide('output'):
            runfn = remote_sudo if use_sudo else remote
            path = "%s/*" % path.rstrip("/")
            stdout = runfn("for i in %s; do echo $i; done" % path)
            if stdout == path: # some kind of bash artifact where it returns `/path/*` when no matches
                return []
>           return stdout.splitlines()
E           AttributeError: 'dict' object has no attribute 'splitlines'

src/buildercore/command.py:149: AttributeError
```
---
(5)
```python
___________________________________________________ TestWithManyNodes.test_restart_one_stopped ___________________________________________________

self = <integration_tests.test_with_many_nodes.TestWithManyNodes testMethod=test_restart_one_stopped>

    def test_restart_one_stopped(self):
        "multiple nodes can be restarted from a mixed state"
        node1 = core.find_ec2_instances(self.stackname)[0]
        node1.stop()
        node1.wait_until_stopped()
>       history = lifecycle.restart(self.stackname)

src/integration_tests/test_with_many_nodes.py:69: 
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 
src/buildercore/lifecycle.py:78: in restart
    done_msg="all nodes have public ips, are reachable via SSH and have completed boot"
src/buildercore/utils.py:175: in call_while
    result = fn()
src/buildercore/lifecycle.py:74: in <lambda>
    lambda: _some_node_is_not_ready(stackname, node=node_id, concurrency='serial'),
src/buildercore/lifecycle.py:156: in _some_node_is_not_ready
    ip_to_ready = stack_all_ec2_nodes(stackname, _daemons_ready, username=config.BOOTSTRAP_USER, **kwargs)
src/buildercore/core.py:372: in stack_all_ec2_nodes
    return serial_work(single_node_work, params)
src/buildercore/core.py:384: in serial_work
    return execute(serial(single_node_work), hosts=list(params['public_ips'].values()))
src/buildercore/threadbare/execute.py:208: in execute_with_hosts
    results = execute(env, func, param_key="host_string", param_values=host_list)
src/buildercore/threadbare/execute.py:192: in execute
    return _serial_execution(env, func, param_key, param_values)
src/buildercore/threadbare/execute.py:139: in _serial_execution
    result_list.append(func())
src/buildercore/threadbare/execute.py:14: in inner
    return func(*args, **kwargs)
src/buildercore/core.py:345: in single_node_work
    return workfn(**work_kwargs)
src/buildercore/lifecycle.py:270: in _daemons_ready
    node_id = current_ec2_node_id()
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 

    def current_ec2_node_id():
        """Assumes it is called inside the 'workfn' of a 'stack_all_ec2_nodes'.
    
        Sticking to the 'node' terminology because 'instance' is too overloaded.
    
        Sample value: 'i-0553487b4b6916bc9'"""
    
>       ensure(env['host'] is not None, "This is supposed to be called with settings for connecting to an EC2 instance")
E       KeyError: 'host'

src/buildercore/core.py:397: KeyError
```
</details>