### PR TITLE
fixes issue in buildercore.utils.nested_dictmap raising a runtime error

### DIFF
--- a/src/buildercore/utils.py
+++ b/src/buildercore/utils.py
@@ -61,13 +61,13 @@ def dictfilter(func, ddict):
     return {k: v for k, v in ddict.items() if func(k, v)}
 
 def dictmap(fn, ddict):
-    return {key: fn(key, val) for key, val in ddict.items()}
+    return {key: fn(key, val) for key, val in list(ddict.items())}
 
 def nested_dictmap(fn, ddict):
     "`fn` should accept both key and value and return a new key and new value. dictionary values will have `fn` applied to them in turn"
     if not fn:
         return ddict
-    for key, val in ddict.items():
+    for key, val in list(ddict.items()):
         new_key, new_val = fn(key, val)
         if isinstance(new_val, dict):
             new_val = nested_dictmap(fn, new_val)


### PR DESCRIPTION
fixes issue in buildercore.utils.nested_dictmap raising a runtime error while modifying the keys of dict during iteration.

probably this issue: https://github.com/python/cpython/issues/80633

![Screenshot at 2022-07-08 16-11-53](https://user-images.githubusercontent.com/2142748/177932487-92f668ec-d1c8-4c29-af22-337a3e92444f.png)

from: https://docs.python.org/3/whatsnew/changelog.html#changelog