### PR TITLE
logging, tweaks to quieten certain loggers

### DIFF
--- a/src/buildercore/s3.py
+++ b/src/buildercore/s3.py
@@ -37,7 +37,7 @@ def write(key, something, overwrite=False):
     if exists(key) and not overwrite:
         raise KeyError("key %r exists and overwrite==False. refusing to overwrite." % key)
     k = builder_bucket().Object(key)
-    LOG.info("writing key %r", key, extra={'key': key})
+    LOG.debug("writing key %r", key, extra={'key': key})
 
     # http://boto3.readthedocs.io/en/latest/reference/services/s3.html#S3.Object.put
     if isstr(something):
@@ -63,7 +63,7 @@ def delete(key):
         raise ValueError(msg)
     if not exists(key):
         return True
-    LOG.info("deleting key %s", key, extra={'key': key})
+    LOG.debug("deleting key %s", key, extra={'key': key})
     k = builder_bucket().Object(key)
     k.delete()
     # http://boto3.readthedocs.io/en/latest/reference/services/s3.html#S3.Object.wait_until_not_exists
@@ -83,7 +83,7 @@ def delete_contents(prefix):
     validate_prefix(prefix)
     # TODO: optimisation here: http://boto3.readthedocs.io/en/latest/reference/services/s3.html#S3.Bucket.delete_objects
     for key in builder_bucket().objects.filter(Prefix=prefix):
-        LOG.info("deleting key %s", key, extra={'key': key})
+        LOG.debug("deleting key %s", key, extra={'key': key})
         key.delete() # not delete(key) ?
 
 def listing(prefix):
@@ -98,6 +98,6 @@ def download(key, output_path, overwrite=False):
     if not overwrite:
         ensure(not os.path.exists(output_path), "given output path exists, will not overwrite: %r" % output_path)
     ensure(exists(key), "key %r not found in bucket %r" % (key, config.BUILDER_BUCKET))
-    LOG.info("downloading key %s", key, extra={'key': key})
+    LOG.debug("downloading key %s", key, extra={'key': key})
     builder_bucket().Object(key).download_file(output_path)
     return output_path

--- a/src/cfn.py
+++ b/src/cfn.py
@@ -249,6 +249,7 @@ def _check_want_to_be_running(stackname, autostart=False):
 
 @requires_aws_stack
 def ssh(stackname, node=None, username=DEPLOY_USER):
+    LOG.info("looking for running instances ...")
     instances = _check_want_to_be_running(stackname)
     if not instances:
         return

--- a/src/taskrunner.py
+++ b/src/taskrunner.py
@@ -2,6 +2,10 @@
 from buildercore import threadbare
 assert threadbare
 
+# import config early so logging can be set properly
+from buildercore import config
+assert config
+
 import sys, os, traceback
 import cfn, lifecycle, masterless, vault, aws, metrics, tasks, master, askmaster, buildvars, project, deploy, report
 from buildercore import command


### PR DESCRIPTION
- [ ] unhelpful 'debug' noise is pushed down to debug level
- [ ] stderr handler only prints 'info' and above log messages
- [ ] file handler still captures 'debug' and above log messages
- [ ] `./logs/app.log` is rotated at a certain file size