### PR TITLE
Editor processes notifications

### DIFF
--- a/projects/elife.yaml
+++ b/projects/elife.yaml
@@ -1704,9 +1704,11 @@ elife-libero-editor:
         ec2: false
         s3:
             "{instance}-elife-libero-editor": {}
-            "elife-production-processes":
-                sqs-notifications:
-                    elife-production-processes: {}
+            # This bucket is required by editor but was created manually pre-editor so can't be configured via builder.
+            # Config would have been:
+            # "elife-production-processes":
+            #     sqs-notifications:
+            #         elife-production-processes: {}
         sqs:
             # Monitor the production process bucket for new deposits from Exeter.
             elife-libero-editor-import--{instance}:

--- a/projects/elife.yaml
+++ b/projects/elife.yaml
@@ -1704,6 +1704,9 @@ elife-libero-editor:
         ec2: false
         s3:
             "{instance}-elife-libero-editor": {}
+            "elife-production-processes":
+                sqs-notifications:
+                    elife-production-processes: {}
         sqs:
             # Monitor the production process bucket for new deposits from Exeter.
             elife-libero-editor-import--{instance}:
@@ -1715,6 +1718,7 @@ elife-libero-editor:
             s3:
                 "{instance}-elife-libero-editor":
                     deletion-policy: delete
+
 
 task-adept:
     description: production data dumps from TaskAdept

--- a/projects/elife.yaml
+++ b/projects/elife.yaml
@@ -1719,7 +1719,6 @@ elife-libero-editor:
                 "{instance}-elife-libero-editor":
                     deletion-policy: delete
 
-
 task-adept:
     description: production data dumps from TaskAdept
     default-branch: null


### PR DESCRIPTION
For context:

eLife has an S3 bucket called `elife-production-processes` which doesn't appear in the builder configuration so may have been created manually at some point. We need `Put` events within that bucket to be picked up by the ` elife-libero-editor-import--staging` and ` elife-libero-editor-import--prod` SQS instances created at the end of last year. They already have the configuration 

```
sqs:
    elife-libero-editor-import--{instance}:
        subscriptions:
            - "elife-production-processes"
```

- Does adding the config in this PR allow me to alter the config for an existing bucket not created by builder?
- Will not including other bucket config in this file (deletion policies for example) overwrite any config that may already be set on the bucket or will this be left as is?
- Have I missed anything to achieve what I described above?