### PR TITLE
Salt 3000 upgrade branch

### DIFF
--- a/projects/elife.yaml
+++ b/projects/elife.yaml
@@ -222,7 +222,7 @@ defaults:
         snsalt:
             description: uses the next version of Salt to test formula for problems upgrading. OS agnostic.
             ec2:
-                salt: '3000.1'
+                salt: '3000.3'
                 masterless: True
 
         1804:

--- a/projects/elife.yaml
+++ b/projects/elife.yaml
@@ -222,7 +222,7 @@ defaults:
         snsalt:
             description: uses the next version of Salt to test formula for problems upgrading. OS agnostic.
             ec2:
-                salt: '2019.2.4'
+                salt: '3000.1'
                 masterless: True
 
         1804:

--- a/src/buildvars.py
+++ b/src/buildvars.py
@@ -14,6 +14,40 @@ LOG = logging.getLogger(__name__)
 
 OLD, ABBREV, FULL = 'old', 'abbrev', 'full'
 
+def _retrieve_build_vars():
+    """wrapper around `read_from_current_host` with integrity checks. returns buildvars for the current instance.
+    raises AssertionError on bad data."""
+    try:
+        buildvars = read_from_current_host()
+        LOG.debug('build vars: %s', buildvars)
+
+        # buildvars exist
+        ensure(isinstance(buildvars, dict), 'build vars not found (%s). use `./bldr buildvars.fix` to attempt to fix this.' % buildvars)
+
+        # nothing important is missing
+        missing_keys = core_utils.missingkeys(buildvars, ['stackname', 'instance_id', 'branch', 'revision'])
+        ensure(
+            len(missing_keys) == 0,
+            'build vars are not valid: missing keys %s. use `./bldr buildvars.fix` to attempt to fix this.' % missing_keys
+        )
+
+        return buildvars
+
+    except (ValueError, AssertionError) as ex:
+        LOG.exception(ex)
+        raise
+
+def _update_remote_bvars(stackname, buildvars):
+    LOG.info('updating %r with new vars %r', stackname, buildvars)
+    encoded = encode_bvars(buildvars)
+    fid = core_utils.ymd(fmt='%Y%m%d%H%M%S')
+    # make a backup
+    remote_sudo('if [ -f /etc/build-vars.json.b64 ]; then cp /etc/build-vars.json.b64 /tmp/build-vars.json.b64.%s; fi;' % fid)
+    upload(StringIO(encoded), "/etc/build-vars.json.b64", use_sudo=True)
+    LOG.info("%r updated. backup written to /tmp/build-vars.json.b64.%s", stackname, fid)
+
+#
+
 @requires_aws_stack
 def switch_revision(stackname, revision=None, concurrency=None):
     if revision is None:
@@ -41,29 +75,6 @@ def read(stackname):
 def valid(stackname):
     return stack_all_ec2_nodes(stackname, lambda: pprint(_retrieve_build_vars()), username=BOOTSTRAP_USER)
 
-def _retrieve_build_vars():
-    """wrapper around `read_from_current_host` with integrity checks. returns buildvars for the current instance.
-    raises AssertionError on bad data."""
-    try:
-        buildvars = read_from_current_host()
-        LOG.debug('build vars: %s', buildvars)
-
-        # buildvars exist
-        ensure(isinstance(buildvars, dict), 'build vars not found (%s). use `./bldr buildvars.fix` to attempt to fix this.' % buildvars)
-
-        # nothing important is missing
-        missing_keys = core_utils.missingkeys(buildvars, ['stackname', 'instance_id', 'branch', 'revision'])
-        ensure(
-            len(missing_keys) == 0,
-            'build vars are not valid: missing keys %s. use `./bldr buildvars.fix` to attempt to fix this.' % missing_keys
-        )
-
-        return buildvars
-
-    except (ValueError, AssertionError) as ex:
-        LOG.exception(ex)
-        raise
-
 @requires_aws_stack
 def fix(stackname):
     def _fix_single_ec2_node(stackname):
@@ -87,6 +98,9 @@ def fix(stackname):
 def force(stackname, field, value):
     "replace a specific key with a new value in the buildvars for all ec2 instances in stack"
     def _force_single_ec2_node():
+        # do not validate build vars.
+        # this way it can be used to repair buildvars when they are missing some field.
+        #buildvars = _validate()
         buildvars = read_from_current_host()
 
         new_vars = buildvars.copy()
@@ -95,22 +109,6 @@ def force(stackname, field, value):
         LOG.info("updated bvars %s", new_vars)
 
     stack_all_ec2_nodes(stackname, _force_single_ec2_node, username=BOOTSTRAP_USER)
-
-def _update_remote_bvars(stackname, buildvars):
-    LOG.info('updating %r with new vars %r', stackname, buildvars)
-    # not all projects have a 'revision'
-    #ensure(core_utils.hasallkeys(buildvars, ['revision']), "buildvars missing key 'revision'")
-
-    encoded = encode_bvars(buildvars)
-    fid = core_utils.ymd(fmt='%Y%m%d%H%M%S')
-    # make a backup
-    remote_sudo('if [ -f /etc/build-vars.json.b64 ]; then cp /etc/build-vars.json.b64 /tmp/build-vars.json.b64.%s; fi;' % fid)
-    upload(StringIO(encoded), "/etc/build-vars.json.b64", use_sudo=True)
-    LOG.info("%r updated", stackname)
-
-#
-#
-#
 
 @requires_aws_stack
 def refresh(stackname, context=None):
@@ -141,8 +139,9 @@ def refresh(stackname, context=None):
         new_buildvars['revision'] = old_buildvars.get('revision') # TODO: is this still necessary?
         _update_remote_bvars(stackname, new_buildvars)
 
-    # lsh@2019-06: cfn.update_infrastructure fails to run highstate on new ec2 instance if keypair not present,
-    # it prompts for a password for the deploy user. prompts when executing in parallel cause operation to fail
+    # lsh@2019-06: cfn.update_infrastructure fails to run highstate on new (unvisited? not the instance author?)
+    # ec2 instance if keypair not present, it prompts for a password for the deploy user. prompts when executing
+    # in parallel cause operation to fail.
     keypair.download_from_s3(stackname, die_if_exists=False)
 
     stack_all_ec2_nodes(stackname, _refresh_buildvars, username=BOOTSTRAP_USER)

--- a/src/master.py
+++ b/src/master.py
@@ -93,6 +93,17 @@ def update_salt(stackname):
     LOG.info("updating context")
     context_handler.write_context(stackname, context)
 
+    # "buildvars are essentially a full copy of the context; if there is an update of infrastructure pending,
+    # we are propagating the new context to the instance without necessarily having created/updated/destroyed
+    # that infrastructure. Since the formulas extensively refer to buildvars to decide what to do,
+    # I see this optimization as unsafe."
+    # - Giorgio, 2019-03-22
+    # - https://github.com/elifesciences/builder/pull/489/files#r268079733
+
+    # this change managed to slip around review and should be 
+    # revisited before next Salt upgrade.
+    # todo: update just the salt version in the stack's *current context*
+    
     LOG.info("updating buildvars")
     buildvars.refresh(stackname, context)
 

--- a/src/master.py
+++ b/src/master.py
@@ -100,10 +100,10 @@ def update_salt(stackname):
     # - Giorgio, 2019-03-22
     # - https://github.com/elifesciences/builder/pull/489/files#r268079733
 
-    # this change managed to slip around review and should be 
+    # this change managed to slip around review and should be
     # revisited before next Salt upgrade.
     # todo: update just the salt version in the stack's *current context*
-    
+
     LOG.info("updating buildvars")
     buildvars.refresh(stackname, context)
 


### PR DESCRIPTION
builder doesn't need it's own special branch for the Salt 3000 upgrade, but I've re-discovered [an unsafe operation](https://github.com/elifesciences/builder/pull/489/files#r268079733) that slipped past code review and it should be dealt with for the next Salt upgrade.
