### PR TITLE
Add autoscaler policy to eks clusters

### DIFF
--- a/projects/elife.yaml
+++ b/projects/elife.yaml
@@ -201,6 +201,7 @@ defaults:
                 # Route53 hosted zone to create subdomains on
                 #domain-filter: elifesciences.org
             efs: false
+            autoscaler-policy: false
         cloudfront:
             # cloudfront defaults only used if a 'cloudfront' section present in project
             subdomains: []
@@ -2417,4 +2418,3 @@ firewall:
                             - UNIXShellCommandsVariables_QUERYARGUMENTS
                             - UNIXShellCommandsVariables_BODY
                         excluded: []
-

--- a/projects/elife.yaml
+++ b/projects/elife.yaml
@@ -2227,7 +2227,7 @@ kubernetes-aws:
                 # but not the ExternalDNS chart release
                 external-dns:
                     domain-filter: "elifesciences.org"
-                autoscaler: true
+                autoscaler-policy: true
 
 # lsh@2021-06-18: deprecated. Software Heritage is replacing elifesciences-publications
 large-repo-wrangler:

--- a/projects/elife.yaml
+++ b/projects/elife.yaml
@@ -2417,3 +2417,4 @@ firewall:
                             - UNIXShellCommandsVariables_QUERYARGUMENTS
                             - UNIXShellCommandsVariables_BODY
                         excluded: []
+

--- a/projects/elife.yaml
+++ b/projects/elife.yaml
@@ -24,7 +24,7 @@ defaults:
         - https://github.com/elifesciences/builder-base-formula
     aws:
         account-id: 512686554592
-        # can this configuration be reused or is it unique? 
+        # can this configuration be reused or is it unique?
         # typically it can be reused, but some configurations embed values that are unique to a named instance.
         # for example: the 'prod' configuration for 'journal' is unique to `journal--prod` and cannot be reused.
         unique: false
@@ -231,13 +231,13 @@ defaults:
                     - 151.101.194.217
             gcslogging: false
             # gcslogging:
-            #   bucket: 
-            #   path: 
-            #   period: 
+            #   bucket:
+            #   path:
+            #   period:
             bigquerylogging: false
             # bigquerylogging:
             #   project:
-            #   dataset: 
+            #   dataset:
             #   table:
             healthcheck: false
             errors: false
@@ -292,7 +292,7 @@ defaults:
             action: allow # count, block, custom-response
             # custom rule sets, $1/mo each.
             # the implementation of these is done as snippets of JSON rather than modeling them in Troposphere.
-            # it makes them slightly *brittle* but you can also build rules in the WAF Rule Builder and then drop 
+            # it makes them slightly *brittle* but you can also build rules in the WAF Rule Builder and then drop
             # them in here with no/little effort.
             # see `src/buildercore/waf/*.json` for examples.
             custom-rules: []
@@ -481,7 +481,7 @@ lax:
                 - 80:
                     cidr-ip: 10.0.0.0/16 # internal access only
                 # bot-lax web UI to upload/validate/transform XML and article-json
-                - 8001 
+                - 8001
         sqs:
             bot-lax-{instance}-inc: {}
             bot-lax-{instance}-out: {}
@@ -586,7 +586,7 @@ api-gateway:
         snsalt:
             fastly: false
         continuumtest:
-            # unique because: 
+            # unique because:
             # - 'fastly.bigquerylogging.dataset' is static.
             unique: true
             fastly:
@@ -1150,7 +1150,7 @@ generic-cdn:
         standalone:
             ec2: false
         end2end:
-            # unique because: 
+            # unique because:
             # - 'fastly.gcslogging.path' is static. log data would be commingled.
             unique: true
             fastly:
@@ -1159,7 +1159,7 @@ generic-cdn:
                     path: generic-cdn--end2end/
                     period: 600
         continuumtest:
-            # unique because: 
+            # unique because:
             # - 'fastly.gcslogging.path' is static. log data would be commingled.
             unique: true
             fastly:
@@ -1170,7 +1170,7 @@ generic-cdn:
                 bigquerylogging:
                     dataset: "staging"
         prod:
-            # unique because: 
+            # unique because:
             # - 'fastly.subdomains' contains static values.
             # - 'fastly.gcslogging.path' is static. log data would be commingled.
             unique: true
@@ -1807,7 +1807,7 @@ iiif:
                     path: /
         # manual tests
         continuumtest:
-            # unique because: 
+            # unique because:
             # - 'fastly.bigquerylogging.dataset' is using a static value.
             unique: true
             ec2:
@@ -2042,7 +2042,7 @@ elife-libero-editor:
                 subscriptions:
                     - elife-production-processes-events
         docdb: {}
-    aws-alt: 
+    aws-alt:
         staging:
             # unique because: 'sns' contains static values.
             unique: true
@@ -2052,7 +2052,7 @@ elife-libero-editor:
             #   "elife-production-processes":
             sns:
                 - "elife-production-processes-events"
-        prod: 
+        prod:
             s3:
                 "{instance}-elife-libero-editor":
                     deletion-policy: delete
@@ -2082,7 +2082,7 @@ fastly-logs:
     domain: false
     intdomain: false
     aws:
-        # unique because: 
+        # unique because:
         # - 'gcp.bigquery.{instance}.project' is static.
         # - 'gcp.bigquery.{instance}.tables' contains static values.
         unique: true
@@ -2185,7 +2185,7 @@ reproducible-document-stack:
                 table: "reproducible_document_stack"
     aws-alt:
         prod:
-            # unique because: 
+            # unique because:
             # - 'fastly.bigquerylogging.table' contains a static value.
             # - 'fastly.subdomains' contains a static value.
             unique: true
@@ -2222,11 +2222,12 @@ kubernetes-aws:
                     max-size: 6
                     desired-capacity: 3
                     root:
-                        size: 40 # GiB    
+                        size: 40 # GiB
                 # since helm: is not installed, this will only add AWS resources
                 # but not the ExternalDNS chart release
                 external-dns:
                     domain-filter: "elifesciences.org"
+                autoscaler: true
 
 # lsh@2021-06-18: deprecated. Software Heritage is replacing elifesciences-publications
 large-repo-wrangler:
@@ -2416,4 +2417,3 @@ firewall:
                             - UNIXShellCommandsVariables_QUERYARGUMENTS
                             - UNIXShellCommandsVariables_BODY
                         excluded: []
-

--- a/projects/elife.yaml
+++ b/projects/elife.yaml
@@ -24,7 +24,7 @@ defaults:
         - https://github.com/elifesciences/builder-base-formula
     aws:
         account-id: 512686554592
-        # can this configuration be reused or is it unique?
+        # can this configuration be reused or is it unique? 
         # typically it can be reused, but some configurations embed values that are unique to a named instance.
         # for example: the 'prod' configuration for 'journal' is unique to `journal--prod` and cannot be reused.
         unique: false
@@ -231,13 +231,13 @@ defaults:
                     - 151.101.194.217
             gcslogging: false
             # gcslogging:
-            #   bucket:
-            #   path:
-            #   period:
+            #   bucket: 
+            #   path: 
+            #   period: 
             bigquerylogging: false
             # bigquerylogging:
             #   project:
-            #   dataset:
+            #   dataset: 
             #   table:
             healthcheck: false
             errors: false
@@ -292,7 +292,7 @@ defaults:
             action: allow # count, block, custom-response
             # custom rule sets, $1/mo each.
             # the implementation of these is done as snippets of JSON rather than modeling them in Troposphere.
-            # it makes them slightly *brittle* but you can also build rules in the WAF Rule Builder and then drop
+            # it makes them slightly *brittle* but you can also build rules in the WAF Rule Builder and then drop 
             # them in here with no/little effort.
             # see `src/buildercore/waf/*.json` for examples.
             custom-rules: []
@@ -481,7 +481,7 @@ lax:
                 - 80:
                     cidr-ip: 10.0.0.0/16 # internal access only
                 # bot-lax web UI to upload/validate/transform XML and article-json
-                - 8001
+                - 8001 
         sqs:
             bot-lax-{instance}-inc: {}
             bot-lax-{instance}-out: {}
@@ -586,7 +586,7 @@ api-gateway:
         snsalt:
             fastly: false
         continuumtest:
-            # unique because:
+            # unique because: 
             # - 'fastly.bigquerylogging.dataset' is static.
             unique: true
             fastly:
@@ -1150,7 +1150,7 @@ generic-cdn:
         standalone:
             ec2: false
         end2end:
-            # unique because:
+            # unique because: 
             # - 'fastly.gcslogging.path' is static. log data would be commingled.
             unique: true
             fastly:
@@ -1159,7 +1159,7 @@ generic-cdn:
                     path: generic-cdn--end2end/
                     period: 600
         continuumtest:
-            # unique because:
+            # unique because: 
             # - 'fastly.gcslogging.path' is static. log data would be commingled.
             unique: true
             fastly:
@@ -1170,7 +1170,7 @@ generic-cdn:
                 bigquerylogging:
                     dataset: "staging"
         prod:
-            # unique because:
+            # unique because: 
             # - 'fastly.subdomains' contains static values.
             # - 'fastly.gcslogging.path' is static. log data would be commingled.
             unique: true
@@ -1807,7 +1807,7 @@ iiif:
                     path: /
         # manual tests
         continuumtest:
-            # unique because:
+            # unique because: 
             # - 'fastly.bigquerylogging.dataset' is using a static value.
             unique: true
             ec2:
@@ -2042,7 +2042,7 @@ elife-libero-editor:
                 subscriptions:
                     - elife-production-processes-events
         docdb: {}
-    aws-alt:
+    aws-alt: 
         staging:
             # unique because: 'sns' contains static values.
             unique: true
@@ -2052,7 +2052,7 @@ elife-libero-editor:
             #   "elife-production-processes":
             sns:
                 - "elife-production-processes-events"
-        prod:
+        prod: 
             s3:
                 "{instance}-elife-libero-editor":
                     deletion-policy: delete
@@ -2082,7 +2082,7 @@ fastly-logs:
     domain: false
     intdomain: false
     aws:
-        # unique because:
+        # unique because: 
         # - 'gcp.bigquery.{instance}.project' is static.
         # - 'gcp.bigquery.{instance}.tables' contains static values.
         unique: true
@@ -2185,7 +2185,7 @@ reproducible-document-stack:
                 table: "reproducible_document_stack"
     aws-alt:
         prod:
-            # unique because:
+            # unique because: 
             # - 'fastly.bigquerylogging.table' contains a static value.
             # - 'fastly.subdomains' contains a static value.
             unique: true
@@ -2222,7 +2222,7 @@ kubernetes-aws:
                     max-size: 6
                     desired-capacity: 3
                     root:
-                        size: 40 # GiB
+                        size: 40 # GiB    
                 # since helm: is not installed, this will only add AWS resources
                 # but not the ExternalDNS chart release
                 external-dns:

--- a/src/buildercore/terraform.py
+++ b/src/buildercore/terraform.py
@@ -820,7 +820,7 @@ def _render_eks_workers_role(context, template):
         })
 
 
-    if lookup(context, 'eks.autoscaler', False):
+    if lookup(context, 'eks.autoscaler-policy', False):
         # kubernetes autoscaler needs to have permission to query and alter the autoscaling group from the worker nodes
         template.populate_resource('aws_iam_policy', 'kubernetes_autoscaler', block={
             'name': '%s--KubernetesAutoScalingGroupsAutoscaler' % context['stackname'],

--- a/src/buildercore/terraform.py
+++ b/src/buildercore/terraform.py
@@ -819,7 +819,9 @@ def _render_eks_workers_role(context, template):
             'role': "${aws_iam_role.worker.name}",
         })
 
+
     if lookup(context, 'eks.autoscaler', False):
+        # kubernetes autoscaler needs to have permission to query and alter the autoscaling group from the worker nodes
         template.populate_resource('aws_iam_policy', 'kubernetes_autoscaler', block={
             'name': '%s--KubernetesAutoScalingGroupsAutoscaler' % context['stackname'],
             'path': '/',
@@ -844,7 +846,6 @@ def _render_eks_workers_role(context, template):
                 ],
             }),
         })
-
         template.populate_resource('aws_iam_role_policy_attachment', 'worker_autoscaler', block={
             'policy_arn': "${aws_iam_policy.kubernetes_autoscaler.arn}",
             'role': "${aws_iam_role.worker.name}",

--- a/src/buildercore/terraform.py
+++ b/src/buildercore/terraform.py
@@ -819,7 +819,6 @@ def _render_eks_workers_role(context, template):
             'role': "${aws_iam_role.worker.name}",
         })
 
-
     if lookup(context, 'eks.autoscaler-policy', False):
         # kubernetes autoscaler needs to have permission to query and alter the autoscaling group from the worker nodes
         template.populate_resource('aws_iam_policy', 'kubernetes_autoscaler', block={

--- a/src/buildercore/terraform.py
+++ b/src/buildercore/terraform.py
@@ -819,7 +819,7 @@ def _render_eks_workers_role(context, template):
             'role': "${aws_iam_role.worker.name}",
         })
 
-    if context['eks']['autoscaler']:
+    if lookup(context, 'eks.autoscaler', False):
         template.populate_resource('aws_iam_policy', 'kubernetes_autoscaler', block={
             'name': '%s--KubernetesAutoScalingGroupsAutoscaler' % context['stackname'],
             'path': '/',

--- a/src/tests/fixtures/projects/dummy-project.yaml
+++ b/src/tests/fixtures/projects/dummy-project.yaml
@@ -896,6 +896,14 @@ project-with-eks-efs:
         eks:
             efs: true
 
+project-with-eks-and-autoscaler-policy:
+    description: project managing an EKS cluster with autoscaler support in AWS
+    domain: False
+    intdomain: False
+    aws:
+        eks:
+            autoscaler-policy: true
+
 project-with-docdb:
     description: project managing a single DocumentDB instance
     aws:

--- a/src/tests/fixtures/projects/dummy-project.yaml
+++ b/src/tests/fixtures/projects/dummy-project.yaml
@@ -170,6 +170,7 @@ defaults:
             helm: false
             external-dns: false
             efs: false
+            autoscaler-policy: false
         cloudfront:
             # cloudfront defaults only used if a 'cloudfront' section present in project
             #subdomains: [] # todo: enable

--- a/src/tests/test_buildercore_project.py
+++ b/src/tests/test_buildercore_project.py
@@ -14,7 +14,7 @@ ALL_PROJECTS = [
     'project-with-cluster-integration-tests', 'project-with-db-params', 'project-with-rds-only', 'project-with-rds-encryption', 'project-with-rds-major-version-upgrade',
     'project-with-elasticache-redis', 'project-with-multiple-elasticaches', 'project-with-fully-overridden-elasticaches',
     'project-on-gcp', 'project-with-bigquery-datasets-only', 'project-with-bigquery', 'project-with-bigquery-remote-schemas',
-    'project-with-eks', 'project-with-eks-helm', 'project-with-eks-external-dns', 'project-with-eks-efs',
+    'project-with-eks', 'project-with-eks-helm', 'project-with-eks-external-dns', 'project-with-eks-efs', 'project-with-eks-and-autoscaler-policy',
     'project-with-docdb', 'project-with-docdb-cluster',
     'project-with-unique-alt-config',
     'project-with-waf',


### PR DESCRIPTION
This (optional for now) IAM policy allows an autoscaling component of kubernetes to alter the AutoScalingGroup from within the cluster, based on requested cpu/mem for kubernetes resources.

This will eventually find it's way on to the production cluster, but for now is just enabled on `flux-test` cluster to see if it works, and observe it's behaviour.