### PR TITLE
fix: brew cask is now included in homebrew

### DIFF
--- a/.prerequisites.py
+++ b/.prerequisites.py
@@ -95,11 +95,6 @@ both_checks = [
 mac_checks = [
     ('brew',
      {'osx': 'ruby -e "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/master/install)"'}),
-
-    ('brew cask',
-     {'osx': 'brew tap caskroom/cask'},
-     lambda x: sh('brew cask help')
-     ),
 ]
 
 def run_checks(check_list, exclusions=[]):


### PR DESCRIPTION
Removed the OSX specific `brew cask` check, as this is now included in homebrew by default.