### PR TITLE
Update shell container to python3

### DIFF
--- a/Dockerfile.osx
+++ b/Dockerfile.osx
@@ -1,7 +1,7 @@
 from ubuntu:20.04
 
 WORKDIR /builder
-RUN apt update && DEBIAN_FRONTEND=noninteractive apt install -y tzdata build-essential software-properties-common git python virtualenv vagrant awscli
+RUN apt-get update && DEBIAN_FRONTEND=noninteractive apt-get install -y tzdata build-essential software-properties-common git python3 python3-venv python3-virtualenv python3-dev vagrant awscli
 RUN wget https://releases.hashicorp.com/terraform/0.11.15/terraform_0.11.15_linux_amd64.zip -O ./terraform.zip && unzip ./terraform.zip -d /bin && rm ./terraform.zip
 RUN wget https://releases.hashicorp.com/vault/0.11.6/vault_0.11.6_linux_amd64.zip -O vault.zip && unzip ./vault.zip -d /bin && rm ./vault.zip
 RUN echo 'eval $(ssh-agent); ssh-add;' >> ~/.bashrc

--- a/update.sh
+++ b/update.sh
@@ -2,7 +2,7 @@
 
 set -e # everything must pass
 
-python .prerequisites.py "$@"
+python3 .prerequisites.py "$@"
 
 # remove any old compiled python files
 find src/ -name '*.pyc' -delete


### PR DESCRIPTION
Updated the shell container used to create a linux environment to run builder on OS X to use Python 3.

Also updated the `update.sh` script to use the `python3` binary name, which looking at other examples in repo, is the expected binary name too.