### PR TITLE
Remove unused sns subscription

### DIFF
--- a/projects/elife.yaml
+++ b/projects/elife.yaml
@@ -1711,9 +1711,7 @@ elife-libero-editor:
             #         elife-production-processes: {}
         sqs:
             # Monitor the production process bucket for new deposits from Exeter.
-            elife-libero-editor-import--{instance}:
-                subscriptions:
-                    - "elife-production-processes"
+            elife-libero-editor-import--{instance}: {}
         docdb: {}
     aws-alt: 
         prod: 


### PR DESCRIPTION
These SQS queues need to take event notifications directly from the target S3 bucket (`elife-production-processes`) I miss-understood the subscription config option originally and added:

```
subscriptions:	
    - "elife-production-processes"
```

This added a permissions policy rule on the SQS queue of something like: 

```
"Condition": {
  "StringLike": {
    "aws:SourceArn": "arn:aws:sns:us-east-1:11111111111111:elife-production-processes"
  }
}
```
I think it may be overkill to require an SNS service as well as an SQS service at this stage for this project as there are no plans for other services needing to be subscribed to notifications.

What I actually need is something like (have manually set this in for staging queue and it's worked):

```
"Condition": {
  "StringLike": {
    "aws:SourceArn": "arn:aws:s3:::elife-production-processes"
  }
}
```

How might I achieve this through this project file?

Thanks 👍 