### PR TITLE
bootstrap, fixes version of setuptools to 44.0 

### DIFF
--- a/scripts/bootstrap.sh
+++ b/scripts/bootstrap.sh
@@ -50,7 +50,7 @@ install_git=false
 # Salt to avoid changing it while it is running
 
 # TODO: remove this block once our python2 dependency is gone
-if ! command -v python2.7; then
+if ! command -v python2.7 || ! python2.7 -m pip; then
     # python2 not found
     upgrade_python2=true
 else

--- a/scripts/bootstrap.sh
+++ b/scripts/bootstrap.sh
@@ -120,7 +120,7 @@ fi
 
 if $elife_depends_on_python2; then
     # upgrade pip setuptools, install dockerlib
-    python2.7 -m pip install pip setuptools --upgrade
+    python2.7 -m pip install pip "setuptools==44.0.0" --upgrade
     python2.7 -m pip install "docker[tls]==4.1.0"
 fi
 


### PR DESCRIPTION
* fixes setuptools at version 44 as 45 does not support py2
* set py2 upgrade flag if py2 'pip' module not found

blocking:

* https://github.com/elifesciences/issues/issues/5391

related to this comment: https://github.com/elifesciences/builder/pull/607#issuecomment-580765621-permalink (ping @giorgiosironi )

just got this in a build failure on master-server:

```

[2020-02-06T04:09:25.873Z] [34.228.156.185] out: if $upgrade_python2; then
[2020-02-06T04:09:25.873Z] [34.228.156.185] out: 
[2020-02-06T04:09:25.873Z] [34.228.156.185] out:     if $elife_depends_on_python2; then
[2020-02-06T04:09:25.873Z] [34.228.156.185] out:         echo "eLife still has formulas that depend on Python2!"
[2020-02-06T04:09:25.873Z] [34.228.156.185] out:         apt-get install python2.7 python2.7-dev -y -q
[2020-02-06T04:09:25.873Z] [34.228.156.185] out: 
[2020-02-06T04:09:25.873Z] [34.228.156.185] out:         # virtualenvs have to be recreated
[2020-02-06T04:09:25.873Z] [34.228.156.185] out:         #find /srv /opt -depth -type d -name venv -exec rm -rf "{}" \;
[2020-02-06T04:09:25.873Z] [34.228.156.185] out: 
[2020-02-06T04:09:25.873Z] [34.228.156.185] out:         # install pip+setuptools
[2020-02-06T04:09:25.873Z] [34.228.156.185] out:         apt-get install python-pip python-setuptools --no-install-recommends -y -q
[2020-02-06T04:09:25.873Z] [34.228.156.185] out:     fi
[2020-02-06T04:09:25.873Z] [34.228.156.185] out: 
[2020-02-06T04:09:25.873Z] [34.228.156.185] out:     # remove flag, if it exists
[2020-02-06T04:09:25.873Z] [34.228.156.185] out:     rm -f /root/upgrade-python.flag
[2020-02-06T04:09:25.873Z] [34.228.156.185] out: fi
[2020-02-06T04:09:25.873Z] [34.228.156.185] out: + false
[2020-02-06T04:09:25.873Z] [34.228.156.185] out: 
[2020-02-06T04:09:25.873Z] [34.228.156.185] out: if $elife_depends_on_python2; then
[2020-02-06T04:09:25.873Z] [34.228.156.185] out:     # upgrade pip setuptools, install dockerlib
[2020-02-06T04:09:25.873Z] [34.228.156.185] out:     python2.7 -m pip install pip setuptools --upgrade
[2020-02-06T04:09:25.873Z] [34.228.156.185] out:     python2.7 -m pip install "docker[tls]==4.1.0"
[2020-02-06T04:09:25.873Z] [34.228.156.185] out: fi
[2020-02-06T04:09:25.873Z] [34.228.156.185] out: + true
[2020-02-06T04:09:25.873Z] [34.228.156.185] out: + python2.7 -m pip install pip setuptools --upgrade
[2020-02-06T04:09:29.105Z] [34.228.156.185] out: DEPRECATION: Python 2.7 reached the end of its life on January 1st, 2020. Please upgrade your Python as Python 2.7 is no longer maintained. A future version of pip will drop support for Python 2.7. More details about Python 2 support in pip, can be found at https://pip.pypa.io/en/latest/development/release-process/#python-2-support
[2020-02-06T04:09:29.105Z] [34.228.156.185] out: WARNING: The directory '/home/ubuntu/.cache/pip' or its parent directory is not owned or is not writable by the current user. The cache has been disabled. Check the permissions and owner of that directory. If executing pip with sudo, you may want sudo's -H flag.
[2020-02-06T04:09:29.656Z] [34.228.156.185] out: Requirement already up-to-date: pip in /usr/local/lib/python2.7/dist-packages (20.0.2)
[2020-02-06T04:09:32.884Z] [34.228.156.185] out: Requirement already up-to-date: setuptools in /usr/local/lib/python2.7/dist-packages (45.1.0)
[2020-02-06T04:09:32.884Z] [34.228.156.185] out: ERROR: Package 'setuptools' requires a different Python: 2.7.12 not in '>=3.5'
```