### PR TITLE
fixes issue 5918, threadbare and fabric ssh behaviour.

### DIFF
--- a/src/cfn.py
+++ b/src/cfn.py
@@ -249,7 +249,7 @@ def _check_want_to_be_running(stackname, autostart=False):
 
 def _interactive_ssh(username, public_ip, private_key):
     try:
-        command = "ssh -o \"ConnectionAttempts 3\" %s@%s -i %s" % (username, public_ip, USER_PRIVATE_KEY)
+        command = "ssh -o \"ConnectionAttempts 3\" %s@%s -i %s" % (username, public_ip, private_key)
         return local(command)
     except CommandException as e:
         LOG.warn(e)

--- a/src/tests/test_cfn.py
+++ b/src/tests/test_cfn.py
@@ -18,7 +18,7 @@ class TestCfn(base.BaseCase):
     def test_ssh_task(self, find_ec2_instances, load_context, active_stack_names, local):
         self._dummy_instance_is_active(find_ec2_instances, load_context, active_stack_names)
         ssh('dummy1--prod')
-        local.assert_called_with('ssh elife@54.54.54.54 -i ~/.ssh/id_rsa')
+        local.assert_called_with('ssh -o "ConnectionAttempts 3" elife@54.54.54.54 -i ~/.ssh/id_rsa')
 
     @patch('cfn.local')
     @patch('buildercore.core.active_stack_names')
@@ -28,7 +28,7 @@ class TestCfn(base.BaseCase):
         self._dummy_instance_is_active(find_ec2_instances, load_context, active_stack_names)
         owner_ssh('dummy1--prod')
         (args, _) = local.call_args
-        self.assertRegex(args[0], 'ssh ubuntu@54.54.54.54 -i .+/.cfn/keypairs/dummy1--prod.pem')
+        self.assertRegex(args[0], 'ssh -o "ConnectionAttempts 3" ubuntu@54.54.54.54 -i .+/.cfn/keypairs/dummy1--prod.pem')
 
     # all non-interactive cases
     def test_generate_stack_from_input(self):


### PR DESCRIPTION
when starting and immediately connecting to an ec2 instance, threadbare fails with an ssh error (retcode 255) while fabric connects fine. Adding several connection attempts appear to fix this. Either threadbare is quicker off the mark than fabric and dies before it's available, or fabric 1.x has connection retry built-in