### PR TITLE
Increase max-size of flux-test-cluster

### DIFF
--- a/projects/elife.yaml
+++ b/projects/elife.yaml
@@ -2047,7 +2047,7 @@ kubernetes-aws:
                 worker:
                     type: t2.large    
                     max-size: 6
-                    desired-capacity: 3
+                    desired-capacity: 6
                 # since helm: is not installed, this will only add AWS resources
                 # but not the ExternalDNS chart release
                 external-dns:

--- a/projects/elife.yaml
+++ b/projects/elife.yaml
@@ -2046,7 +2046,7 @@ kubernetes-aws:
             eks:
                 worker:
                     type: t2.large    
-                    max-size: 3
+                    max-size: 6
                     desired-capacity: 3
                 # since helm: is not installed, this will only add AWS resources
                 # but not the ExternalDNS chart release


### PR DESCRIPTION
Sciencebeam is resource hungry.

Looking at the builder code we are using a `aws_autoscaling_group`. If I understand correctly this requires additional tooling to actually autoscale: https://docs.aws.amazon.com/eks/latest/userguide/cluster-autoscaler.html

There is also a `aws_eks_node_group`. And if we start looking into autoscaling we might want to also look into using spot instances: https://aws.amazon.com/blogs/compute/run-your-kubernetes-workloads-on-amazon-ec2-spot-instances-with-amazon-eks/

There is also the fargate/fargate-spot offering to consider.