### PR TITLE
search shouldn't listen for updates to subjects

### DIFF
--- a/projects/elife.yaml
+++ b/projects/elife.yaml
@@ -1235,7 +1235,6 @@ search:
                 subscriptions:
                     - bus-articles--{instance}
                     - bus-podcast-episodes--{instance}
-                    - bus-subjects--{instance}
                     - bus-collections--{instance}
                     - bus-interviews--{instance}
                     - bus-blog-articles--{instance}


### PR DESCRIPTION
Discovered while deploying https://github.com/elifesciences/issues/issues/4608

We know `search` doesn't index `subject`s as they are not in the possible results.

https://github.com/elifesciences/search/blob/856d3931264783e78ed120a79b76d6ced4cca27c/src/Search/GearmanTransformer.php#L21-L28 shows the mapping of types for bus messages coming in, and there's no mention of `subject`.

When a `subject` message is in the queue, its processing fails even before that:
https://github.com/elifesciences/bus-sdk-php/blob/3af0739fac110e79ea7f21aadf8d17b891f3b918/src/Queue/BasicTransformer.php#L57