### PR TITLE
Force setuptools compatible with Python 2

### DIFF
--- a/py2-requirements.txt
+++ b/py2-requirements.txt
@@ -23,3 +23,4 @@ requests==2.20.0
 troposphere==2.3.3
 unittest2==1.1.0
 parallel-ssh==1.9.1
+setuptools==44.0.0


### PR DESCRIPTION
After some problems in https://github.com/elifesciences/builder/pull/607

This is not the best way to do this, as a newer setuptools is installed at virtualenv creation and is then downgraded. But it appears to work. More analysis needed.