### PR TITLE
fix(eks): allow describe actions to be performed on all resources, so ASG auto-discovery can happen

### DIFF
--- a/src/buildercore/terraform.py
+++ b/src/buildercore/terraform.py
@@ -835,6 +835,14 @@ def _render_eks_workers_role(context, template):
                             "autoscaling:DescribeAutoScalingInstances",
                             "autoscaling:DescribeLaunchConfigurations",
                             "autoscaling:DescribeTags",
+                            "ec2:DescribeInstanceTypes",
+                            "ec2:DescribeLaunchTemplateVersions"
+                        ],
+                        "Resource": ["*"]
+                    },
+                    {
+                        "Effect": "Allow",
+                        "Action": [
                             "autoscaling:SetDesiredCapacity",
                             "autoscaling:TerminateInstanceInAutoScalingGroup"
                         ],

--- a/src/tests/test_buildercore_terraform.py
+++ b/src/tests/test_buildercore_terraform.py
@@ -1428,8 +1428,16 @@ class TestBuildercoreTerraform(base.BaseCase):
                             "autoscaling:DescribeAutoScalingInstances",
                             "autoscaling:DescribeLaunchConfigurations",
                             "autoscaling:DescribeTags",
+                            "ec2:DescribeInstanceTypes",
+                            "ec2:DescribeLaunchTemplateVersions"
+                        ],
+                        "Resource": ["*"]
+                    },
+                    {
+                        "Effect": "Allow",
+                        "Action": [
                             "autoscaling:SetDesiredCapacity",
-                            "autoscaling:TerminateInstanceInAutoScalingGroup"
+                            "autoscaling:TerminateInstanceInAutoScalingGroup",
                         ],
                         "Resource": [
                             "${aws_autoscaling_group.worker.arn}",


### PR DESCRIPTION
I created a more restrictive a policy than the getting started suggested (as I didn't want the test cluster updating the prod ASGs) However it doesn't allow the autoscaler to list ASGs to discover (as it only has access to one).

This creates a new policy allowing the worker node permission to query all ASGs, but still keeps it only altering the ASG it belongs to.

Helpful documentation is [here](https://github.com/kubernetes/autoscaler/blob/master/cluster-autoscaler/cloudprovider/aws/README.md#full-cluster-autoscaler-features-policy-recommended).