### PR TITLE
projects, removed 'unique' flag from data-pipeline.

### DIFF
--- a/projects/elife.yaml
+++ b/projects/elife.yaml
@@ -1862,8 +1862,6 @@ fastly-logs:
 data-pipeline:
     description: Data consolidation project
     aws:
-        # unique because: 'gcp.bigquery.{instance}.project' is static.
-        unique: true
         ec2: false
         s3:
             "{instance}-elife-data-pipeline":


### PR DESCRIPTION
I had mistaken the 'project' key as some kind of unique identifier when really it is the dataset ('instance') value that is the identifier.