### PR TITLE
cfn.ssh and cfn.owner_ssh now allow node information from stackname.

### DIFF
--- a/src/buildercore/bootstrap.py
+++ b/src/buildercore/bootstrap.py
@@ -567,9 +567,10 @@ def master_minion_keys(master_stackname, group_by_stackname=True):
         master_stack_key_paths = remote_listfiles("/etc/salt/pki/master/minions/", use_sudo=True)
     if not group_by_stackname:
         return master_stack_key_paths
-    # group by stackname. stackname is created by stripping node information off the end.
-    # not all keys will have node information! in these case, we just want the first two 'bits'
-    keyfn = lambda p: "--".join(core.parse_stackname(os.path.basename(p), all_bits=True)[:2])
+    # group by stackname. the stackname is created by stripping node information off the end.
+    # not all keys will have node information! in these case, we just want the first two 'bits'.
+    # lsh@2022-08-17: all keys now have node information but we still don't want the node.
+    keyfn = lambda p: core.stackname_sans_node(os.path.basename(p))
     return utils.mkidx(keyfn, master_stack_key_paths)
 
 # TODO: bootstrap.py may not be best place for this

--- a/src/buildercore/cfngen.py
+++ b/src/buildercore/cfngen.py
@@ -284,8 +284,8 @@ def build_context_sns_sqs(pdata, context):
 def project_wrangler(pdata, context):
     bits = core.parse_stackname(context['stackname'], all_bits=True, idx=True)
     pname = context['project_name']
-    ensure(bits['project_name'] == pname,
-           "the project name %r derived from the given `stackname` %r doesn't match" % (bits['project_name'], pname))
+    err_msg = "the project name %r derived from the given `stackname` %r doesn't match" % (bits['project_name'], pname)
+    ensure(bits['project_name'] == pname, err_msg)
     # provides 'project_name', 'instance_id', 'cluster_id'
     context.update(bits)
 

--- a/src/cfn.py
+++ b/src/cfn.py
@@ -73,7 +73,7 @@ def update_infrastructure(stackname, skip=None, start=['ec2']):
     skip = skip.split(",") if skip else []
     start = start.split(",") if isinstance(start, str) else start or []
 
-    (pname, _) = core.parse_stackname(stackname)
+    pname, _ = core.parse_stackname(stackname)
     more_context = {}
     context, delta, current_context = cfngen.regenerate_stack(stackname, **more_context)
 
@@ -321,6 +321,11 @@ def _interactive_ssh(username, public_ip, private_key):
 @requires_aws_stack
 def ssh(stackname, node=None, username=DEPLOY_USER):
     "connect to a instance over SSH using the deploy user ('elife') and *your* private key."
+    _, _, _node = core.parse_stackname(stackname, all_bits=True)
+    stackname = core.stackname_sans_node(stackname)
+    if node and _node:
+        LOG.warning("node from parameter %r preferred over node from stackname %r" % (node, _node))
+    node = node or _node
     instances = _check_want_to_be_running(stackname)
     if not instances:
         return
@@ -331,6 +336,11 @@ def ssh(stackname, node=None, username=DEPLOY_USER):
 def owner_ssh(stackname, node=None):
     """maintenance ssh.
     connects to an instance over SSH using the bootstrap user ('ubuntu') and the instance's private key"""
+    _, _, _node = core.parse_stackname(stackname, all_bits=True)
+    stackname = core.stackname_sans_node(stackname)
+    if node and _node:
+        LOG.warning("node from parameter %r preferred over node from stackname %r" % (node, _node))
+    node = node or _node
     instances = _check_want_to_be_running(stackname)
     if not instances:
         return

--- a/src/tests/test_buildercore_core.py
+++ b/src/tests/test_buildercore_core.py
@@ -63,26 +63,35 @@ class SimpleCases(base.BaseCase):
         # basic
         expected = [
             ('lax--prod', ['lax', 'prod']),
-            ('lax--prod--1', ['lax', 'prod--1']), # is this really what we're expecting?
+            ('lax--prod--1', ['lax', 'prod']),
             ('journal-cms--end2end', ['journal-cms', 'end2end']),
-            ('journal-cms--end2end--2', ['journal-cms', 'end2end--2']), # again, really?
+            ('journal-cms--end2end--2', ['journal-cms', 'end2end']),
         ]
         self.assertAllPairsEqual(core.parse_stackname, expected)
 
+        # basic, as dict
+        expected = [
+            ('lax--prod', {"project_name": 'lax', "instance_id": 'prod'}),
+            ('lax--prod--1', {"project_name": 'lax', "instance_id": 'prod'}),
+            ('journal-cms--end2end', {"project_name": 'journal-cms', "instance_id": 'end2end'}),
+            ('journal-cms--end2end--2', {"project_name": 'journal-cms', "instance_id": 'end2end'}),
+        ]
+        self.assertAllPairsEqual(partial(core.parse_stackname, all_bits=False, idx=True), expected)
+
         # extended
         expected = [
-            ('lax--prod', ['lax', 'prod']),
+            ('lax--prod', ['lax', 'prod', None]),
             ('lax--prod--1', ['lax', 'prod', '1']),
-            ('journal-cms--end2end', ['journal-cms', 'end2end']),
+            ('journal-cms--end2end', ['journal-cms', 'end2end', None]),
             ('journal-cms--end2end--2', ['journal-cms', 'end2end', '2']),
         ]
         self.assertAllPairsEqual(partial(core.parse_stackname, all_bits=True), expected)
 
-        # as dict
+        # extended, as dict
         expected = [
-            ('lax--prod', {"project_name": 'lax', "instance_id": 'prod'}),
+            ('lax--prod', {"project_name": 'lax', "instance_id": 'prod', "cluster_id": None}),
             ('lax--prod--1', {"project_name": 'lax', "instance_id": 'prod', "cluster_id": '1'}),
-            ('journal-cms--end2end', {"project_name": 'journal-cms', "instance_id": 'end2end'}),
+            ('journal-cms--end2end', {"project_name": 'journal-cms', "instance_id": 'end2end', "cluster_id": None}),
             ('journal-cms--end2end--2', {"project_name": 'journal-cms', "instance_id": 'end2end', "cluster_id": '2'}),
         ]
         self.assertAllPairsEqual(partial(core.parse_stackname, all_bits=True, idx=True), expected)


### PR DESCRIPTION
so this is now possible: `./bldr ssh:lax--prod--2` as well as `./bldr ssh:lax--prod,2`

you'll get a warning if you try something like this: `./bldr ssh:lax--prod--2,1` and the explicit node parameter (1) will be preferred over the implicit node parameter (2) from the stackname.

- [ ] does this interfere with bringing up a stopped stack? (yes)
- [ ] does this still prompt when ssh'ing into a multi-node cluster? (yes)
- [ ] ...
- [ ] review