### PR TITLE
Fastly, adds 'initial' and 'threshold' healthchecks to generated config.

### DIFF
--- a/projects/elife.yaml
+++ b/projects/elife.yaml
@@ -116,8 +116,8 @@ defaults:
                 protocol: http
                 port: 80
                 path: /ping
-                timeout: 4
-                interval: 5
+                timeout: 2000 # ms
+                check-interval: 10000 # ms
                 unhealthy_threshold: 2
                 healthy_threshold: 2
         sqs: []
@@ -189,6 +189,15 @@ defaults:
             vcl:
                 - "original-host"
             surrogate-keys: {}
+            # if no backend specified then a Fastly 'shield' is used.
+            # the Fastly shield PoP to use is mapped to the 'aws.region' value.
+            #backends:
+            #    # first is default
+            #    default:
+            #        hostname: some-bucket.s3.amazonaws.com
+            #    articles:
+            #        hostname: "{instance}-some-bucket.s3.amazonaws.com"
+            #        condition: req.url ~ "^/some-prefix/"
         subdomains: []
         elasticache:
             # elasticache defaults only used if an `rds` section present in project

--- a/projects/elife.yaml
+++ b/projects/elife.yaml
@@ -116,8 +116,8 @@ defaults:
                 protocol: http
                 port: 80
                 path: /ping
-                timeout: 2000 # ms
-                check-interval: 10000 # ms
+                timeout: 4
+                interval: 5
                 unhealthy_threshold: 2
                 healthy_threshold: 2
         sqs: []

--- a/src/buildercore/terraform.py
+++ b/src/buildercore/terraform.py
@@ -190,6 +190,7 @@ def render_fastly(context, template):
         }
     )
 
+    # https://registry.terraform.io/providers/fastly/fastly/latest/docs/resources/service_v1#nested-schema-for-healthcheck
     if context['fastly']['healthcheck']:
         template.populate_resource(
             RESOURCE_TYPE_FASTLY,
@@ -201,6 +202,12 @@ def render_fastly(context, template):
                 'path': context['fastly']['healthcheck']['path'],
                 'check_interval': context['fastly']['healthcheck']['check-interval'],
                 'timeout': context['fastly']['healthcheck']['timeout'],
+                # lsh@2021-06-14: while debugging 503 errors from end2end and continuumtest CDNs, Fastly support offered:
+                # > "I would suggest to change your healthcheck configuration .initial value shouldn't be lower than threshold.
+                # > If .initial < .threshold, the backend will be initialized as Unhealthy state until (.threshold - .initial)
+                # > number of healthchecks have happened and they all are pass."
+                'initial': 2, # default is 2
+                'threshold': 2, # default is 3
             }
         )
         for b in template.resource[RESOURCE_TYPE_FASTLY][RESOURCE_NAME_FASTLY]['backend']:

--- a/src/tests/test_buildercore_terraform.py
+++ b/src/tests/test_buildercore_terraform.py
@@ -497,6 +497,8 @@ class TestBuildercoreTerraform(base.BaseCase):
                                 'path': '/ping-fastly',
                                 'check_interval': 30000,
                                 'timeout': 10000,
+                                'initial': 2,
+                                'threshold': 2,
                             },
                             'condition': [
                                 {


### PR DESCRIPTION
threshold default has been reduced from 3 to 2 so backend is considered healthy initially.
This is to avoid mysterious 503 errors in end2end and continuumtest environments.