### PR TITLE
core, ec2 boto3 'Resource' connections get improved retry mode.

### DIFF
--- a/src/buildercore/core.py
+++ b/src/buildercore/core.py
@@ -6,7 +6,7 @@ from . import utils, config, project, decorators # BE SUPER CAREFUL OF CIRCULAR 
 from .utils import ensure, first, lookup, lmap, lfilter, unique, isstr
 import boto3
 import botocore
-from botocore.config
+import botocore.config
 from contextlib import contextmanager
 from . import context_handler
 from .command import settings, execute, parallel, serial, env, CommandException, NetworkError
@@ -122,7 +122,7 @@ def boto_resource(service, region):
     kwargs = {'region_name': region}
     if service == 'ec2':
         kwargs['config'] = botocore.config.Config(
-            retries = {
+            retries={
                 'max_attempts': 10,
                 'mode': 'adaptive'
             }

--- a/src/buildercore/core.py
+++ b/src/buildercore/core.py
@@ -6,6 +6,7 @@ from . import utils, config, project, decorators # BE SUPER CAREFUL OF CIRCULAR 
 from .utils import ensure, first, lookup, lmap, lfilter, unique, isstr
 import boto3
 import botocore
+from botocore.config
 from contextlib import contextmanager
 from . import context_handler
 from .command import settings, execute, parallel, serial, env, CommandException, NetworkError
@@ -115,7 +116,18 @@ def all_sns_subscriptions(region, stackname=None):
 #
 
 def boto_resource(service, region):
-    return boto3.resource(service, region_name=region)
+    # lsh@2022-07-25: set the retry mode to 'adaptive' (experimental)
+    # - https://boto3.amazonaws.com/v1/documentation/api/latest/guide/retries.html
+    # this mode may change in features and behaviour, but it already sounds quite clever/magical.
+    kwargs = {'region_name': region}
+    if service == 'ec2':
+        kwargs['config'] = botocore.config.Config(
+            retries = {
+                'max_attempts': 10,
+                'mode': 'adaptive'
+            }
+        )
+    return boto3.resource(service, **kwargs)
 
 def boto_client(service, region=None):
     """the boto3 'service' client is a lower-level construct compared to the boto3 'resource' client.
@@ -126,6 +138,7 @@ def boto_client(service, region=None):
     return boto3.client(service, region_name=region)
 
 def boto_conn(pname_or_stackname, service, client=False):
+    "convenience. returns a boto Resource or client for the given project or stack name, using the region found in the project config."
     fn = project_data_for_stackname if '--' in pname_or_stackname else project.project_data
     pdata = fn(pname_or_stackname)
     # prefer resource if possible


### PR DESCRIPTION
tackles the throttling issues.

```python
[2022-07-25T02:22:08.466Z] INFO - buildercore.lifecycle - EC2 nodes to be started: ['i-042f1e892682ab480']
[2022-07-25T02:22:12.589Z] exception while executing task 'start': An error occurred (RequestLimitExceeded) when calling the StartInstances operation (reached max retries: 4): Request limit exceeded.
[2022-07-25T02:22:12.589Z] 
[2022-07-25T02:22:12.589Z] Traceback (most recent call last):
[2022-07-25T02:22:12.589Z]   File "src/taskrunner.py", line 256, in exec_task
[2022-07-25T02:22:12.589Z]     return_map['result'] = task_map['fn'](*task_args, **task_kwargs)
[2022-07-25T02:22:12.589Z]   File "/ext/srv/builder/src/decorators.py", line 84, in call
[2022-07-25T02:22:12.589Z]     return func(stackname, *args, **kwargs)
[2022-07-25T02:22:12.589Z]   File "/ext/srv/builder/src/decorators.py", line 19, in wrap
[2022-07-25T02:22:12.589Z]     result = fn(*args, **kw)
[2022-07-25T02:22:12.589Z]   File "/ext/srv/builder/src/lifecycle.py", line 8, in start
[2022-07-25T02:22:12.589Z]     lifecycle.start(stackname)
[2022-07-25T02:22:12.589Z]   File "/ext/srv/builder/src/buildercore/lifecycle.py", line 62, in start
[2022-07-25T02:22:12.589Z]     _ec2_connection(stackname).instances.filter(InstanceIds=ec2_to_be_started).start()
[2022-07-25T02:22:12.589Z]   File "/ext/srv/builder/venv/lib/python3.8/site-packages/boto3/resources/collection.py", line 561, in batch_action
[2022-07-25T02:22:12.589Z]     return action(self, *args, **kwargs)
[2022-07-25T02:22:12.589Z]   File "/ext/srv/builder/venv/lib/python3.8/site-packages/boto3/resources/action.py", line 162, in __call__
[2022-07-25T02:22:12.589Z]     response = getattr(client, operation_name)(*args, **params)
[2022-07-25T02:22:12.589Z]   File "/ext/srv/builder/venv/lib/python3.8/site-packages/botocore/client.py", line 508, in _api_call
[2022-07-25T02:22:12.589Z]     return self._make_api_call(operation_name, kwargs)
[2022-07-25T02:22:12.589Z]   File "/ext/srv/builder/venv/lib/python3.8/site-packages/botocore/client.py", line 911, in _make_api_call
[2022-07-25T02:22:12.589Z]     raise error_class(parsed_response, operation_name)
[2022-07-25T02:22:12.589Z] botocore.exceptions.ClientError: An error occurred (RequestLimitExceeded) when calling the StartInstances operation (reached max retries: 4): Request limit exceeded.
```