### PR TITLE
trop, sets the ALB 'name' attribute.

### DIFF
--- a/src/buildercore/trop.py
+++ b/src/buildercore/trop.py
@@ -897,6 +897,7 @@ def render_alb(context, template, ec2_instances):
     lb_attrs = [alb.LoadBalancerAttributes(Key=key, Value=val) for key, val in lb_attrs.items()]
     lb = alb.LoadBalancer(
         ALB_TITLE,
+        Name=context['stackname'],
         Scheme='internet-facing' if alb_is_public else 'internal',
         Subnets=context['alb']['subnets'],
         SecurityGroups=[Ref(ALB_SECURITY_GROUP_ID)],

--- a/src/tests/fixtures/cloudformation/project-with-alb.json
+++ b/src/tests/fixtures/cloudformation/project-with-alb.json
@@ -204,6 +204,7 @@
         },
         "ELBv2": {
             "Properties": {
+                "Name": "project-with-alb--foo",
                 "LoadBalancerAttributes": [
                     {
                         "Key": "idle_timeout.timeout_seconds",


### PR DESCRIPTION
this gives us readable names in the console

![Screenshot at 2021-11-05 16-39-40](https://user-images.githubusercontent.com/2142748/140466769-9e6a79bf-473c-4c44-a899-4d9acc8f2665.png)
