### PR TITLE
projects, disables the 'ec2.type = t2.small' from alt-configs.

### DIFF
--- a/projects/elife.yaml
+++ b/projects/elife.yaml
@@ -329,7 +329,9 @@ defaults:
             ec2:
                 # should be the same as basebox '18.04' and 'standalone18.04' aws-alt configurations
                 ami: ami-0b425589c7bb7663d # bionic, build 20180814, hvm:ebs-ssd
-                type: t2.small
+                # lsh@2022-04-21: disabled, not sure why it was added.
+                # it was preventing search-formula PRs from using the default t2.medium instances
+                #type: t2.small
 
         snsalt:
             description: uses the next version of Salt to test formula for problems upgrading. OS agnostic, isolated from the master-server and any external pillar data (Vault)
@@ -340,9 +342,11 @@ defaults:
         1804:
             description: Ubuntu 18.04 (Bionic)
             # todo: explicitly specify an 18.04 AMI when 18.04 is no longer the default (2023?)
-            #ec2: {} # means 'use defaults'. don't use 'true'.
-            ec2:
-                type: t2.small
+            ec2: {} # means 'use defaults'. don't use 'true'.
+            # lsh@2022-04-21: disabled, not sure why it was added.
+            # it was preventing search-formula PRs from using the default t2.medium instances
+            #ec2:
+            #    type: t2.small
 
         # lsh@2022-02-23: disabled, unused.
         # 18.04, deprecated, use s1804
@@ -360,7 +364,9 @@ defaults:
                 ami: ami-03ad5d7a3fe98ff86 # GENERATED created from basebox--1804
                                            # us-east-1, build date 20180814, hvm:ebs-ssd, AMI built on 20180828
                 masterless: true
-                type: t2.small
+                # lsh@2022-04-21: disabled, not sure why it was added.
+                # it was preventing search-formula PRs from using the default t2.medium instances
+                #type: t2.small
 
         2004:
             description: Ubuntu 20.04 (Focal)
@@ -379,7 +385,9 @@ defaults:
             description: same as default configuration, but isolated from the master-server and any external pillar data (Vault)
             ec2:
                 masterless: true
-                type: t2.small
+                # lsh@2022-04-21: disabled, not sure why it was added.
+                # it was preventing search-formula PRs from using the default t2.medium instances
+                #type: t2.small
     gcp:
         bigquery: false
     vagrant:


### PR DESCRIPTION
not sure of the reasoning behind this, but it's interfering with project defaults.