### PR TITLE
Support for bus-reviewed-preprints—{instance}

### DIFF
--- a/projects/elife.yaml
+++ b/projects/elife.yaml
@@ -1317,6 +1317,7 @@ bus:
             - bus-metrics--{instance}
             - bus-profiles--{instance}
             - bus-digests--{instance}
+            - bus-reviewed-preprints--{instance}
 
 search:
     domain: false
@@ -1343,6 +1344,7 @@ search:
                     - bus-interviews--{instance}
                     - bus-blog-articles--{instance}
                     - bus-labs-posts--{instance}
+                    - bus-reviewed-preprints--{instance}
     aws-alt:
         end2end:
             ec2:


### PR DESCRIPTION
@lsh-0 we need to add support for reviewed-preprints in the search application. While we will not be emit sns notifications upon the creation or modification of reviewed preprints we use bus-sdk-php within the search code.

We must add support for the reviewed-preprint type in the bus. This will allow us to use the bus-sdk-php to process reviewed-preprint in the sqs queue. The queue items will be being created manually for now. 

This is related to: https://github.com/elifesciences/bus-sdk-php/pull/34