### PR TITLE
upgrades salt to 2018.3. salt-bootstrap uses py3

### DIFF
--- a/projects/elife.yaml
+++ b/projects/elife.yaml
@@ -1,7 +1,6 @@
 defaults:
     description: defaults for all projects in this file
-    #salt: '2018.3.4' # the version of salt these project use
-    salt: '2017.7.8'
+    salt: '2018.3.4' # the version of salt these project use
     # use false with a subdomain to assign internal addresses only
     domain: elifesciences.org
     # addressing within VPC

--- a/scripts/bootstrap.sh
+++ b/scripts/bootstrap.sh
@@ -108,7 +108,8 @@ if $upgrade_python2; then
         apt-get install python2.7 python2.7-dev -y
 
         # virtualenvs have to be recreated
-        find /srv /opt -depth -type d -name venv -exec rm -rf "{}" \;
+        # lsh@2020-01-23: disabled as no longer necessary. re-enable if anything breaks
+        #find /srv /opt -depth -type d -name venv -exec rm -rf "{}" \;
 
         # install/upgrade pip+setuptools
         apt-get install python-pip python-setuptools --no-install-recommends -y

--- a/scripts/bootstrap.sh
+++ b/scripts/bootstrap.sh
@@ -154,8 +154,7 @@ if ($installing || $upgrading); then
     # -c  Temporary configuration directory
     # -M  Also install master
     # https://github.com/saltstack/salt-bootstrap/blob/develop/bootstrap-salt.sh
-    #sh salt_bootstrap.sh -x python3 -P -F -c /tmp stable "$version"
-    sh salt_bootstrap.sh -P -F -c /tmp stable "$version"
+    sh salt_bootstrap.sh -x python3 -P -F -c /tmp stable "$version"
 else
     echo "Skipping minion bootstrap, found: $(salt-minion --version)"
 fi
@@ -166,8 +165,7 @@ if [ "$install_master" = "true" ]; then
     # salt is not installed or the version installed is old
     if ! (command -v salt-master > /dev/null && salt-master --version | grep "$version"); then
         # master not installed
-        #sh salt_bootstrap.sh -x python3 -P -F -M -c /tmp stable "$version"
-        sh salt_bootstrap.sh -P -F -M -c /tmp stable "$version"
+        sh salt_bootstrap.sh -x python3 -P -F -M -c /tmp stable "$version"
     else
         echo "Skipping master bootstrap, found: $(salt-master --version)"
     fi


### PR DESCRIPTION
follow up PR to python2 removal branch

cc @giorgiosironi 