### PR TITLE
Feature: next-salt alt-config

### DIFF
--- a/projects/elife.yaml
+++ b/projects/elife.yaml
@@ -216,8 +216,8 @@ defaults:
 
         next-salt:
             description: uses the next version of Salt to test formula for problems upgrading. OS agnostic.
+            salt: '2018.3.4'
             ec2:
-                salt: '2018.3.4'
                 masterless: True
 
         1804:

--- a/projects/elife.yaml
+++ b/projects/elife.yaml
@@ -216,8 +216,8 @@ defaults:
 
         next-salt:
             description: uses the next version of Salt to test formula for problems upgrading. OS agnostic.
-            salt: '2018.3.4'
             ec2:
+                salt: '2018.3.4'
                 masterless: True
 
         1804:

--- a/projects/elife.yaml
+++ b/projects/elife.yaml
@@ -214,7 +214,7 @@ defaults:
                 # should be the same as basebox '18.04' and 'standalone18.04' aws-alt configurations
                 ami: ami-0b425589c7bb7663d # bionic, build 20180814, hvm:ebs-ssd
 
-        next-salt:
+        standalone-next-salt:
             description: uses the next version of Salt to test formula for problems upgrading. OS agnostic.
             ec2:
                 salt: '2018.3.4'

--- a/projects/elife.yaml
+++ b/projects/elife.yaml
@@ -213,6 +213,13 @@ defaults:
             ec2:
                 # should be the same as basebox '18.04' and 'standalone18.04' aws-alt configurations
                 ami: ami-0b425589c7bb7663d # bionic, build 20180814, hvm:ebs-ssd
+
+        next-salt:
+            description: uses the next version of Salt to test formula for problems upgrading. OS agnostic.
+            ec2:
+                salt: '2018.3.4'
+                masterless: True
+
         1804:
             description: Ubuntu 18.04 (Bionic)
             ec2: true # explicitly specify an 18.04 ami when 18.04 is no longer the default (2023?)

--- a/scripts/bootstrap.sh
+++ b/scripts/bootstrap.sh
@@ -93,7 +93,7 @@ if ! dpkg -l git; then
 fi
 
 if ($upgrade_python2 || $upgrade_python3 || $install_git); then
-    apt-get update -y
+    apt-get update -y -q
 fi
 
 
@@ -105,14 +105,14 @@ if $upgrade_python2; then
 
     if $elife_depends_on_python2; then
         echo "eLife still has formulas that depend on Python2!"
-        apt-get install python2.7 python2.7-dev -y
+        apt-get install python2.7 python2.7-dev -y -q
 
         # virtualenvs have to be recreated
         #find /srv /opt -depth -type d -name venv -exec rm -rf "{}" \;
 
         # install/upgrade pip+setuptools
-        apt-get install python-pip python-setuptools --no-install-recommends -y
-        python2.7 -m pip install pip setuptools --upgrade
+        apt-get install python-pip python-setuptools --no-install-recommends -y -q
+        python2.7 -m pip install pip setuptools --upgrade --progress-bar off
     fi
 
     # remove flag, if it exists
@@ -126,13 +126,14 @@ if $upgrade_python3; then
     # confold: If conf file modified and the version in the package changed, keep the old version without prompting
     apt-get install \
         python3 python3-dev python3-pip python3-setuptools \
-        -y --no-install-recommends \
+        -y -q --no-install-recommends \
         -o Dpkg::Options::="--force-confdef" -o Dpkg::Options::="--force-confold"
 
+    # --progress-bar off -- this option only available since pip 10.0. 16.04 has pip 8 by default
     python3 -m pip install pip setuptools --upgrade
 
-    # some libraries need to be installed *before* calling Salt
-    python3 -m pip install "docker[tls]==4.1.0"
+    # some Salt states require libraries to be installed before calling highstate
+    python3 -m pip install "docker[tls]==4.1.0" --progress-bar off
 
     # record an entry about when python3 was installed/upgraded
     # presence of this entry is used to skip this section in future, unless forced with a flag
@@ -147,7 +148,7 @@ if $upgrade_python3; then
 fi
 
 if $install_git; then
-    apt-get install git -y
+    apt-get install git -y -q
 fi
 
 

--- a/src/buildercore/bootstrap.py
+++ b/src/buildercore/bootstrap.py
@@ -486,7 +486,15 @@ def update_ec2_stack(stackname, context, concurrency=None, formula_revisions=Non
         # write out environment config (/etc/cfn-info.json) so Salt can read CFN outputs
         write_environment_info(stackname, overwrite=True)
 
+        # bit of a hack, but project config merging doesn't apply to top-level values
+        # in this case we look for an alternate salt version under a project's 'ec2' section
         salt_version = context['project']['salt']
+        alt_salt_version = context['ec2'].get('salt')
+
+        # and we only use it if we're going masterless
+        if alt_salt_version and is_masterless:
+            salt_version = alt_salt_version
+
         install_master_flag = str(is_master or is_masterless).lower() # ll: 'true'
 
         build_vars = bvars.read_from_current_host()


### PR DESCRIPTION
* adds new alt-config 'next-salt' to base config

todo:

- [x] bootstrap script is receiving old version of Salt still.
- [x] hide pip progress bar in this call `python3 -m pip install pip setuptools --upgrade`
- [x] address this `ERROR: requests 2.22.0 has requirement idna<2.9,>=2.5, but you'll have idna 2.0 which is incompatible.` (see log)
