### PR TITLE
python3, re-enable py3 build

### DIFF
--- a/Dockerfile.py3
+++ b/Dockerfile.py3
@@ -1,4 +1,4 @@
-FROM python:3.5-alpine3.8
+FROM python:3.5-alpine3.12
 
 # cmake + zlib-dev for parallel-ssh dependencies
 # paramiko is pure python and never needed it

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -22,8 +22,7 @@ elifePipeline {
     }
 
     lock('builder') {
-        //def pythons = ['py27', 'py3']
-        def pythons = ['py27']
+        def pythons = ['py27', 'py3']
         def majorVersions = [2, 3]
         def actions = [:]
         for (int i = 0; i < pythons.size(); i++) {


### PR DESCRIPTION
the python3 docker build is failing and had to be disabled to unblock other work.