### PR TITLE
command, 'env' access is now via a function call rather than dict

### DIFF
--- a/src/buildercore/command.py
+++ b/src/buildercore/command.py
@@ -79,7 +79,14 @@ def fab_api_settings_wrapper(*args, **kwargs):
 
 #
 
-env = api(fab_api.env, threadbare.state.ENV)
+# lsh@2020-12-10: last minute change to how `env` is accessed.
+# worker processes during multiprocessing seem to hang on to old imported references of `env`.
+# this means `buildercore.command.env` is missing values, but `buildercore.threadbare.state.ENV` is fine.
+# force proper reference by enclosing in a function.
+#env = api(fab_api.env, threadbare.state.ENV)
+def env(key=None):
+    _env = api(fab_api.env, threadbare.state.ENV)
+    return _env[key] if key is not None else _env
 
 local = api(fab_api_results_wrapper(fab_api.local), threadbare.operations.local)
 execute = api(fab_api.execute, threadbare.execute.execute_with_hosts)

--- a/src/buildercore/command.py
+++ b/src/buildercore/command.py
@@ -85,6 +85,8 @@ def fab_api_settings_wrapper(*args, **kwargs):
 # force proper reference by enclosing in a function.
 #env = api(fab_api.env, threadbare.state.ENV)
 def env(key=None):
+    """function for accessing the globally shared and mutable 'env' dictionary.
+    When called without a `key` it returns the whole dictionary."""
     _env = api(fab_api.env, threadbare.state.ENV)
     return _env[key] if key is not None else _env
 

--- a/src/buildercore/core.py
+++ b/src/buildercore/core.py
@@ -321,7 +321,7 @@ def all_node_params(stackname):
     # TODO: default copied from stack_all_ec2_nodes, but not the most robust probably
     params = _ec2_connection_params(stackname, config.DEPLOY_USER)
 
-    # custom for builder, these are available inside workfn as `command.env['public_ips']`
+    # custom for builder, these are available inside workfn as `command.env('public_ips')`
     params.update({
         'stackname': stackname,
         'public_ips': public_ips,
@@ -351,7 +351,7 @@ def stack_all_ec2_nodes(stackname, workfn, username=config.DEPLOY_USER, concurre
     params = _ec2_connection_params(stackname, username)
     params.update(kwargs)
 
-    # custom for builder, these are available inside workfn as `command.env['public_ips']`
+    # custom for builder, these are available inside workfn as `command.env('public_ips')`
     params.update({
         'stackname': stackname,
         'public_ips': public_ips,
@@ -423,11 +423,11 @@ def current_ec2_node_id():
 
     Sample value: 'i-0553487b4b6916bc9'"""
 
-    ensure(env['host_string'] is not None, "This is supposed to be called with settings for connecting to an EC2 instance")
-    current_public_ip = env['host_string']
+    ensure('host_string' in env() and env('host_string') is not None, "This is supposed to be called with settings for connecting to an EC2 instance")
+    current_public_ip = env('host_string')
 
-    ensure('public_ips' in env, "This is supposed to be called by stack_all_ec2_nodes, which provides the correct configuration")
-    matching_instance_ids = [instance_id for (instance_id, public_ip) in env['public_ips'].items() if current_public_ip == public_ip]
+    ensure('public_ips' in env(), "This is supposed to be called by stack_all_ec2_nodes, which provides the correct configuration")
+    matching_instance_ids = [instance_id for (instance_id, public_ip) in env('public_ips').items() if current_public_ip == public_ip]
 
     ensure(len(matching_instance_ids) == 1, "Too many instance ids (%s) pointing to this ip (%s)" % (matching_instance_ids, current_public_ip))
     return matching_instance_ids[0]
@@ -437,20 +437,20 @@ def current_node_id():
 
     Returns a number from 1 to N (usually a small number, like 2) indicating how the current node has been numbered on creation to distinguish it from the others"""
     ec2_id = current_ec2_node_id()
-    ensure(ec2_id in env['nodes'], "Can't find %s in %s node map" % (ec2_id, env['nodes']))
-    return env['nodes'][ec2_id]
+    ensure(ec2_id in env('nodes'), "Can't find %s in %s node map" % (ec2_id, env('nodes')))
+    return env('nodes')[ec2_id]
 
 def current_ip():
     """Assumes it is called inside the 'workfn' of a 'stack_all_ec2_nodes'.
 
     Returns the ip address used to access the current host, e.g. '54.243.19.153'"""
-    return env['host_string']
+    return env('host_string')
 
 def current_stackname():
     """Assumes it is called inside the 'workfn' of a 'stack_all_ec2_nodes'.
 
     Returns the name of the stack the task is working on, e.g. 'journal--end2end'"""
-    return env['stackname']
+    return env('stackname')
 
 #
 # stackname wrangling

--- a/src/buildercore/lifecycle.py
+++ b/src/buildercore/lifecycle.py
@@ -86,7 +86,7 @@ def restart(stackname, initial_states='pending|running|stopping|stopped'):
         raise
 
 def start(stackname):
-    "Puts all EC2 nodes of stackname into the 'started' state. Idempotent"
+    "Puts all EC2 nodes and RDS instances of given `stackname` into the 'started' state. Idempotent"
 
     context = load_context(stackname)
 
@@ -345,7 +345,7 @@ def _select_nodes_with_state(interesting_state, states):
     return [instance_id for (instance_id, state) in states.items() if state == interesting_state]
 
 def _ec2_nodes_states(stackname, node_ids=None):
-    """dictionary from instance id to a string state.
+    """returns a dictionary of instance-id to a string state.
     e.g. {'i-6f727961': 'stopped'}"""
 
     def _by_node_name(ec2_data):

--- a/src/buildercore/lifecycle.py
+++ b/src/buildercore/lifecycle.py
@@ -86,7 +86,7 @@ def restart(stackname, initial_states='pending|running|stopping|stopped'):
         raise
 
 def start(stackname):
-    "Puts all EC2 nodes and RDS instances of given `stackname` into the 'started' state. Idempotent"
+    "Puts all EC2 nodes and RDS instances for given `stackname` into the 'started' state. Idempotent"
 
     context = load_context(stackname)
 
@@ -345,8 +345,8 @@ def _select_nodes_with_state(interesting_state, states):
     return [instance_id for (instance_id, state) in states.items() if state == interesting_state]
 
 def _ec2_nodes_states(stackname, node_ids=None):
-    """returns a dictionary of instance-id to a string state.
-    e.g. {'i-6f727961': 'stopped'}"""
+    """returns a dictionary of ec2 `instance-id` => state.
+    for example: {'i-6f727961': 'stopped'}"""
 
     def _by_node_name(ec2_data):
         "{'lax--end2end--1': [old_terminated_ec2, current_ec2]}"

--- a/src/buildercore/threadbare/execute.py
+++ b/src/buildercore/threadbare/execute.py
@@ -1,3 +1,4 @@
+import traceback
 import copy
 from multiprocessing import Process, Queue
 import time
@@ -51,7 +52,6 @@ def _parallel_execution_worker_wrapper(env, worker_func, name, queue):
         result = worker_func()
         queue.put({"name": name, "result": result})
     except BaseException as unhandled_exception:
-        import traceback
         traceback.print_exc()
 
         # "Note that exit handlers and finally clauses, etc., will not be executed."

--- a/src/buildercore/threadbare/execute.py
+++ b/src/buildercore/threadbare/execute.py
@@ -51,9 +51,8 @@ def _parallel_execution_worker_wrapper(env, worker_func, name, queue):
         result = worker_func()
         queue.put({"name": name, "result": result})
     except BaseException as unhandled_exception:
-        # kept for debugging
-        # import traceback
-        # traceback.print_exc()
+        import traceback
+        traceback.print_exc()
 
         # "Note that exit handlers and finally clauses, etc., will not be executed."
         # - https://docs.python.org/2/library/multiprocessing.html#multiprocessing.Process.terminate
@@ -231,7 +230,7 @@ def execute_with_hosts(
     """convenience wrapper around `execute`. calls `execute` on given `func` for each host in `hosts`.
     The host is available within the worker function's `env` as `host_string`."""
     host_list = hosts or state.ENV.get("hosts") or []
-    assert isinstance(host_list, list), "hosts must be a list"
+    assert isinstance(host_list, list) and host_list, "'hosts' must be a non-empty list"
     # Fabric may know about many hosts ('all_hosts') but only be acting upon a subset of them ('hosts')
     # - https://github.com/mathiasertl/fabric/blob/master/sites/docs/usage/env.rst#all_hosts
     # set here:


### PR DESCRIPTION
during multiprocessing there is a case where an indirect reference to the state isn't updated.

- [x] review