### PR TITLE
projects, reverts 'salt' back to v 3000.3.

### DIFF
--- a/projects/elife.yaml
+++ b/projects/elife.yaml
@@ -1,6 +1,6 @@
 defaults:
     description: defaults for all projects in this file
-    salt: '3002.6' # the version of salt these project use
+    salt: '3000.3' # the version of salt these project use
     # use false with a subdomain to assign internal addresses only
     domain: elifesciences.org
     # addressing within VPC


### PR DESCRIPTION
3002.6 has a bug in it's requisites handling