### PR TITLE
separates re-mastering of a minion from upgrading salt version

### DIFF
--- a/scripts/highstate.sh
+++ b/scripts/highstate.sh
@@ -2,13 +2,18 @@
 set -e # everything must pass
 set -u # no unbound variables
 
-# todo: make this a --dry-run parameter or similar
-just_test=false
+arg1=$1 # --dry-run
 
-if $just_test; then
+dry_run=false
+if [ "$arg1" = "--dry-run" ]; then
+    dry_run=true
+fi
+
+if $dry_run; then
+    echo "Executing salt highstate (testing)"
     sudo salt-call --force-color state.highstate -l info test=True --retcode-passthrough
 else
-    echo "Executing salt highstate (provisioning)"
+    echo "Executing salt highstate"
     log_file=/var/log/salt/salt-highstate-$(date "+%Y-%m-%dT%H:%M:%S").log
     set -o pipefail
     sudo salt-call --force-color state.highstate -l info --retcode-passthrough | tee "$log_file" || {

--- a/scripts/highstate.sh
+++ b/scripts/highstate.sh
@@ -2,15 +2,18 @@
 set -e # everything must pass
 set -u # no unbound variables
 
-# TODO? enabling this will kill any 'stuck' highstate calls
-# killall salt-call
+# todo: make this a --dry-run parameter or similar
+just_test=false
 
-echo "Executing salt highstate (provisioning)"
-log_file=/var/log/salt/salt-highstate-$(date "+%Y-%m-%dT%H:%M:%S").log
-set -o pipefail
-sudo salt-call --force-color state.highstate -l info --retcode-passthrough | tee "$log_file" || {
-    status=$?
-    echo "Error provisioning, state.highstate returned: ${status}"
-    logger "Salt highstate failure: $log_file on $(hostname)"
-    exit $status
-}
+if $just_test; then
+    sudo salt-call --force-color state.highstate -l info test=True --retcode-passthrough
+else
+    echo "Executing salt highstate (provisioning)"
+    log_file=/var/log/salt/salt-highstate-$(date "+%Y-%m-%dT%H:%M:%S").log
+    set -o pipefail
+    sudo salt-call --force-color state.highstate -l info --retcode-passthrough | tee "$log_file" || {
+        status=$?
+        echo "Error provisioning, state.highstate returned: ${status}"
+        logger "Salt highstate failure: $log_file on $(hostname)"
+        exit $status
+    }

--- a/scripts/highstate.sh
+++ b/scripts/highstate.sh
@@ -17,3 +17,4 @@ else
         logger "Salt highstate failure: $log_file on $(hostname)"
         exit $status
     }
+fi

--- a/src/master.py
+++ b/src/master.py
@@ -74,7 +74,7 @@ def _cached_master_ip(master_stackname):
 @requires_aws_stack
 def update_salt(stackname):
     # start the machine if it's stopped
-    # you might also want to acquire a lock so alfred doesn't stop things
+    # you might also want to acquire a lock or turn off automatic shutdowns so alfred doesn't stop things
     cfn._check_want_to_be_running(stackname, autostart=True)
 
     context = context_handler.load_context(stackname)

--- a/src/master.py
+++ b/src/master.py
@@ -103,6 +103,7 @@ def update_salt(stackname):
 
 def update_salt_master(region=None):
     "convenience. update the version of Salt installed on the master-server."
+    region = region or utils.find_region()
     current_master_stackname = core.find_master(region)
     return update_salt(current_master_stackname)
 


### PR DESCRIPTION
* splits `master.remaster` into `master.update_salt` and `remaster`
* adds a `--dry-run` parameter to the `highstate.sh` script used to run highstate on minions. This will not execute any states but will provide feedback if any states are broken or deprecated.
* alters `mater.remaster_all` to accept a list of project names (not *stack* names) to remaster

- [x] review (self)