### PR TITLE
adds 'reports' module for creating lists of things

### DIFF
--- a/projects/elife.yaml
+++ b/projects/elife.yaml
@@ -1057,7 +1057,6 @@ elife-dashboard:
 elife-reporting:
     formula-repo: https://github.com/elifesciences/elife-reporting-formula
     vagrant:
-        box: ubuntu/trusty64 # Ubuntu 14.04, deprecated
         ram: 1024
         ports:
             1333: 80

--- a/src/buildercore/core.py
+++ b/src/buildercore/core.py
@@ -133,10 +133,12 @@ def ec2_instances(state='running'):
     """returns a list of all ec2 instances in given state.
     possible states are 'running' (default), 'stopped', 'terminated', ..."""
     conn = boto_resource('ec2', find_region())
-    
-    filters = [
-        {'Name': 'instance-state-name', 'Values': [state]}
-    ]
+
+    filters = []
+    if state:
+        filters = [
+            {'Name': 'instance-state-name', 'Values': [state]}
+        ]
     qs = conn.instances.filter(Filters=filters)
     result = list(ec2.meta.data for ec2 in qs) # paginated?
     for ec2 in result:

--- a/src/buildercore/core.py
+++ b/src/buildercore/core.py
@@ -142,7 +142,9 @@ def tags2dict(tags):
 def ec2_instances(state='running'):
     """returns a list of all ec2 instances in given state.
     default state is 'running'. `None` is considered 'any state'"""
-    ensure(state is None or state in ALL_EC2_STATES, "unknown ec2 state %r" % state)
+    known_states_str = ", ".join(ALL_EC2_STATES)
+    err_msg = "unknown ec2 state %r; known states: %s and None (all states)" % (state, known_states_str)
+    ensure(state is None or state in ALL_EC2_STATES, err_msg)
 
     conn = boto_resource('ec2', find_region())
 
@@ -627,6 +629,13 @@ def active_stack_names(region):
 def steady_stack_names(region):
     "convenience. returns names of all stacks in a non-transitory state"
     return stack_names(steady_aws_stacks(region))
+
+def adhoc_stack_names(region):
+    "returns the names of all active stacks whose instance name doesn't match any defined environment"
+    active_stack_names(region)
+    raw_project_data = project.files.read_project_file(config.app()['project-locations'][0])
+    print(raw_project_data)
+    # ...
 
 class MultipleRegionsError(EnvironmentError):
     def __init__(self, regions):

--- a/src/buildercore/core.py
+++ b/src/buildercore/core.py
@@ -139,7 +139,7 @@ def tags2dict(tags):
         return {}
     return dict((el['Key'], el['Value']) for el in tags)
 
-def ec2_instances(state='running'):
+def ec2_instance_list(state='running'):
     """returns a list of all ec2 instances in given state.
     default state is 'running'. `None` is considered 'any state'"""
     known_states_str = ", ".join(ALL_EC2_STATES)

--- a/src/buildercore/project/files.py
+++ b/src/buildercore/project/files.py
@@ -8,7 +8,7 @@ import logging
 LOG = logging.getLogger(__name__)
 
 def read_project_file(project_file):
-    "reads the contents of the YAML project file"
+    "reads the contents of the YAML project file (`/path/to/builder/projects/elife.yaml`)."
     return utils.ordered_load(open(project_file, 'r'))
 
 @cached

--- a/src/buildercore/project/files.py
+++ b/src/buildercore/project/files.py
@@ -1,25 +1,19 @@
 import os, copy
 from os.path import join
 from collections import OrderedDict
-
-# from . import core # DONT import core. this module should be relatively independent
 from buildercore import utils
-from buildercore.decorators import testme
 from buildercore.config import CLOUD_EXCLUDING_DEFAULTS_IF_NOT_PRESENT
 from kids.cache import cache as cached
-
 import logging
 LOG = logging.getLogger(__name__)
 
-
-@testme
-def update_project_file(path, value, pdata, project_file):
-    utils.updatein(pdata, path, value, create=True)
-    return pdata
+def read_project_file(project_file):
+    "reads the contents of the YAML project file"
+    return utils.ordered_load(open(project_file, 'r'))
 
 @cached
 def all_projects(project_file):
-    allp = utils.ordered_load(open(project_file))
+    allp = read_project_file(project_file)
     if allp is None:
         return ({}, [])
     assert "defaults" in allp, ("Project file %s is missing a `default` section" % project_file)
@@ -60,7 +54,6 @@ def project_data(pname, project_file):
 
     return pdata
 
-# TODO: make less AWS-specific
 def project_cloud_alt(project_alt_contents, project_base_cloud, global_cloud):
     cloud_alt = OrderedDict()
 

--- a/src/cfn.py
+++ b/src/cfn.py
@@ -1,5 +1,4 @@
 import os
-from distutils.util import strtobool as _strtobool  # pylint: disable=import-error,no-name-in-module
 from pprint import pformat
 import backoff
 from buildercore.command import local, remote, remote_sudo, upload, download, settings, remote_file_exists, CommandException, NetworkError
@@ -16,9 +15,6 @@ from buildercore.utils import lmap, ensure
 
 import logging
 LOG = logging.getLogger(__name__)
-
-def strtobool(x):
-    return x if isinstance(x, bool) else bool(_strtobool(x))
 
 # TODO: move to a lower level if possible
 #@requires_steady_stack
@@ -51,7 +47,7 @@ def ensure_destroyed(stackname):
 def update(stackname, autostart="0", concurrency='serial'):
     """Updates the environment within the stack's ec2 instance.
     does *not* call Cloudformation's `update` command on the stack"""
-    instances = _check_want_to_be_running(stackname, strtobool(autostart))
+    instances = _check_want_to_be_running(stackname, utils.strtobool(autostart))
     if not instances:
         return
     return bootstrap.update_stack(stackname, service_list=['ec2'], concurrency=concurrency)
@@ -285,7 +281,7 @@ def download_file(stackname, path, destination='.', node=None, allow_missing="Fa
 
     Boolean arguments are expressed as strings as this is the idiomatic way of passing them from the command line.
     """
-    allow_missing, use_bootstrap_user = lmap(strtobool, [allow_missing, use_bootstrap_user])
+    allow_missing, use_bootstrap_user = lmap(utils.strtobool, [allow_missing, use_bootstrap_user])
 
     @backoff.on_exception(backoff.expo, NetworkError, max_time=60)
     def _download(path, destination):

--- a/src/cfn.py
+++ b/src/cfn.py
@@ -46,7 +46,7 @@ def ensure_destroyed(stackname):
 @timeit
 def update(stackname, autostart="0", concurrency='serial'):
     """Updates the environment within the stack's ec2 instance.
-    does *not* call Cloudformation's `update` command on the stack"""
+    Does *not* call Cloudformation's `update` command on the stack (see `update_infrastructure`)."""
     instances = _check_want_to_be_running(stackname, utils.strtobool(autostart))
     if not instances:
         return

--- a/src/decorators.py
+++ b/src/decorators.py
@@ -78,7 +78,7 @@ def requires_aws_stack(func):
         if stackname:
             args = args[1:]
             return func(stackname, *args, **kwargs)
-        # TODO: this assumes all stacks have an ec2 instance.
+        # note: this assumes all stacks have an ec2 instance.
         asl = core.active_stack_names(region)
         if not asl:
             raise RuntimeError('\nno AWS stacks *in an active state* exist, cannot continue.')

--- a/src/decorators.py
+++ b/src/decorators.py
@@ -78,7 +78,7 @@ def requires_aws_stack(func):
         if stackname:
             args = args[1:]
             return func(stackname, *args, **kwargs)
-        # TODO: this assumes all stacks have an ec2 instance. 
+        # TODO: this assumes all stacks have an ec2 instance.
         asl = core.active_stack_names(region)
         if not asl:
             raise RuntimeError('\nno AWS stacks *in an active state* exist, cannot continue.')

--- a/src/decorators.py
+++ b/src/decorators.py
@@ -78,6 +78,7 @@ def requires_aws_stack(func):
         if stackname:
             args = args[1:]
             return func(stackname, *args, **kwargs)
+        # TODO: this assumes all stacks have an ec2 instance. 
         asl = core.active_stack_names(region)
         if not asl:
             raise RuntimeError('\nno AWS stacks *in an active state* exist, cannot continue.')

--- a/src/report.py
+++ b/src/report.py
@@ -17,6 +17,7 @@ def sort_by_env(name):
     adhoc = 0 # adhoc/unrecognised names first
     order = {
         'continuumtest': 1,
+        'staging': 1,
         'ci': 2,
         'end2end': 3,
         'prod': 4, # prod last
@@ -63,7 +64,7 @@ def all_formulas():
     # remove any empty values, probably from reading the `defaults` section
     formula_list = filter(None, formula_list)
     # extract just the name from the formula url
-    formula_list = map(lambda url: os.path.basename(url), formula_list)
+    formula_list = map(os.path.basename, formula_list)
     return formula_list
 
 @report
@@ -103,7 +104,7 @@ def all_adhoc_ec2_instances(state='running'):
 
     # extract the names of ec2 instances that are not part of any known environment
     def adhoc_instance(stackname):
-        "predicate, returns True if stackname is in a known environment"
+        "predicate, returns True if stackname is *not* in a known environment"
         try:
             iid = core.parse_stackname(stackname, all_bits=True, idx=True)['instance_id']
             return iid not in env_list

--- a/src/report.py
+++ b/src/report.py
@@ -1,4 +1,5 @@
-from buildercore import core, project
+import os
+from buildercore import core, project, utils as core_utils
 from functools import wraps
 
 def print_list(row_list, checkboxes=True):
@@ -10,23 +11,39 @@ def print_list(row_list, checkboxes=True):
 
 def report(fn):
     @wraps(fn)
-    def _wrapped(checkboxes=True, *args, **kwargs):
+    def _wrapped(checkboxes=True, ordered=True, *args, **kwargs):
         results = fn(*args, **kwargs)
+        if not results:
+            return
+        # TODO: this could be better. ci first, continuumtest next, etc
+        if ordered:
+            results.sort()
         print_list(results, checkboxes)
     return _wrapped
         
 @report
 def all_projects():
+    "a list of *all* projects"
     return project.project_list()
 
 @report
-def all_ec2_projects():
-    pass
-
-@report
-def all_ec2_instances():
-    return [ec2['TagsDict']['Name'] for ec2 in core.ec2_instances(state=None)]
-
-@report
 def all_formulas():
+    "returns a list of all known formulas"
+    formula_url_list = filter(None, list(set(core_utils.shallow_flatten(project.project_formulas().values()))))
+    formula_list = map(lambda url: os.path.basename(url), formula_url_list)
+    return formula_list
+
+@report
+def all_ec2_projects():
+    "all projects that use ec2"
     pass
+
+@report
+def all_ec2_instances(state=None):
+    "all ec2 instances. set `state` to `running` to see all running ec2 instances"
+    return [ec2['TagsDict']['Name'] for ec2 in core.ec2_instances(state=state)]
+
+def all_adhoc_ec2_instances():
+    "all ec2 instances whose instance ID doesn't match a known environment"
+    return all_ec2_instances(state='running')
+    

--- a/src/report.py
+++ b/src/report.py
@@ -1,0 +1,32 @@
+from buildercore import core, project
+from functools import wraps
+
+def print_list(row_list, checkboxes=True):
+    template = "- %s"
+    if checkboxes:
+        template = "- [ ] %s"
+    for row in row_list:
+        print(template % row)
+
+def report(fn):
+    @wraps(fn)
+    def _wrapped(checkboxes=True, *args, **kwargs):
+        results = fn(*args, **kwargs)
+        print_list(results, checkboxes)
+    return _wrapped
+        
+@report
+def all_projects():
+    return project.project_list()
+
+@report
+def all_ec2_projects():
+    pass
+
+@report
+def all_ec2_instances():
+    return [ec2['TagsDict']['Name'] for ec2 in core.ec2_instances(state=None)]
+
+@report
+def all_formulas():
+    pass

--- a/src/taskrunner.py
+++ b/src/taskrunner.py
@@ -49,7 +49,6 @@ TASK_LIST = [
     tasks.repair_cfn_info,
     tasks.repair_context,
     tasks.remove_minion_key,
-    tasks.restart_all_running_ec2,
 
     master.update,
 
@@ -98,8 +97,6 @@ UNQUALIFIED_DEBUG_TASK_LIST = [
 DEBUG_TASK_LIST = [
     aws.rds_snapshots,
     aws.detailed_stack_list,
-
-    tasks.diff_builder_config,
 
     deploy.load_balancer_status,
     deploy.load_balancer_register_all,

--- a/src/taskrunner.py
+++ b/src/taskrunner.py
@@ -1,5 +1,5 @@
 import sys, os, traceback
-import cfn, lifecycle, masterless, vault, aws, metrics, tasks, master, askmaster, buildvars, project, deploy
+import cfn, lifecycle, masterless, vault, aws, metrics, tasks, master, askmaster, buildvars, project, deploy, report
 from buildercore import command
 from decorators import echo_output
 from functools import reduce
@@ -75,6 +75,12 @@ TASK_LIST = [
     vault.token_lookup_accessor,
     vault.token_create,
     vault.token_revoke,
+
+    report.all_projects,
+    report.all_ec2_projects,
+    report.all_ec2_instances,
+    report.all_formulas,
+
 ]
 
 # 'debug' tasks are those that are available when the environment variable BLDR_ROLE is set to 'admin'

--- a/src/taskrunner.py
+++ b/src/taskrunner.py
@@ -80,6 +80,7 @@ TASK_LIST = [
     report.all_ec2_projects,
     report.all_ec2_instances,
     report.all_formulas,
+    report.all_adhoc_ec2_instances,
 
 ]
 

--- a/src/tasks.py
+++ b/src/tasks.py
@@ -3,10 +3,8 @@
 If you find certain 'types' of tasks accumulating, they might be
 better off in their own module. This module really is for stuff
 that has no home."""
-import os
-from buildercore import core, bootstrap, bakery, lifecycle
-from buildercore.command import local
-from utils import confirm, errcho, get_input
+from buildercore import core, bootstrap, bakery
+from utils import confirm, errcho
 from decorators import requires_aws_stack
 from buildercore.core import stack_conn
 from buildercore.context_handler import load_context
@@ -24,26 +22,6 @@ def create_ami(stackname, name=None):
     print(amiid)
     errcho('update project file with new ami %s. these changes must be merged and committed manually' % amiid)
 
-#
-#
-#
-
-def diff_builder_config():
-    "helps keep three"
-    file_sets = [
-        [
-            "./builder-private-example/pillar/elife.sls",
-            "./cloned-projects/builder-base-formula/pillar/elife.sls",
-            "./builder-private/pillar/elife.sls"
-        ],
-        [
-            "./projects/elife.yaml",
-            "./builder-private/projects/elife-private.yaml",
-        ]
-    ]
-    for paths in file_sets:
-        local("meld " + " ".join(paths))
-
 @requires_aws_stack
 def repair_cfn_info(stackname):
     with stack_conn(stackname):
@@ -57,65 +35,3 @@ def repair_context(stackname):
 @requires_aws_stack
 def remove_minion_key(stackname):
     bootstrap.remove_minion_key(stackname)
-
-
-def restart_all_running_ec2(statefile):
-    "restarts all running ec2 instances. multiple nodes are restarted serially and failures prevent the rest of the node from being restarted"
-
-    os.system("touch " + statefile)
-
-    results = core.active_stack_names(core.find_region())
-
-    u1404 = [
-        'api-gateway',
-        'journal',
-        'search',
-        'api-dummy',
-        'medium',
-    ]
-
-    legacy = [
-        'elife-api'
-    ]
-
-    dont_do = u1404 + legacy
-
-    # order not preserved
-    do_first = [
-        'master-server',
-        'bus',
-        'elife-alfred',
-        'elife-bot',
-        'iiif',
-    ]
-
-    pname = lambda stackname: core.parse_stackname(stackname)[0]
-    todo = sorted(results, key=lambda stackname: pname(stackname) in do_first, reverse=True)
-    todo = filter(lambda stackname: pname(stackname) not in dont_do, todo)
-
-    with open(statefile, 'r') as fh:
-        done = fh.read().split('\n')
-
-    with open(statefile, 'a') as fh:
-        LOG.info('writing state to ' + fh.name)
-
-        for stackname in todo:
-            if stackname in done:
-                LOG.info('skipping ' + stackname)
-                continue
-            try:
-                LOG.info('restarting' + stackname)
-                # only restart instances that are currently running
-                # this will skip ci/end2end
-                lifecycle.restart(stackname, initial_states='running')
-                LOG.info('done' + stackname)
-                fh.write(stackname + "\n")
-                fh.flush()
-
-            except BaseException:
-                LOG.exception("unhandled exception restarting %s", stackname)
-                LOG.warn("%s is in an unknown state", stackname)
-                get_input('pausing, any key to continue, ctrl+c to quit')
-
-        print
-        print('wrote state to', fh.name)

--- a/src/tests/test_utils.py
+++ b/src/tests/test_utils.py
@@ -70,3 +70,24 @@ class TestUtils(base.BaseCase):
         rows = [AnObject('lax', 'ci'), AnObject('bot', 'end2end')]
         keys = ['project', 'instance_id']
         self.assertEqual("lax, ci\nbot, end2end", utils.table(rows, keys))
+
+    def test_strtobool(self):
+        true_case_list = [
+            True,
+            1, "1",
+            "y", "yes", "Yes", "YES",
+            "t", "true", "True", "TRUE",
+        ]
+        for true_case in true_case_list:
+            self.assertEqual(True, utils.strtobool(true_case))
+
+        false_case_list = [
+            False,
+            0, "0",
+            "n", "no", "No", "NO",
+            "f", "false", "False", "FALSE"
+        ]
+        for false_case in false_case_list:
+            self.assertEqual(False, utils.strtobool(false_case))
+
+        self.assertRaises(ValueError, utils.strtobool, "this value is neither true nor false")

--- a/src/utils.py
+++ b/src/utils.py
@@ -11,7 +11,7 @@ LOG = logging.getLogger(__name__)
 def strtobool(x):
     """wraps `distutils.util.strtobool` that casts 'yes', 'no', '1', '0', 'true', 'false', etc to
     boolean values, but only if the given value isn't already a boolean"""
-    return x if isinstance(x, bool) else bool(_strtobool(x))
+    return x if isinstance(x, bool) else bool(_strtobool(str(x)))
 
 def rmval(lst, *vals):
     """removes each val in `vals` from `lst`, if it exists.

--- a/src/utils.py
+++ b/src/utils.py
@@ -1,5 +1,6 @@
 import logging
 import os, sys
+from distutils.util import strtobool as _strtobool  # pylint: disable=import-error,no-name-in-module
 from buildercore import config
 from buildercore.utils import second, last, gtpy2
 from buildercore.command import local
@@ -7,9 +8,10 @@ from buildercore import core
 
 LOG = logging.getLogger(__name__)
 
-# totally is assigned :(
-# pylint: disable=global-variable-not-assigned
-CACHE = {}
+def strtobool(x):
+    """wraps `distutils.util.strtobool` that casts 'yes', 'no', '1', '0', 'true', 'false', etc to
+    boolean values, but only if the given value isn't already a boolean"""
+    return x if isinstance(x, bool) else bool(_strtobool(x))
 
 def rmval(lst, *vals):
     """removes each val in `vals` from `lst`, if it exists.


### PR DESCRIPTION
* adds new 'report' module to tasks
* adds 'adhoc ec2' report to find ec2 instances that are not part of any known environment
* emits lists as github-flavoured markdown items with optional checkboxes
* adds 'ec2_instance_list' to `buildercore.core` that returns ec2 instance data as dictionaries
* removes two large unused tasks (`tasks.diff_builder_config` and `tasks.restart_all_running_ec2`) to bump test coverage

- [x] review (self)