### PR TITLE
py3 docker, installs wheel before installing requirements.

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,4 +1,5 @@
 builder-private/
+builder-configuration/
 cloned-projects/
 .cfn/
 .git

--- a/Dockerfile.py3
+++ b/Dockerfile.py3
@@ -12,12 +12,14 @@ RUN apk add --no-cache \
 RUN apk add --no-cache --virtual build-deps \
     curl \
     gcc \
+    g++ \
     make
 
 RUN curl https://bootstrap.pypa.io/get-pip.py -o get-pip.py && \
     python get-pip.py pip && \
-    pip install virtualenv wheel && \
-    virtualenv --python=python3 /venv 
+    pip install virtualenv && \
+    virtualenv --python=python3 /venv && \
+    /venv/bin/pip install wheel pip --upgrade
     
 COPY requirements.txt /requirements.txt
 

--- a/Dockerfile.py3
+++ b/Dockerfile.py3
@@ -16,7 +16,7 @@ RUN apk add --no-cache --virtual build-deps \
 
 RUN curl https://bootstrap.pypa.io/get-pip.py -o get-pip.py && \
     python get-pip.py pip && \
-    pip install virtualenv && \
+    pip install virtualenv wheel && \
     virtualenv --python=python3 /venv 
     
 COPY requirements.txt /requirements.txt


### PR DESCRIPTION
greenlet dependency is failing to find gcc and build. It should be installed via wheel.