### PR TITLE
Recreate kubernetes-aws--test to deal with security group naming

### DIFF
--- a/docs/eks.md
+++ b/docs/eks.md
@@ -67,6 +67,17 @@ helm status my-release-name
 
 A project can be configured to create a cluster with the `eks` configuration in `elife.yaml`.
 
+### Delete a cluster
+
+A cluster cannot be deleted as-is as its operations create cloud resources that become dependent upon the cluster resources, or would become leftovers if not deleted at the right level of abstraction.
+
+Checklist to go through before destruction:
+
+- delete all Helm releases (should take care of DNS entries from `Service` instances)
+- scale worker nodes down to 0 (untested but should take care of ENI dependent on security groups)
+- delete ELBs that haven't been deleted yet (not sure if necessary)
+- delete security groups that haven't been deleted yet (not sure if necessary)
+
 ### See the moving parts
 
 builder generates Terraform templates that describe the set of EKS, EC2 and even some Helm-managed Kubernetes resources that are created inside an `eks`-enabling stack.

--- a/projects/elife.yaml
+++ b/projects/elife.yaml
@@ -2123,7 +2123,7 @@ kubernetes-aws:
             worker:
                 type: t2.small    
                 max-size: 4
-                desired-capacity: 4
+                desired-capacity: 3
             helm: true
             external-dns:
                 domain-filter: "elifesciences.org"

--- a/projects/elife.yaml
+++ b/projects/elife.yaml
@@ -2123,7 +2123,7 @@ kubernetes-aws:
             worker:
                 type: t2.small    
                 max-size: 4
-                desired-capacity: 3
+                desired-capacity: 4
             helm: true
             external-dns:
                 domain-filter: "elifesciences.org"

--- a/src/buildercore/terraform.py
+++ b/src/buildercore/terraform.py
@@ -697,7 +697,7 @@ def _render_eks_workers_security_group(context, template):
     })
 
     security_group_tags = aws.generic_tags(context)
-    security_group_tags['kubernetes.io/cluster/%s'] = 'owned'
+    security_group_tags['kubernetes.io/cluster/%s' % context['stackname']] = 'owned'
     template.populate_resource('aws_security_group', 'worker', block={
         'name': '%s--worker' % context['stackname'],
         'description': 'Security group for all worker nodes in the cluster',

--- a/src/buildercore/terraform.py
+++ b/src/buildercore/terraform.py
@@ -629,6 +629,8 @@ def render_eks(context, template):
         _render_helm(context, template)
 
 def _render_eks_master_security_group(context, template):
+    security_group_tags = aws.generic_tags(context)
+    security_group_tags['kubernetes.io/cluster/%s' % context['stackname']] = 'owned'
     template.populate_resource('aws_security_group', 'master', block={
         'name': '%s--master' % context['stackname'],
         'description': 'Cluster communication with worker nodes',
@@ -639,7 +641,7 @@ def _render_eks_master_security_group(context, template):
             'protocol': '-1',
             'cidr_blocks': ['0.0.0.0/0'],
         },
-        'tags': aws.generic_tags(context),
+        'tags': security_group_tags,
     })
 
 def _render_eks_master_role(context, template):

--- a/src/tests/test_buildercore_terraform.py
+++ b/src/tests/test_buildercore_terraform.py
@@ -951,7 +951,7 @@ class TestBuildercoreTerraform(base.BaseCase):
                     'Environment': self.environment,
                     'Name': 'project-with-eks--%s' % self.environment,
                     'Cluster': 'project-with-eks--%s' % self.environment,
-                    'kubernetes.io/cluster/%s': 'owned',
+                    'kubernetes.io/cluster/project-with-eks--%s' % self.environment: 'owned',
                 }
             }
         )

--- a/src/tests/test_buildercore_terraform.py
+++ b/src/tests/test_buildercore_terraform.py
@@ -915,6 +915,7 @@ class TestBuildercoreTerraform(base.BaseCase):
                     'Environment': self.environment,
                     'Name': 'project-with-eks--%s' % self.environment,
                     'Cluster': 'project-with-eks--%s' % self.environment,
+                    'kubernetes.io/cluster/project-with-eks--%s' % self.environment: 'owned',
                 }
             }
         )


### PR DESCRIPTION
Part of https://github.com/elifesciences/issues/issues/5222

This requires destroying the cluster because the [security groups are still wrong](https://console.aws.amazon.com/vpc/home?region=us-east-1#SecurityGroups:search=sg-0686e67d3592051f4;sort=groupId). I thought https://github.com/elifesciences/builder/pull/552 solved this but the cluster was apparently re-created with an older version in https://github.com/elifesciences/builder/pull/583.