### PR TITLE
fix: default root hdd size should be 40GB not 20GB for eks worker nodes

### DIFF
--- a/projects/elife.yaml
+++ b/projects/elife.yaml
@@ -197,6 +197,8 @@ defaults:
                 max-size: 3
                 # (currently fixed) number of EC2 nodes
                 desired-capacity: 1
+                #root:
+                #   size: 20 # GiB, default
             helm: false
             external-dns: false
                 # Route53 hosted zone to create subdomains on
@@ -2079,6 +2081,8 @@ kubernetes-aws:
                     type: t2.large
                     max-size: 6
                     desired-capacity: 6
+                    root:
+                        size: 40 # GiB    
                 # since helm: is not installed, this will only add AWS resources
                 # but not the ExternalDNS chart release
                 external-dns:

--- a/scripts/highstate.sh
+++ b/scripts/highstate.sh
@@ -18,11 +18,13 @@ fi
 
 if $dry_run; then
     echo "Executing salt highstate (testing)"
-    sudo salt-call "$force_color" state.highstate -l info test=True --retcode-passthrough
+    # shellcheck disable=SC2086
+    sudo salt-call $force_color state.highstate -l info test=True --retcode-passthrough
 else
     echo "Executing salt highstate"
     log_file=/var/log/salt/salt-highstate-$(date "+%Y-%m-%dT%H:%M:%S").log
     set -o pipefail
+    # shellcheck disable=SC2086
     sudo salt-call $force_color state.highstate -l info --retcode-passthrough | tee "$log_file" || {
         status=$?
         echo "Error provisioning, state.highstate returned: ${status}"

--- a/src/buildercore/terraform.py
+++ b/src/buildercore/terraform.py
@@ -878,6 +878,9 @@ set -o xtrace
         'iam_instance_profile': '${aws_iam_instance_profile.worker.name}',
         'image_id': '${data.aws_ami.worker.id}',
         'instance_type': context['eks']['worker']['type'],
+        'root_block_device': {
+            'volume_size': 20
+        },
         'name_prefix': '%s--worker' % context['stackname'],
         'security_groups': ['${aws_security_group.worker.id}'],
         'user_data_base64': '${base64encode(local.worker_userdata)}',

--- a/src/buildercore/terraform.py
+++ b/src/buildercore/terraform.py
@@ -4,7 +4,7 @@ from os.path import join
 from python_terraform import Terraform, IsFlagged, IsNotFlagged
 from .config import BUILDER_BUCKET, BUILDER_REGION, TERRAFORM_DIR, PROJECT_PATH
 from .context_handler import only_if, load_context
-from .utils import ensure, mkdir_p
+from .utils import ensure, mkdir_p, lookup
 from . import aws, fastly
 
 MANAGED_SERVICES = ['fastly', 'gcs', 'bigquery', 'eks']
@@ -873,21 +873,24 @@ def _render_eks_workers_autoscaling_group(context, template):
 set -o xtrace
 /etc/eks/bootstrap.sh --apiserver-endpoint '${aws_eks_cluster.main.endpoint}' --b64-cluster-ca '${aws_eks_cluster.main.certificate_authority.0.data}' '${aws_eks_cluster.main.name}'""")
 
-    template.populate_resource('aws_launch_configuration', 'worker', block={
+    worker = {
         'associate_public_ip_address': True,
         'iam_instance_profile': '${aws_iam_instance_profile.worker.name}',
         'image_id': '${data.aws_ami.worker.id}',
         'instance_type': context['eks']['worker']['type'],
-        'root_block_device': {
-            'volume_size': 40
-        },
         'name_prefix': '%s--worker' % context['stackname'],
         'security_groups': ['${aws_security_group.worker.id}'],
         'user_data_base64': '${base64encode(local.worker_userdata)}',
         'lifecycle': {
             'create_before_destroy': True,
         },
-    })
+    }
+    root_volume_size = lookup(context, 'eks.worker.root.size', None)
+    if root_volume_size:
+        worker['root_block_device'] = {
+            'volume_size': root_volume_size
+        }
+    template.populate_resource('aws_launch_configuration', 'worker', block=worker)
 
     autoscaling_group_tags = [
         {

--- a/src/buildercore/terraform.py
+++ b/src/buildercore/terraform.py
@@ -879,7 +879,7 @@ set -o xtrace
         'image_id': '${data.aws_ami.worker.id}',
         'instance_type': context['eks']['worker']['type'],
         'root_block_device': {
-            'volume_size': 20
+            'volume_size': 40
         },
         'name_prefix': '%s--worker' % context['stackname'],
         'security_groups': ['${aws_security_group.worker.id}'],

--- a/src/tests/fixtures/projects/dummy-project.yaml
+++ b/src/tests/fixtures/projects/dummy-project.yaml
@@ -844,6 +844,8 @@ project-with-eks:
                 desired-capacity: 3
                 min-size: 1
                 max-size: 3
+                root:
+                    size: 40
 
 project-with-eks-helm:
     description: project managing an EKS cluster with Helm for chart installation

--- a/src/tests/test_buildercore_terraform.py
+++ b/src/tests/test_buildercore_terraform.py
@@ -1086,6 +1086,9 @@ class TestBuildercoreTerraform(base.BaseCase):
                 'iam_instance_profile': '${aws_iam_instance_profile.worker.name}',
                 'image_id': '${data.aws_ami.worker.id}',
                 'instance_type': 't2.small',
+                'root_block_device': {
+                    'volume_size': 40
+                },
                 'name_prefix': 'project-with-eks--%s--worker' % self.environment,
                 'security_groups': ['${aws_security_group.worker.id}'],
                 'user_data_base64': '${base64encode(local.worker_userdata)}',


### PR DESCRIPTION
Progresses elifesciences/data-hub-issues#276

This PR is to increase the default size of the root disk/partition from 20GB to 40GB for the kubernetes workers/nodes to address the issues with importing large datasets in DataHub failing