### PR TITLE
iiif, api-gateway, disables fastly for altbuilds

### DIFF
--- a/projects/elife.yaml
+++ b/projects/elife.yaml
@@ -455,6 +455,8 @@ api-gateway:
             fastly: false
         s1804:
             fastly: false
+        snsalt:
+            fastly: false
         end2end: {}
         continuumtest:
             fastly:
@@ -1497,6 +1499,8 @@ iiif:
         s1604:
             fastly: false
         s1804:
+            fastly: false
+        snsalt:
             fastly: false
         # for testing new versions
         ci:


### PR DESCRIPTION
* disables `fastly` configuration in `snsalt` alt-config builds for iiif and api-gateway

regarding this failing build:
https://github.com/elifesciences/api-gateway-formula/pull/15

cc @giorgiosironi 