### PR TITLE
Move creation of elife-production-processes-events to aws-alt

### DIFF
--- a/projects/elife.yaml
+++ b/projects/elife.yaml
@@ -1711,7 +1711,7 @@ elife-libero-editor:
                     - elife-production-processes-events
         docdb: {}
     aws-alt: 
-        production-processes:
+        staging:
             # This bucket is required by editor but was created manually pre-editor so can't be configured via builder.
             # It should also notify the bus-elife-libero-editor on Put events
             # s3:

--- a/projects/elife.yaml
+++ b/projects/elife.yaml
@@ -1704,11 +1704,6 @@ elife-libero-editor:
         ec2: false
         s3:
             "{instance}-elife-libero-editor": {}
-            # This bucket is required by editor but was created manually pre-editor so can't be configured via builder.
-            # It should also notify the bus-elife-libero-editor on Put events
-            # "elife-production-processes":
-        sns:
-            - "elife-production-processes-events"
         sqs:
             # Monitor the production process bucket for new deposits from Exeter.
             elife-libero-editor-import--{instance}:
@@ -1716,6 +1711,13 @@ elife-libero-editor:
                     - elife-production-processes-events
         docdb: {}
     aws-alt: 
+        production-processes:
+            # This bucket is required by editor but was created manually pre-editor so can't be configured via builder.
+            # It should also notify the bus-elife-libero-editor on Put events
+            # s3:
+            #   "elife-production-processes":
+            sns:
+                - "elife-production-processes-events"
         prod: 
             s3:
                 "{instance}-elife-libero-editor":


### PR DESCRIPTION
We only need a single `elife-production-processes-events` SNS topic, which both of our `prod` and `staging` `elife-libero-editor-import--{instance}` SQS queues will be subscribed to. Having the `elife-production-processes-events` SNS created as it was causes an error when trying to `update_infrastructure:elife-libero-editor prod` after running the `update_infrastructure :elife-libero-editor staging` (I had to request Daniel H to run these for me as the newer version of OSX don't like installing builder deps). The error thrown was: `elife-production-processes-events already exists in stack arn:aws:cloudformation:us-east-1:512686554592:stack/elife-libero-editor--staging/c21115f0-3879-11eb-b050-0e6115325dc3`

I'm hoping that the change I've made would mean someone could bring up staging which would create the SNS then when they bring up prod the SNS required by its instance SQS queue will already be available. 

Maybe I've came at this from the wrong direction but both @NuclearRedeye and I had looked for docs / existing examples for something similar and this as the best we could come up with. 