### PR TITLE
Increase size of kubernetes-aws nodes to t2.medium

### DIFF
--- a/projects/elife.yaml
+++ b/projects/elife.yaml
@@ -2121,9 +2121,9 @@ kubernetes-aws:
         ec2: false
         eks:
             worker:
-                type: t2.small    
+                type: t2.medium    
                 max-size: 4
-                desired-capacity: 3
+                desired-capacity: 2
             helm: true
             external-dns:
                 domain-filter: "elifesciences.org"


### PR DESCRIPTION
For https://github.com/elifesciences/issues/issues/5253

`t2.medium` instances have 4GB available.
According to
https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/using-eni.html#AvailableIpPerENI
this gives us a total of 18 ip addresses per node.

I suspect the pods won't fit on 2 nodes as 1 will be dedicated to
`jats-validator` so may increase them back to 3.