### PR TITLE
Upgrade flux-test cluster to k8s 1.15

### DIFF
--- a/projects/elife.yaml
+++ b/projects/elife.yaml
@@ -2044,6 +2044,7 @@ kubernetes-aws:
         flux-test:
             ec2: false
             eks:
+                version: 1.15
                 worker:
                     type: t2.large    
                     max-size: 6


### PR DESCRIPTION
Need to upgrade one minor version at a time according to aws docs.