### PR TITLE
Register EKS OIDC as an identity provider in IAM 

### DIFF
--- a/projects/elife.yaml
+++ b/projects/elife.yaml
@@ -221,6 +221,7 @@ defaults:
                 #domain-filter: elifesciences.org
             efs: false
             autoscaler-policy: false
+            iam-oidc-provider: false
         cloudfront:
             # cloudfront defaults only used if a 'cloudfront' section present in project
             subdomains: []

--- a/src/buildercore/terraform.py
+++ b/src/buildercore/terraform.py
@@ -1001,7 +1001,7 @@ def _render_eks_iam_access(context, template):
 
     template.populate_resource('aws_iam_openid_connect_provider', 'default', block={
         'client_id_list': ['sts.amazonaws.com'],
-        'thumbprint_list': ['$data.tls_certificate.cert.certificates[0].sha1_fingerprint'],
+        'thumbprint_list': ['${data.tls_certificate.oidc_cert.certificates.0.sha1_fingerprint}'],
         'url': '${aws_eks_cluster.main.identity.0.oidc.0.issuer}'
     })
 

--- a/src/buildercore/terraform.py
+++ b/src/buildercore/terraform.py
@@ -11,7 +11,7 @@ MANAGED_SERVICES = ['fastly', 'gcs', 'bigquery', 'eks']
 only_if_managed_services_are_present = only_if(*MANAGED_SERVICES)
 
 EMPTY_TEMPLATE = '{}'
-PROVIDER_AWS_VERSION = '2.3.0',
+PROVIDER_AWS_VERSION = '2.28.0',
 PROVIDER_FASTLY_VERSION = '0.9.0',
 PROVIDER_VAULT_VERSION = '1.3'
 HELM_CHART_VERSION_EXTERNAL_DNS = '2.6.1'

--- a/src/buildercore/terraform.py
+++ b/src/buildercore/terraform.py
@@ -12,6 +12,7 @@ only_if_managed_services_are_present = only_if(*MANAGED_SERVICES)
 
 EMPTY_TEMPLATE = '{}'
 PROVIDER_AWS_VERSION = '2.28.0',
+PROVIDER_TLS_VERSION = '2.2'
 PROVIDER_FASTLY_VERSION = '0.9.0',
 PROVIDER_VAULT_VERSION = '1.3'
 HELM_CHART_VERSION_EXTERNAL_DNS = '2.6.1'
@@ -1247,6 +1248,11 @@ def init(stackname, context):
                     'aws': {
                         'version': "= %s" % PROVIDER_AWS_VERSION,
                         'region': context['aws']['region'],
+                    },
+                },
+                {
+                    'tls': {
+                        'version': "= %s" % PROVIDER_TLS_VERSION,
                     },
                 },
                 {

--- a/src/tests/fixtures/projects/dummy-project.yaml
+++ b/src/tests/fixtures/projects/dummy-project.yaml
@@ -79,7 +79,7 @@ defaults:
         redundant-subnet-id-2: subnet-2116727b # elife-public-subnet-3, us-east-1a
         redundant-subnet-cidr-2: '10.0.10.0/24'
         redundant-availability-zone-2: us-east-1a
-        
+
         rds:
             multi-az: false
             engine: postgres # or 'MySQL'
@@ -421,15 +421,15 @@ just-some-sns:
     repo: ssh://git@github.com/elifesciences/dummy3
     aws:
         ec2: false
-        sns: 
+        sns:
             - widgets-{instance}
 
 project-with-sqs:
     repo: ssh://git@github.com/elifesciences/dummy3
     aws:
         ec2: false
-        sqs: 
-            project-with-sqs-incoming-{instance}: 
+        sqs:
+            project-with-sqs-incoming-{instance}:
                 subscriptions:
                     - widgets-{instance}
 
@@ -437,9 +437,9 @@ project-with-s3:
     repo: ssh://git@github.com/elifesciences/dummy3
     aws:
         ec2: false
-        s3: 
-            widgets-{instance}: 
-            widgets-archive-{instance}: 
+        s3:
+            widgets-{instance}:
+            widgets-archive-{instance}:
                 deletion-policy: retain
             widgets-static-hosting-{instance}:
                 website-configuration:
@@ -456,7 +456,7 @@ project-with-ext:
         ec2:
             ports:
                 - 80
-        ext: 
+        ext:
             size: 200
 
 project-with-cloudfront:
@@ -501,7 +501,7 @@ project-with-cloudfront-error-pages:
         cloudfront:
             subdomains:
                 - "{instance}--cdn-of-www"
-            errors: 
+            errors:
                 domain: "{instance}--example-errors.com"
                 pattern: "???.html"
                 codes:
@@ -673,7 +673,7 @@ project-with-cluster:
             cluster-size: 2
             dns-external-primary: true
             dns-internal: true
-        elb: 
+        elb:
             protocol: http
         subdomains:
             - project.tv
@@ -692,7 +692,7 @@ project-with-cluster-suppressed:
             suppressed: [1]
         ext:
             size: 10
-        elb: 
+        elb:
             protocol: http
 
 project-with-cluster-overrides:
@@ -706,13 +706,13 @@ project-with-cluster-overrides:
                 - 80
             cluster-size: 2
             overrides:
-                1: 
+                1:
                     type: t2.xlarge
-                    ext: 
+                    ext:
                         size: 20
         ext:
             size: 10
-        elb: 
+        elb:
             protocol: http
 
 project-with-cluster-empty:
@@ -737,7 +737,7 @@ project-with-stickiness:
                 - 80
         ec2:
             cluster-size: 2
-        elb: 
+        elb:
             protocol: http
             stickiness:
                 type: cookie
@@ -755,7 +755,7 @@ project-with-multiple-elb-listeners:
                 - 80
                 - 8001
             cluster-size: 2
-        elb: 
+        elb:
             protocol:
                 - http
                 - 25
@@ -825,7 +825,7 @@ project-with-multiple-elasticaches:
                 maxmemory-policy: volatile-lru
             suppressed: [3]
             overrides:
-                2: 
+                2:
                     type: cache.t2.medium
                     configuration:
                         maxmemory-policy: volatile-ttl
@@ -845,7 +845,7 @@ project-with-fully-overridden-elasticaches:
                 1:
                     configuration:
                         maxmemory-policy: volatile-ttl
-                2: 
+                2:
                     configuration:
                         maxmemory-policy: volatile-ttl
 
@@ -976,6 +976,14 @@ project-with-eks-and-autoscaler-policy:
     aws:
         eks:
             autoscaler-policy: true
+
+project-with-eks-and-iam-oidc-provider:
+    description: project managing an EKS cluster with autoscaler support in AWS
+    domain: False
+    intdomain: False
+    aws:
+        eks:
+            iam-oidc-provider: true
 
 project-with-docdb:
     description: project managing a single DocumentDB instance

--- a/src/tests/test_buildercore_project.py
+++ b/src/tests/test_buildercore_project.py
@@ -14,7 +14,7 @@ ALL_PROJECTS = [
     'project-with-db-params', 'project-with-rds-only', 'project-with-rds-encryption', 'project-with-rds-major-version-upgrade', 'project-with-rds-snapshot',
     'project-with-elasticache-redis', 'project-with-multiple-elasticaches', 'project-with-fully-overridden-elasticaches',
     'project-on-gcp', 'project-with-bigquery-datasets-only', 'project-with-bigquery', 'project-with-bigquery-remote-schemas',
-    'project-with-eks', 'project-with-eks-helm', 'project-with-eks-external-dns', 'project-with-eks-efs', 'project-with-eks-and-autoscaler-policy',
+    'project-with-eks', 'project-with-eks-helm', 'project-with-eks-external-dns', 'project-with-eks-efs', 'project-with-eks-and-autoscaler-policy', 'project-with-eks-and-iam-oidc-provider',
     'project-with-docdb', 'project-with-docdb-cluster',
     'project-with-unique-alt-config',
     'project-with-waf',

--- a/src/tests/test_buildercore_terraform.py
+++ b/src/tests/test_buildercore_terraform.py
@@ -1457,6 +1457,35 @@ class TestBuildercoreTerraform(base.BaseCase):
             terraform_template['resource']['aws_iam_role_policy_attachment']['worker_autoscaler']
         )
 
+    def test_eks_and_iam_oidc_provider(self):
+        pname = 'project-with-eks-and-iam-oidc-provider'
+        iid = pname + '--%s' % self.environment
+        context = cfngen.build_context(pname, stackname=iid)
+        terraform_template = json.loads(terraform.render(context))
+
+        self.assertIn('oidc_cert', terraform_template['data']['tls_certificate'])
+        self.assertEqual(
+            '${aws_eks_cluster.main.identity.0.oidc.0.issuer}',
+            terraform_template['data']['tls_certificate']['oidc_cert']['url']
+        )
+
+        self.assertIn(
+            'default',
+            terraform_template['resource']['aws_iam_openid_connect_provider']
+        )
+        self.assertEqual(
+            '${aws_eks_cluster.main.identity.0.oidc.0.issuer}',
+            terraform_template['resource']['aws_iam_openid_connect_provider']['default']['url']
+        )
+        self.assertIn(
+            'sts.amazonaws.com',
+            terraform_template['resource']['aws_iam_openid_connect_provider']['default']['client_id_list']
+        )
+        self.assertIn(
+            '$data.tls_certificate.cert.certificates[0].sha1_fingerprint',
+            terraform_template['resource']['aws_iam_openid_connect_provider']['default']['thumbprint_list']
+        )
+
     def test_sanity_of_rendered_log_format(self):
         def _render_log_format_with_dummy_template():
             return re.sub(

--- a/src/tests/test_buildercore_terraform.py
+++ b/src/tests/test_buildercore_terraform.py
@@ -1474,7 +1474,7 @@ class TestBuildercoreTerraform(base.BaseCase):
             terraform_template['resource']['aws_iam_openid_connect_provider']
         )
         self.assertEqual(
-            '${aws_eks_cluster.main.identity.0.oidc_cert.0.issuer}',
+            '${aws_eks_cluster.main.identity.0.oidc.0.issuer}',
             terraform_template['resource']['aws_iam_openid_connect_provider']['default']['url']
         )
         self.assertIn(
@@ -1482,7 +1482,7 @@ class TestBuildercoreTerraform(base.BaseCase):
             terraform_template['resource']['aws_iam_openid_connect_provider']['default']['client_id_list']
         )
         self.assertIn(
-            '${data.tls_certificate.cert.certificates.0.sha1_fingerprint}',
+            '${data.tls_certificate.oidc_cert.certificates.0.sha1_fingerprint}',
             terraform_template['resource']['aws_iam_openid_connect_provider']['default']['thumbprint_list']
         )
 

--- a/src/tests/test_buildercore_terraform.py
+++ b/src/tests/test_buildercore_terraform.py
@@ -1474,7 +1474,7 @@ class TestBuildercoreTerraform(base.BaseCase):
             terraform_template['resource']['aws_iam_openid_connect_provider']
         )
         self.assertEqual(
-            '${aws_eks_cluster.main.identity.0.oidc.0.issuer}',
+            '${aws_eks_cluster.main.identity.0.oidc_cert.0.issuer}',
             terraform_template['resource']['aws_iam_openid_connect_provider']['default']['url']
         )
         self.assertIn(
@@ -1482,7 +1482,7 @@ class TestBuildercoreTerraform(base.BaseCase):
             terraform_template['resource']['aws_iam_openid_connect_provider']['default']['client_id_list']
         )
         self.assertIn(
-            '$data.tls_certificate.cert.certificates[0].sha1_fingerprint',
+            '${data.tls_certificate.cert.certificates.0.sha1_fingerprint}',
             terraform_template['resource']['aws_iam_openid_connect_provider']['default']['thumbprint_list']
         )
 


### PR DESCRIPTION
# Description

Currently, we set permissions for cluster resources in IAM based on the role given to the worker nodes. This works fine, but in effect gives all services running on the clusters the same level of access, even if only 1 service needs it.

Current IAM policy examples that technically all services have access to:
- alter desired-capacity on the ASG (used by `autoscaler`  when it decides to scale up or down)
- create and alter records in Route53 (used by `external-dns` to register new Ingress or services)

For my 10% time, I investigated and wrote this change to add the cluster as an identity provider to IAM. It should then allow us to define IAM policies by cluster service account, rather than by the nodes. If this works, I can then alter the existing policy attachments to be only to the correct service account, reducing the security exposure.

It also will help me feel much more comfortable about installing cluster services that interact with AWS services, as we are not in effect allowing all services the same privileges, and can keep the policies very fine-grained.

# Things of note:

- This requires a newer version of aws provider, which I've tested works on a state refresh of the flux-test cluster, but I'm not sure if it's used anywhere else. It being a minor version should be backwards compatible, and still supported on TF v0.11.
- I've added a new provider, required to get the fingerprint of the OIDC cert. Handily, the earliest version is also the last supported on TF v0.11, not requiring a TF upgrade.
- This is optional and defaulting to false for now, to allow me to iterate on it on just the test cluster to start with. I intend to remove the option and make it the default to register a cluster with IAM when I've figured out the other bits to the equation.