### PR TITLE
disables python3 build

### DIFF
--- a/Dockerfile.py3
+++ b/Dockerfile.py3
@@ -9,19 +9,20 @@ RUN apk add --no-cache \
     cmake \
     zlib-dev
 
-COPY requirements.txt /requirements.txt
-
 RUN apk add --no-cache --virtual build-deps \
     curl \
     gcc \
-    make \
-    && \
-    curl https://bootstrap.pypa.io/get-pip.py -o get-pip.py && \
+    make
+
+RUN curl https://bootstrap.pypa.io/get-pip.py -o get-pip.py && \
     python get-pip.py pip==9.0.2 && \
     pip install virtualenv && \
-    mkdir /venv && \
-    virtualenv --python=python3 /venv && \
-    /venv/bin/pip install -r /requirements.txt && \
-    apk del build-deps
+    virtualenv --python=python3 /venv 
+    
+COPY requirements.txt /requirements.txt
+
+RUN /venv/bin/pip install -r /requirements.txt
+
+RUN apk del build-deps
 
 CMD /venv/bin/python

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -22,7 +22,8 @@ elifePipeline {
     }
 
     lock('builder') {
-        def pythons = ['py27', 'py3']
+        //def pythons = ['py27', 'py3']
+        def pythons = ['py27']
         def majorVersions = [2, 3]
         def actions = [:]
         for (int i = 0; i < pythons.size(); i++) {


### PR DESCRIPTION
no quick fix for it at the moment

ref:

```
Traceback (most recent call last):
  File "/venv/lib/python3.5/site-packages/fabric/network.py", line 21, in <module>
    import paramiko as ssh
  File "/venv/lib/python3.5/site-packages/paramiko/__init__.py", line 22, in <module>
    from paramiko.transport import SecurityOptions, Transport
  File "/venv/lib/python3.5/site-packages/paramiko/transport.py", line 129, in <module>
    class Transport(threading.Thread, ClosingContextManager):
  File "/venv/lib/python3.5/site-packages/paramiko/transport.py", line 190, in Transport
    if KexCurve25519.is_available():
  File "/venv/lib/python3.5/site-packages/paramiko/kex_curve25519.py", line 30, in is_available
    X25519PrivateKey.generate()
  File "/venv/lib/python3.5/site-packages/cryptography/hazmat/primitives/asymmetric/x25519.py", line 39, in generate
    from cryptography.hazmat.backends.openssl.backend import backend
  File "/venv/lib/python3.5/site-packages/cryptography/hazmat/backends/openssl/__init__.py", line 7, in <module>
    from cryptography.hazmat.backends.openssl.backend import backend
  File "/venv/lib/python3.5/site-packages/cryptography/hazmat/backends/openssl/backend.py", line 109, in <module>
    from cryptography.hazmat.bindings.openssl import binding
  File "/venv/lib/python3.5/site-packages/cryptography/hazmat/bindings/openssl/binding.py", line 14, in <module>
    from cryptography.hazmat.bindings._openssl import ffi, lib
ImportError: Error relocating /venv/lib/python3.5/site-packages/cryptography/hazmat/bindings/_openssl.abi3.so: DTLS_client_method: symbol not found

There was a problem importing our SSH library (see traceback above).
Please make sure all dependencies are installed and importable.
```