### PR TITLE
increase max flux-prod cluster size to 14

### DIFF
--- a/projects/elife.yaml
+++ b/projects/elife.yaml
@@ -1977,8 +1977,8 @@ kubernetes-aws:
                 version: '1.21'
                 worker:
                     type: t3.large
-                    max-size: 12
-                    desired-capacity: 11
+                    max-size: 14
+                    desired-capacity: 12
                 # since helm: is not installed, this will only add AWS resources
                 # but not the ExternalDNS chart release
                 external-dns:


### PR DESCRIPTION
 to allow for scaling if needed through EPP launch - we're currently at the max 12 nodes, and at fairly high utilisation across them. Also observed issues with pods being evicted over the weekend.