### PR TITLE
projects, elife-metrics, changed RDS type from db.t2.small to db.t2.medium.

### DIFF
--- a/projects/elife.yaml
+++ b/projects/elife.yaml
@@ -891,6 +891,9 @@ elife-metrics:
                 size: 10 # GB
                 type: standard
             rds:
+                # lsh@2022-03-01: upgraded from a db.t2.small.
+                # metrics sees a constant > 20% CPU usage and isn't regenerating credits well.
+                type: db.t2.medium
                 multi-az: true
                 storage: 20
                 storage-type: Standard


### PR DESCRIPTION
CPU credits had been running empty for a long time.