### PR TITLE
api-dummy, default to t2.small

### DIFF
--- a/projects/elife.yaml
+++ b/projects/elife.yaml
@@ -1150,14 +1150,14 @@ api-dummy:
     repo: https://github.com/elifesciences/api-dummy
     formula-repo: https://github.com/elifesciences/api-dummy-formula
     aws:
-        type: t2.micro
         ports:
             - 22
             - 443
             - 80
     aws-alt:
-        snsalt:
-            type: t2.small
+        # 2020-09-21: todo, remove when api-dummy--demo is removed
+        demo:
+            type: t2.micro
     vagrant:
         ports:
             1242: 80


### PR DESCRIPTION
`ci` takes an age to complete and inevitably fails with some memory issue. 

Don't think we can get away with anything less than a t2.small with Ubuntu 18.0+ anymore.