### PR TITLE
adds the 'checks' module with the lone job 'stack_exists'.

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -8,6 +8,7 @@ This is just a scratchpad for keeping track of ideas, nice-to-haves, etc.
 
 ## todo (bucket)
 
+* handle all cases of BUILDER_NON_INTERACTIVE and get_input
 * add a changelog and versioning and releases
 * revisit tests
     - they take *forever*

--- a/src/buildercore/config.py
+++ b/src/buildercore/config.py
@@ -88,6 +88,11 @@ logging.getLogger('paramiko.transport').setLevel(logging.ERROR)
 # TODO: leave on for FILE_HANDLER but not for CONSOLE_HANDLER
 # logging.getLogger('botocore.vendored').setLevel(logging.ERROR)
 
+# disables the endless log messages from boto:
+# 2021-11-09 15:43:51,541 botocore.credentials [INFO] Found credentials in shared credentials file: ~/.aws/credentials
+# INFO - botocore.credentials - Found credentials in shared credentials file: ~/.aws/credentials
+logging.getLogger('botocore.credentials').setLevel(logging.WARNING)
+
 def get_logger(name):
     "ensures logging is setup before handing out a Logger object to use"
     return logging.getLogger(name)

--- a/src/buildercore/core.py
+++ b/src/buildercore/core.py
@@ -41,8 +41,8 @@ ALL_CFN_STATUS = [
     'UPDATE_ROLLBACK_FAILED',
     'UPDATE_ROLLBACK_COMPLETE_CLEANUP_IN_PROGRESS',
     'UPDATE_ROLLBACK_COMPLETE',
-    'REVIEW_IN_PROGRESS',
     # imports not supported/used so far
+    # 'REVIEW_IN_PROGRESS',
     # 'IMPORT_IN_PROGRESS',
     # 'IMPORT_COMPLETE',
     # 'IMPORT_ROLLBACK_IN_PROGRESS',
@@ -574,15 +574,15 @@ def stack_is_active(stackname):
     return stack_is(stackname, ACTIVE_CFN_STATUS)
 
 def stack_exists(stackname, steady=False, active=False):
-    """returns True if the stack exists and is a 'steady' state - not transitioning between states.
+    """returns `True` if the stack exists.
     if `steady` is `True`, stack must also be in a non-transitioning 'steady' state.
     if `active` is `True`, stack must also be in a healthy 'active' state (no failed updates, etc)."""
     allowed_states = ALL_CFN_STATUS
     if steady:
-        # order is important, 'steady' is a subset of 'allowed'
+        # order is important, 'steady' is a subset of 'all'.
         allowed_states = STEADY_CFN_STATUS
     if active:
-        # and 'active' is a subset of 'steady'
+        # and 'active' is a subset of 'steady'.
         allowed_states = ACTIVE_CFN_STATUS
     return stack_is(stackname, allowed_states)
 

--- a/src/buildercore/project/__init__.py
+++ b/src/buildercore/project/__init__.py
@@ -71,7 +71,7 @@ def project_data(pname):
     try:
         return data[pname]
     except KeyError:
-        raise ValueError("unknown project %r, known projects %r" % (pname, data.keys()))
+        raise ValueError("unknown project %r, known projects %r" % (pname, list(data.keys())))
 
 #
 #

--- a/src/checks.py
+++ b/src/checks.py
@@ -1,0 +1,9 @@
+from buildercore import core
+from utils import strtobool, TaskExit
+
+def stack_exists(stackname, steady=False, healthy=False):
+    """returns True if the stack exists and is a 'steady' state - not transitioning between states.
+    if `healthy` is `True`, stack must also be in a healthy 'active' state (no failed updates, etc).
+    if `steady` is `True`, stack must also be in a non-transitioning 'steady' state."""
+    if not core.stack_exists(stackname, strtobool(steady), strtobool(healthy)):
+        raise TaskExit() # INFO in core.describe_stacks is good enough

--- a/src/checks.py
+++ b/src/checks.py
@@ -1,9 +1,9 @@
 from buildercore import core
-from utils import strtobool, TaskExit
+from utils import TaskExit
 
-def stack_exists(stackname, steady=False, healthy=False):
+def stack_exists(stackname, state=None):
     """returns `True` if the stack exists.
-    if `healthy` is `True`, stack must also be in a healthy 'active' state (no failed updates, etc).
-    if `steady` is `True`, stack must also be in a non-transitioning 'steady' state."""
-    if not core.stack_exists(stackname, strtobool(steady), strtobool(healthy)):
+    if `state` is 'steady', stack must also be in a non-transitioning 'steady' state.
+    if `state` is 'active', stack must also be in a healthy 'active' state (no failed updates, etc)."""
+    if not core.stack_exists(stackname, state):
         raise TaskExit() # a log.INFO in core.describe_stacks is good enough

--- a/src/checks.py
+++ b/src/checks.py
@@ -2,8 +2,8 @@ from buildercore import core
 from utils import strtobool, TaskExit
 
 def stack_exists(stackname, steady=False, healthy=False):
-    """returns True if the stack exists and is a 'steady' state - not transitioning between states.
+    """returns `True` if the stack exists.
     if `healthy` is `True`, stack must also be in a healthy 'active' state (no failed updates, etc).
     if `steady` is `True`, stack must also be in a non-transitioning 'steady' state."""
     if not core.stack_exists(stackname, strtobool(steady), strtobool(healthy)):
-        raise TaskExit() # INFO in core.describe_stacks is good enough
+        raise TaskExit() # a log.INFO in core.describe_stacks is good enough

--- a/src/decorators.py
+++ b/src/decorators.py
@@ -38,6 +38,10 @@ def requires_filtered_project(filterfn=None):
             pname = os.environ.get('PROJECT', _pname) # used by Vagrant ...?
             project_list = project.filtered_projects(filterfn)
             if not pname or not pname.strip() or pname not in project_list:
+                # TODO:
+                # if config.BUILDER_NON_INTERACTIVE:
+                #    print('project name not found or not provided and input is disabled, cannot continue.')
+                #    return
                 pname = utils._pick("project", sorted(project_list), default_file=deffile('.project'))
             return func(pname, *args, **kwargs)
         return wrap2

--- a/src/taskrunner.py
+++ b/src/taskrunner.py
@@ -107,7 +107,6 @@ TASK_LIST = [
     report.all_adhoc_ec2_instances,
 
     checks.stack_exists,
-
 ]
 
 # 'debug' tasks are those that are available when the environment variable BLDR_ROLE is set to 'admin'

--- a/src/taskrunner.py
+++ b/src/taskrunner.py
@@ -3,7 +3,7 @@ from buildercore import threadbare
 from functools import reduce
 from decorators import echo_output
 from buildercore import command
-import cfn, lifecycle, masterless, vault, aws, metrics, tasks, master, askmaster, buildvars, project, deploy, report, fix
+import cfn, lifecycle, masterless, vault, aws, metrics, tasks, master, askmaster, buildvars, project, deploy, report, fix, checks
 import sys, os, traceback
 import utils
 
@@ -105,6 +105,8 @@ TASK_LIST = [
     report.all_ec2_instances_for_salt_upgrade,
     report.all_formulas,
     report.all_adhoc_ec2_instances,
+
+    checks.stack_exists,
 
 ]
 
@@ -252,7 +254,8 @@ def exec_task(task_str, task_map_list):
         return return_map
 
     except utils.TaskExit as te:
-        print(te)
+        msg = str(te)
+        msg and print(msg)
         print('\nQuit.')
         return_map['rc'] = 1
         return return_map

--- a/src/taskrunner.py
+++ b/src/taskrunner.py
@@ -255,7 +255,8 @@ def exec_task(task_str, task_map_list):
 
     except utils.TaskExit as te:
         msg = str(te)
-        msg and print(msg)
+        if msg:
+            print(msg)
         print('\nQuit.')
         return_map['rc'] = 1
         return return_map

--- a/src/utils.py
+++ b/src/utils.py
@@ -49,6 +49,9 @@ def errcho(x):
     return x
 
 def get_input(message):
+    # TODO
+    # if config.BUILDER_NON_INTERACTIVE:
+    #    raise IOError("stdin requested in non-interactive mode.")
     fn = input if gtpy2() else raw_input
     return fn(message)
 


### PR DESCRIPTION
taskrunner, adds the 'checks' module with the lone job 'stack_exists'.
it accepts two optional params, 'healthy' and 'steady' and will exit with a non-0 response code.
also, raises botocore.credentials logging level to WARN.

- [x] review