### PR TITLE
increase flux-test cluster workers to 7

### DIFF
--- a/projects/elife.yaml
+++ b/projects/elife.yaml
@@ -2046,8 +2046,8 @@ kubernetes-aws:
             eks:
                 worker:
                     type: t2.large    
-                    max-size: 6
-                    desired-capacity: 6
+                    max-size: 7
+                    desired-capacity: 7
                 # since helm: is not installed, this will only add AWS resources
                 # but not the ExternalDNS chart release
                 external-dns:


### PR DESCRIPTION
We need headroom to update nodes.

Can you please run this using `bldr` @lsh-0? The following failed for me, but not for @giorgiosironi so we are looking for more datapoints.

Command that fails for me: `./bldr update_infrastructure:kubernetes-aws--flux-test`

We were only able to isolate it to an auth issue during `terraform refresh` of the aws config_map:

```
2020-06-23T15:47:43.053+0100 [DEBUG] plugin.terraform-provider-kubernetes_v1.5.2_x4: 2020/06/23 15:47:43 [DEBUG] Received error: &errors.StatusError{ErrStatus:v1.Status{TypeMeta
:v1.TypeMeta{Kind:"", APIVersion:""}, ListMeta:v1.ListMeta{SelfLink:"", ResourceVersion:"", Continue:""}, Status:"Failure", Message:"Unauthorized", Reason:"Unauthorized", Detail
s:(*v1.StatusDetails)(nil), Code:401}}

Error: Error refreshing state: 1 error occurred:
        * kubernetes_config_map.aws_auth: 1 error occurred:
        * kubernetes_config_map.aws_auth: kubernetes_config_map.aws_auth: Unauthorized
```

Happy to create a ticket for this once we know if it works for you or not.