### PR TITLE
Do not log error on private key in Jenkins builds

### DIFF
--- a/src/buildercore/core.py
+++ b/src/buildercore/core.py
@@ -285,8 +285,7 @@ def _ec2_connection_params(stackname, username, **kwargs):
         if os.path.exists(pem):
             params['key_filename'] = pem
         else:
-            LOG.error("private key for the bootstrap user for this host does not exist. I looked here: %s" % pem)
-            #raise RuntimeError("private key for the bootstrap user for this host does not exist. I looked here: %s" % pem)
+            LOG.info("private key for the bootstrap user for this host is not present locally (%s); will not override ~/.ssh with it." % pem)
     params.update(kwargs)
     return params
 


### PR DESCRIPTION
Jenkins routinely logs this:
```
14:53:41  ERROR - buildercore.core - private key for the bootstrap user for this host does not exist. I looked here: /ext/srv/builder/.cfn/keypairs/annotations--end2end.pem
```
(e.g. https://alfred.elifesciences.org/job/test-elife-spectrum/377/console)

It is not an error though: the user keys from `builder-private` are provisioned to all EC2 nodes on the `ubuntu` and `elife` user. Jenkins succeeds in connecting with the default key from `~/.ssh`.