### PR TITLE
Return default None when rds.num-replacements isn't set on stack state context

### DIFF
--- a/src/buildercore/core.py
+++ b/src/buildercore/core.py
@@ -255,7 +255,7 @@ def find_rds_instances(stackname, state='available'):
         # lsh@2022-05-20: rds instance id can no longer be generated from the stackname alone.
         # rds instances can now be replaced and the replacement number is incorporated into the rds instance id.
         context = context_handler.load_context(stackname)
-        rid = rds_iid(stackname, lookup(context, 'rds.num-replacements'))
+        rid = rds_iid(stackname, lookup(context, 'rds.num-replacements', None))
         if rid:
             # TODO: return the first (and only) result of DBInstances
             return conn.describe_db_instances(DBInstanceIdentifier=rid)['DBInstances']


### PR DESCRIPTION
Related to  https://github.com/elifesciences/issues/issues/7430

I'm guessing for preexisting state stored in S3 it doesn't contain this data, therefore defaulting to None (and thus no suffix) is the right behaviour.