### PR TITLE
bootstrap, disables --progress-bar param when upgrading pip

### DIFF
--- a/scripts/bootstrap.sh
+++ b/scripts/bootstrap.sh
@@ -120,8 +120,8 @@ fi
 
 if $elife_depends_on_python2; then
     # upgrade pip setuptools, install dockerlib
-    python2.7 -m pip install pip setuptools --upgrade --progress-bar off
-    python2.7 -m pip install "docker[tls]==4.1.0" --progress-bar off
+    python2.7 -m pip install pip setuptools --upgrade
+    python2.7 -m pip install "docker[tls]==4.1.0"
 fi
 
 if $upgrade_python3; then


### PR DESCRIPTION
option is not supported in very early versions of pip.