### PR TITLE
Add an SNS for elife-production-processes bucket to notify

### DIFF
--- a/projects/elife.yaml
+++ b/projects/elife.yaml
@@ -1705,13 +1705,15 @@ elife-libero-editor:
         s3:
             "{instance}-elife-libero-editor": {}
             # This bucket is required by editor but was created manually pre-editor so can't be configured via builder.
-            # Config would have been:
+            # It should also notify the bus-elife-libero-editor on Put events
             # "elife-production-processes":
-            #     sqs-notifications:
-            #         elife-production-processes: {}
+        sns:
+            - "bus-elife-libero-editor"
         sqs:
             # Monitor the production process bucket for new deposits from Exeter.
-            elife-libero-editor-import--{instance}: {}
+            elife-libero-editor-import--{instance}:
+                subscriptions:
+                    - bus-elife-libero-editor
         docdb: {}
     aws-alt: 
         prod: 

--- a/projects/elife.yaml
+++ b/projects/elife.yaml
@@ -1708,12 +1708,12 @@ elife-libero-editor:
             # It should also notify the bus-elife-libero-editor on Put events
             # "elife-production-processes":
         sns:
-            - "bus-elife-libero-editor"
+            - "elife-production-processes-events"
         sqs:
             # Monitor the production process bucket for new deposits from Exeter.
             elife-libero-editor-import--{instance}:
                 subscriptions:
-                    - bus-elife-libero-editor
+                    - elife-production-processes-events
         docdb: {}
     aws-alt: 
         prod: 


### PR DESCRIPTION
Due to limitation of S3 buckets not being able to notify multiple SQS queues with the same configuration, this adds an SNS which the S3 bucket will notify (manually as the bucket isn't configured via builder) which will then notify SQS. 

https://github.com/libero/editor/issues/644