### PR TITLE
bootstrap, python2.7 removal

### DIFF
--- a/projects/elife.yaml
+++ b/projects/elife.yaml
@@ -1,7 +1,6 @@
 defaults:
     description: defaults for all projects in this file
-    #salt: '2017.7.8' # the version of salt these project use
-    salt: '2018.3.4'
+    salt: '2018.3.4' # the version of salt these project use
     # use false with a subdomain to assign internal addresses only
     domain: elifesciences.org
     # addressing within VPC

--- a/projects/elife.yaml
+++ b/projects/elife.yaml
@@ -1,6 +1,7 @@
 defaults:
     description: defaults for all projects in this file
-    salt: '2018.3.4' # the version of salt these project use
+    #salt: '2018.3.4' # the version of salt these project use
+    salt: '2017.7.8'
     # use false with a subdomain to assign internal addresses only
     domain: elifesciences.org
     # addressing within VPC

--- a/projects/elife.yaml
+++ b/projects/elife.yaml
@@ -1,6 +1,7 @@
 defaults:
     description: defaults for all projects in this file
-    salt: '2017.7.8' # the version of salt these project use
+    #salt: '2017.7.8' # the version of salt these project use
+    salt: '2018.3.4'
     # use false with a subdomain to assign internal addresses only
     domain: elifesciences.org
     # addressing within VPC

--- a/scripts/bootstrap.sh
+++ b/scripts/bootstrap.sh
@@ -7,6 +7,8 @@ set -e # everything must pass
 set -u # no unbound variables
 set -xv  # output the scripts and interpolated steps
 
+export DEBIAN_FRONTEND=noninteractive # no ncurses prompts
+
 echo "-----------------------------"
 
 if [ ! "$#" -ge 3 ]; then
@@ -96,7 +98,7 @@ if $upgrade_python; then
 
     apt-get install python3 python3-dev -y
 
-    # virtual envs have to be recreated
+    # virtualenvs have to be recreated
     find /srv /opt -depth -type d -name venv -exec rm -rf "{}" \;
 
     # install/upgrade pip+setuptools

--- a/scripts/bootstrap.sh
+++ b/scripts/bootstrap.sh
@@ -154,7 +154,8 @@ if ($installing || $upgrading); then
     # -c  Temporary configuration directory
     # -M  Also install master
     # https://github.com/saltstack/salt-bootstrap/blob/develop/bootstrap-salt.sh
-    sh salt_bootstrap.sh -x python3 -P -F -c /tmp stable "$version"
+    #sh salt_bootstrap.sh -x python3 -P -F -c /tmp stable "$version"
+    sh salt_bootstrap.sh -P -F -c /tmp stable "$version"
 else
     echo "Skipping minion bootstrap, found: $(salt-minion --version)"
 fi

--- a/scripts/bootstrap.sh
+++ b/scripts/bootstrap.sh
@@ -123,9 +123,6 @@ if $upgrade_python3; then
     apt-get install python3 python3-dev python3-pip python3-setuptools -y --no-install-recommends
     python3 -m pip install pip setuptools --upgrade
 
-    # virtualenvs have to be recreated
-    find /srv /opt -depth -type d -name venv -exec rm -rf "{}" \;
-
     # some libraries need to be installed *before* calling Salt
     python3 -m pip install "docker[tls]==4.1.0"
 

--- a/scripts/bootstrap.sh
+++ b/scripts/bootstrap.sh
@@ -166,7 +166,8 @@ if [ "$install_master" = "true" ]; then
     # salt is not installed or the version installed is old
     if ! (command -v salt-master > /dev/null && salt-master --version | grep "$version"); then
         # master not installed
-        sh salt_bootstrap.sh -x python3 -P -F -M -c /tmp stable "$version"
+        #sh salt_bootstrap.sh -x python3 -P -F -M -c /tmp stable "$version"
+        sh salt_bootstrap.sh -P -F -M -c /tmp stable "$version"
     else
         echo "Skipping master bootstrap, found: $(salt-master --version)"
     fi

--- a/scripts/bootstrap.sh
+++ b/scripts/bootstrap.sh
@@ -108,7 +108,7 @@ if $upgrade_python2; then
         apt-get install python2.7 python2.7-dev -y
 
         # virtualenvs have to be recreated
-        find /srv /opt -depth -type d -name venv -exec rm -rf "{}" \;
+        #find /srv /opt -depth -type d -name venv -exec rm -rf "{}" \;
 
         # install/upgrade pip+setuptools
         apt-get install python-pip python-setuptools --no-install-recommends -y

--- a/scripts/bootstrap.sh
+++ b/scripts/bootstrap.sh
@@ -82,15 +82,33 @@ if ($upgrade_python || $install_git); then
     apt-get update -y
 fi
 
+
+# flag we can toggle to disable installation of python2 and python2 libs
+# set to `false` once all formulas and formula code has been updated
+elife_depends_on_python2=true
+
 if $upgrade_python; then
-    apt-get install python2.7 python2.7-dev -y
+
+    if $elife_depends_on_python2; then
+        echo "eLife still has formulas that depend on Python2!"
+        apt-get install python2.7 python2.7-dev -y
+    fi
+
+    apt-get install python3 python3-dev -y
+
     # virtual envs have to be recreated
     find /srv /opt -depth -type d -name venv -exec rm -rf "{}" \;
 
     # install/upgrade pip+setuptools
-    apt-get install python-pip python-setuptools --no-install-recommends -y
-    python2.7 -m pip install pip setuptools --upgrade
+    if $elife_depends_on_python2; then
+        apt-get install python-pip python-setuptools --no-install-recommends -y
+        python2.7 -m pip install pip setuptools --upgrade
+    fi
 
+    apt-get install python3-pip python3-setuptools --no-install-recommends -y
+    python3 -m pip install pip setuptools --upgrade
+
+    # remove flag, if it exists
     rm -f /root/upgrade-python.flag
 fi
 

--- a/scripts/bootstrap.sh
+++ b/scripts/bootstrap.sh
@@ -42,17 +42,19 @@ else
     fi
 fi
 
-upgrade_python=false
+upgrade_python2=false
+upgrade_python3=false
 install_git=false
 
 # Python is such a hard dependency of Salt that we have to upgrade it outside of 
 # Salt to avoid changing it while it is running
 
+# TODO: remove this block once our python2 dependency is gone
 if ! command -v python2.7; then
     # python2 not found
-    upgrade_python=true
+    upgrade_python2=true
 else
-    # python found, check installed version
+    # python2 found, check installed version
     python_version=$(dpkg-query -W --showformat="\${Version}" python2.7) # e.g. 2.7.5-5ubuntu3
     if dpkg --compare-versions "$python_version" lt 2.7.12; then
         # we used this, which is not available anymore, to provide a more recent Python 2.7
@@ -66,12 +68,22 @@ else
         # libpython2.7-stdlib : Breaks: python-urllib3 (< 1.9.1-3) but 1.7.1-1ubuntu4 is to be installed
         # due to the previous PPA
         add-apt-repository -y ppa:ross-kallisti/python-urllib3
-        upgrade_python=true
+        upgrade_python2=true
     fi
 
     # if flag present, upgrade python
     if [ -f /root/upgrade-python.flag ]; then
-        upgrade_python=true
+        upgrade_python2=true
+    fi
+fi
+
+if ! command -v python3; then
+    # python3 not found
+    upgrade_python3=true
+else
+    # python 3 found but have our other py3 dependencies been installed?
+    if ! grep "installed/upgraded python3" /root/events.log; then
+        upgrade_python3=true
     fi
 fi
 
@@ -80,38 +92,53 @@ if ! dpkg -l git; then
     install_git=true
 fi
 
-if ($upgrade_python || $install_git); then
+if ($upgrade_python2 || $upgrade_python3 || $install_git); then
     apt-get update -y
 fi
 
 
-# flag we can toggle to disable installation of python2 and python2 libs
-# set to `false` once all formulas and formula code has been updated
+# flag we can toggle to disable installation of python2 and python2 libs.
+# set to `false` once all formulas and formula code has been updated.
 elife_depends_on_python2=true
 
-if $upgrade_python; then
+if $upgrade_python2; then
 
     if $elife_depends_on_python2; then
         echo "eLife still has formulas that depend on Python2!"
         apt-get install python2.7 python2.7-dev -y
-    fi
 
-    apt-get install python3 python3-dev -y
+        # virtualenvs have to be recreated
+        find /srv /opt -depth -type d -name venv -exec rm -rf "{}" \;
 
-    # virtualenvs have to be recreated
-    find /srv /opt -depth -type d -name venv -exec rm -rf "{}" \;
-
-    # install/upgrade pip+setuptools
-    if $elife_depends_on_python2; then
+        # install/upgrade pip+setuptools
         apt-get install python-pip python-setuptools --no-install-recommends -y
         python2.7 -m pip install pip setuptools --upgrade
     fi
 
-    apt-get install python3-pip python3-setuptools --no-install-recommends -y
-    python3 -m pip install pip setuptools --upgrade
-
     # remove flag, if it exists
     rm -f /root/upgrade-python.flag
+fi
+
+if $upgrade_python3; then
+    apt-get install python3 python3-dev python3-pip python3-setuptools -y --no-install-recommends
+    python3 -m pip install pip setuptools --upgrade
+
+    # virtualenvs have to be recreated
+    find /srv /opt -depth -type d -name venv -exec rm -rf "{}" \;
+
+    # some libraries need to be installed *before* calling Salt
+    python3 -m pip install "docker[tls]==4.1.0"
+
+    # record an entry about when python3 was installed/upgraded
+    # presence of this entry is used to skip this section in future, unless forced with a flag
+    if [ -f /root/upgrade-python3.flag ]; then
+        echo "$(date -I) -- installed/upgraded python3 (forced)" >> /root/events.log;
+    else
+        echo "$(date -I) -- installed/upgraded python3" >> /root/events.log;
+    fi
+
+    # remove 'force upgrade' flag, if it exists
+    rm -f /root/upgrade-python3.flag
 fi
 
 if $install_git; then

--- a/scripts/init-master.sh
+++ b/scripts/init-master.sh
@@ -9,6 +9,10 @@ set -e # everything must pass
 set -u # no unbound variables
 set -xv  # output the scripts and interpolated steps
 
+export DEBIAN_FRONTEND=noninteractive # no ncurses prompts
+
+echo "-----------------------------"
+
 stackname=$1 # who am I? ll: master-server--2016-01-01
 pillar_repo=$2 # what secrets do I know?
 configuration_repo=$3 # what configuration do I know?
@@ -123,9 +127,9 @@ done
 # install/update builder
 # the master server will need to install project formulas. 
 
-# install builder dependencies for Ubuntu
-apt-get install python-dev python-pip libffi-dev libssl-dev -y
-pip install virtualenv
+# install builder dependencies for Ubuntu not covered by bootstrap.sh
+apt-get install libffi-dev libssl-dev -y
+python3 -m pip install virtualenv
 
 rm -rf /opt/builder
 

--- a/src/buildercore/config.py
+++ b/src/buildercore/config.py
@@ -116,10 +116,12 @@ CLOUD_EXCLUDING_DEFAULTS_IF_NOT_PRESENT = ['rds', 'ext', 'elb', 'cloudfront', 'e
 
 #
 # settings
-# believe it or not but buildercore.config is NOT the place for user config
+# buildercore.config is NOT the place for user config
 #
 
 PROJECTS_FILES = ['projects/elife.yaml']
+
+PROJECT_FORMULAS = os.path.join(PROJECT_PATH, 'cloned-projects') # same path as used by Vagrant
 
 USER_PRIVATE_KEY = os.environ.get('CUSTOM_SSH_KEY', '~/.ssh/id_rsa')
 

--- a/src/buildercore/config.py
+++ b/src/buildercore/config.py
@@ -121,7 +121,7 @@ CLOUD_EXCLUDING_DEFAULTS_IF_NOT_PRESENT = ['rds', 'ext', 'elb', 'cloudfront', 'e
 
 PROJECTS_FILES = ['projects/elife.yaml']
 
-PROJECT_FORMULAS = os.path.join(PROJECT_PATH, 'cloned-projects') # same path as used by Vagrant
+CLONED_PROJECT_FORMULA_DIR = os.path.join(PROJECT_PATH, 'cloned-projects') # same path as used by Vagrant
 
 USER_PRIVATE_KEY = os.environ.get('CUSTOM_SSH_KEY', '~/.ssh/id_rsa')
 

--- a/src/buildercore/project/__init__.py
+++ b/src/buildercore/project/__init__.py
@@ -2,9 +2,7 @@
 from buildercore import utils, config
 from kids.cache import cache
 from . import files
-
 import copy
-
 import logging
 from functools import reduce
 LOG = logging.getLogger(__name__)
@@ -94,19 +92,15 @@ def ec2_projects(*args, **kwargs):
 #
 #
 
-def transformed_projects(mapfn, *args, **kwargs):
-    return utils.dictmap(mapfn, project_map(*args, **kwargs))
-
 def project_formulas():
-    return transformed_projects(lambda _, pdata: [pdata.get('formula-repo')] + pdata.get('formula-dependencies', []))
+    def fn(pname, pdata):
+        return [pdata.get('formula-repo')] + pdata.get('formula-dependencies', [])
+    return utils.dictmap(fn, project_map())
 
 #
 #
 #
 
 def known_formulas():
-    "a simple list of all known project formulas (excluding the private-repo)"
-    lst = utils.unique(utils.shallow_flatten(project_formulas().values()))
-    if None in lst:
-        lst.remove(None)
-    return lst
+    "a simple list of all known project formulas"
+    return utils.lfilter(None, utils.unique(utils.shallow_flatten(project_formulas().values())))

--- a/src/project.py
+++ b/src/project.py
@@ -1,5 +1,6 @@
-from buildercore.command import local
-from buildercore import project, utils as core_utils, core, cfngen
+import os
+from buildercore.command import local, CommandException
+from buildercore import project, utils as core_utils, core, cfngen, config
 from buildercore.utils import ensure
 from decorators import requires_project, echo_output
 import utils
@@ -30,6 +31,34 @@ def context(pname, output_format=None):
     ensure(output_format in formatters.keys(), "unknown output format %r" % output_format)
     formatter = formatters.get(output_format)
     return formatter(cfngen.build_context(pname, stackname=core.mk_stackname(pname, "test")))
+
+@requires_project
+def clone_project_formulas(pname):
+    """clones a project's list of formulas to `cloned-projects/$formulaname` if it doesn't already exist. 
+    if it does exist, it attempts to update it with a `git pull`."""
+    destination = config.PROJECT_FORMULAS
+    pdata = project.project_data(pname)
+
+    formula_url_list = [pdata.get('formula-repo')]
+    formula_url_list.extend(pdata.get('formula-dependencies', []))
+    formula_url_list = filter(None, formula_url_list)
+
+    for furl in formula_url_list:
+        fpath = os.path.join(destination, os.path.basename(furl))
+        if os.path.exists(fpath):
+            cmd = "cd %s; git pull" % (fpath,)
+        else:
+            cmd = "cd %s; git clone %s" % (destination, furl)
+
+        try:
+            result = local(cmd)
+        except CommandException:
+            pass # any error is printed to stdout/stderr
+
+def clone_all_formulas():
+    "clones the formulas and formula dependencies of all known projects"
+    for pname in project.project_list():
+        clone_project_formulas(pname)
 
 def new():
     "creates a new project formula"

--- a/src/project.py
+++ b/src/project.py
@@ -1,5 +1,5 @@
 import os
-from buildercore.command import local, CommandException, settings
+from buildercore.command import local, settings
 from buildercore import project, utils as core_utils, core, cfngen, config
 from buildercore.utils import ensure
 from decorators import requires_project, echo_output
@@ -34,7 +34,7 @@ def context(pname, output_format=None):
 
 @requires_project
 def clone_project_formulas(pname):
-    """clones a project's list of formulas to `cloned-projects/$formulaname`, if it doesn't already exist. 
+    """clones a project's list of formulas to `cloned-projects/$formulaname`, if it doesn't already exist.
     if it does exist, it attempts to update it with a `git pull`."""
     destination = config.PROJECT_FORMULAS
     pdata = project.project_data(pname)

--- a/src/project.py
+++ b/src/project.py
@@ -1,5 +1,5 @@
 import os
-from buildercore.command import local, CommandException
+from buildercore.command import local, CommandException, settings
 from buildercore import project, utils as core_utils, core, cfngen, config
 from buildercore.utils import ensure
 from decorators import requires_project, echo_output
@@ -34,7 +34,7 @@ def context(pname, output_format=None):
 
 @requires_project
 def clone_project_formulas(pname):
-    """clones a project's list of formulas to `cloned-projects/$formulaname` if it doesn't already exist. 
+    """clones a project's list of formulas to `cloned-projects/$formulaname`, if it doesn't already exist. 
     if it does exist, it attempts to update it with a `git pull`."""
     destination = config.PROJECT_FORMULAS
     pdata = project.project_data(pname)
@@ -50,10 +50,8 @@ def clone_project_formulas(pname):
         else:
             cmd = "cd %s; git clone %s" % (destination, furl)
 
-        try:
-            result = local(cmd)
-        except CommandException:
-            pass # any error is printed to stdout/stderr
+        with settings(warn_only=True):
+            local(cmd)
 
 def clone_all_formulas():
     "clones the formulas and formula dependencies of all known projects"

--- a/src/taskrunner.py
+++ b/src/taskrunner.py
@@ -110,7 +110,8 @@ DEBUG_TASK_LIST = [
     buildvars.fix,
     buildvars.force,
 
-    project.clone_all_formulas,
+    project.clone_project_formulas,
+    project.clone_all_project_formulas,
 ]
 
 def mk_task_map(task, qualified=True):

--- a/src/taskrunner.py
+++ b/src/taskrunner.py
@@ -109,6 +109,8 @@ DEBUG_TASK_LIST = [
     buildvars.valid,
     buildvars.fix,
     buildvars.force,
+
+    project.clone_all_formulas,
 ]
 
 def mk_task_map(task, qualified=True):


### PR DESCRIPTION
* ~changes salt version to `2018.3.4`~ separate PR
* adds command to clone formula repositories locally. Used for checking formulas for instances of python2-isms and changed states
* adds switch to bootstrap script to cleanly disable installation of python2 in future
* adds python library `docker` so salt can use `docker_*` states

prepares the path for switch away from py2 and salt 2018.3 that uses py3