### PR TITLE
projects, bastion, default instance type is now t2.small.

### DIFF
--- a/projects/elife.yaml
+++ b/projects/elife.yaml
@@ -2087,11 +2087,12 @@ bastion:
     formula-repo: https://github.com/elifesciences/bastion-formula
     aws:
         ec2:
-            type: t2.nano # 500 MB
             ports:
                 - 22
     aws-alt:
         prod:
+            ec2:
+                type: t2.nano # 500 MB
             # unique because: 'subdomains' contains static values.
             unique: true
             subdomains:


### PR DESCRIPTION
prod is preserved as t2.nano. CI times are killing me.