### PR TITLE
Clean up: remove helm v2

### DIFF
--- a/docs/eks.md
+++ b/docs/eks.md
@@ -32,35 +32,6 @@ $ kubectl version
 $ kubectl get nodes
 ```
 
-### Configure Helm
-
-Helm uses the same authentication as `kubectl` so no further credentials are required.
-
-If you are running Helm for the first time, initialize your local configuration with:
-
-```
-helm init --client-only
-```
-
-## Chart developer guide
-
-If you want to deploy an application to Kubernetes, you're going to use Helm to create a chart. Make sure you go through the [user guide](#user-guide) first to setup the tool.
-
-### Create a new chart
-
-```
-helm create my-chart-name
-```
-
-### Test a chart
-
-```
-helm lint my-chart-name
-helm delete --purge my-release-name  # if previously created
-helm upgrade my-release-name my-chart-name -i
-helm status my-release-name
-```
-
 ## Administrator guide
 
 ### Create a new cluster
@@ -83,10 +54,7 @@ kubernetes-aws:
                     type: t2.large
                     max-size: 2
                     desired-capacity: 2
-                # since helm: is not installed, this will only add AWS resources
-                # but not the ExternalDNS chart release
-                external-dns:
-                    domain-filter: "elifesciences.org"
+                external-dns: true
 ```
 
 ```
@@ -107,7 +75,7 @@ Checklist to go through before destruction:
 
 ### See the moving parts
 
-builder generates Terraform templates that describe the set of EKS, EC2 and even some Helm-managed Kubernetes resources that are created inside an `eks`-enabling stack.
+builder generates Terraform templates that describe the set of EKS and EC2 resources that are created inside an `eks`-enabling stack.
 
 ```
 bldr update_infrastructure:kubernetes-aws--test  # will generate Terraform templates, they should have no change to apply
@@ -128,7 +96,7 @@ Workers are managed through an [autoscaling group](https://docs.aws.amazon.com/a
 The best option to update the AMI is to cordon off servers, drain them and delete them so that they are recreated by the autoscaling group. This is not implemented in `builder`, but can be achieved with the commands:
 
 ```
-kubectl get nodes       # 
+kubectl get nodes       #
 kubectl cordon my-node  # no new Pods will be scheduled here
 kubectl drain my-node   # existing Pods will be evicted and sent to another noe
 aws ec2 terminate-instances --instance-ids=...  # terminate a node, a new one will be created

--- a/projects/elife.yaml
+++ b/projects/elife.yaml
@@ -220,10 +220,7 @@ defaults:
                 desired-capacity: 1
                 #root:
                 #   size: 20 # GiB, default
-            helm: false
             external-dns: false
-                # Route53 hosted zone to create subdomains on
-                #domain-filter: elifesciences.org
             efs: false
             autoscaler-policy: false
 
@@ -1994,10 +1991,7 @@ kubernetes-aws:
                     type: t3.large
                     max-size: 14
                     desired-capacity: 12
-                # since helm: is not installed, this will only add AWS resources
-                # but not the ExternalDNS chart release
-                external-dns:
-                    domain-filter: "elifesciences.org"
+                external-dns: true
                 autoscaler-policy: true
         flux-test:
             ec2: false
@@ -2007,10 +2001,7 @@ kubernetes-aws:
                     type: t3.large
                     max-size: 6
                     desired-capacity: 3
-                # since helm: is not installed, this will only add AWS resources
-                # but not the ExternalDNS chart release
-                external-dns:
-                    domain-filter: "elifesciences.org"
+                external-dns: true
                 autoscaler-policy: true
 
 bioprotocol:

--- a/src/buildercore/terraform.py
+++ b/src/buildercore/terraform.py
@@ -15,9 +15,6 @@ PROVIDER_AWS_VERSION = '2.28.0'
 PROVIDER_TLS_VERSION = '2.2'
 PROVIDER_FASTLY_VERSION = '0.9.0' # '0.26.0' last for terraform 0.11.x
 PROVIDER_VAULT_VERSION = '1.3' # '1.9.0' last for terraform 0.11.x
-HELM_CHART_VERSION_EXTERNAL_DNS = '2.6.1'
-HELM_CHART_VERSION_RAW = '0.2.3'
-HELM_APP_VERSION_EXTERNAL_DNS = '0.5.16'
 
 RESOURCE_TYPE_FASTLY = 'fastly_service_v1'
 RESOURCE_NAME_FASTLY = 'fastly-cdn'
@@ -26,13 +23,11 @@ DATA_TYPE_VAULT_GENERIC_SECRET = 'vault_generic_secret'
 DATA_TYPE_HTTP = 'http'
 DATA_TYPE_TEMPLATE = 'template_file'
 DATA_TYPE_AWS_AMI = 'aws_ami'
-DATA_TYPE_HELM_REPOSITORY = 'helm_repository'
 DATA_NAME_VAULT_GCS_LOGGING = 'fastly-gcs-logging'
 DATA_NAME_VAULT_GCP_LOGGING = 'fastly-gcp-logging'
 DATA_NAME_VAULT_FASTLY_API_KEY = 'fastly'
 DATA_NAME_VAULT_GCP_API_KEY = 'gcp'
 DATA_NAME_VAULT_GITHUB = 'github'
-DATA_NAME_HELM_INCUBATOR = 'incubator'
 
 # keys to lookup in Vault
 # cannot modify these without putting new values inside Vault:
@@ -685,91 +680,6 @@ def render_bigquery(context, template):
 
 # EKS
 
-def _render_helm(context, template):
-    template.populate_resource('kubernetes_service_account', 'tiller', block={
-        'metadata': {
-            'name': 'tiller',
-            'namespace': 'kube-system',
-        },
-    })
-
-    template.populate_resource('kubernetes_cluster_role_binding', 'tiller', block={
-        'metadata': {
-            'name': 'tiller',
-        },
-        'role_ref': {
-            'api_group': 'rbac.authorization.k8s.io',
-            'kind': 'ClusterRole',
-            'name': 'cluster-admin',
-        },
-        'subject': [
-            {
-                'kind': 'ServiceAccount',
-                'name': '${kubernetes_service_account.tiller.metadata.0.name}',
-                'namespace': 'kube-system',
-            },
-        ],
-    })
-
-    template.populate_data(DATA_TYPE_HELM_REPOSITORY, DATA_NAME_HELM_INCUBATOR, block={
-        'name': 'incubator',
-        'url': 'https://kubernetes-charts-incubator.storage.googleapis.com',
-    })
-
-    # creating at least one release is necessary to trigger the Tiller installation
-    template.populate_resource('helm_release', 'common_resources', block={
-        'name': 'common-resources',
-        'repository': "${data.helm_repository.%s.metadata.0.name}" % DATA_NAME_HELM_INCUBATOR,
-        'chart': 'incubator/raw',
-        'depends_on': ['kubernetes_cluster_role_binding.tiller'],
-        'values': [
-            "templates:\n- |\n  apiVersion: v1\n  kind: ConfigMap\n  metadata:\n    name: hello-world\n",
-        ],
-    })
-
-    if context['eks']['external-dns']:
-        template.populate_resource('helm_release', 'external_dns', block={
-            'name': 'external-dns',
-            # 'repository': "${data.helm_repository.%s.metadata.0.name}" % DATA_NAME_HELM_INCUBATOR,
-            'chart': 'stable/external-dns',
-            'version': HELM_CHART_VERSION_EXTERNAL_DNS,
-            'depends_on': ['helm_release.common_resources'],
-            'set': [
-                {
-                    'name': 'image.tag',
-                    'value': HELM_APP_VERSION_EXTERNAL_DNS,
-                },
-                {
-                    'name': 'sources[0]',
-                    'value': 'service',
-                },
-                {
-                    'name': 'provider',
-                    'value': 'aws',
-                },
-                {
-                    'name': 'domainFilters[0]',
-                    'value': context['eks']['external-dns']['domain-filter'],
-                },
-                {
-                    'name': 'policy',
-                    'value': 'sync',
-                },
-                {
-                    'name': 'aws.zoneType',
-                    'value': 'public', # 'private',
-                },
-                {
-                    'name': 'txtOwnerId',
-                    'value': context['stackname'],
-                },
-                {
-                    'name': 'rbac.create',
-                    'value': 'true',
-                },
-            ],
-        })
-
 def _render_eks_iam_access(context, template):
     template.populate_data("tls_certificate", "oidc_cert", {
         'url': '${aws_eks_cluster.main.identity.0.oidc.0.issuer}'
@@ -1203,8 +1113,6 @@ def render_eks(context, template):
     _render_eks_user_access(context, template)
     if lookup(context, 'eks.iam-oidc-provider', False):
         _render_eks_iam_access(context, template)
-    if context['eks']['helm']:
-        _render_helm(context, template)
 
 # ---
 
@@ -1444,17 +1352,6 @@ def init(stackname, context):
                     'name': '${aws_eks_cluster.main.name}',
                 },
             }
-            if context['eks']['helm']:
-                providers['provider'].append({'helm': {
-                    'version': '= 0.9.0',
-                    'service_account': '${kubernetes_cluster_role_binding.tiller.subject.0.name}',
-                    'kubernetes': {
-                        'host': '${data.aws_eks_cluster.main.endpoint}',
-                        'cluster_ca_certificate': '${base64decode(data.aws_eks_cluster.main.certificate_authority.0.data)}',
-                        'token': '${data.aws_eks_cluster_auth.main.token}',
-                        'load_config_file': False,
-                    },
-                }})
         fp.write(json.dumps(providers, indent=2))
     terraform.init(input=False, capture_output=False, raise_on_error=True)
     return terraform

--- a/src/tests/fixtures/projects/dummy-project.yaml
+++ b/src/tests/fixtures/projects/dummy-project.yaml
@@ -211,10 +211,7 @@ defaults:
                 desired-capacity: 3
                 #root:
                 #   size: 20 # GiB, default
-            helm: false
             external-dns: false
-                # Route53 hosted zone to create subdomains on
-                #domain-filter: elifesciences.org
             efs: false
             autoscaler-policy: false
         cloudfront:
@@ -943,23 +940,13 @@ project-with-eks:
                 root:
                     size: 40
 
-project-with-eks-helm:
-    description: project managing an EKS cluster with Helm for chart installation
-    domain: False
-    intdomain: False
-    aws:
-        eks:
-            helm: true
-
 project-with-eks-external-dns:
     description: project managing an EKS cluster with external-dns for Route53 entries creation
     domain: False
     intdomain: False
     aws:
         eks:
-            helm: true  # required
-            external-dns:
-                domain-filter: "elifesciences.net"
+            external-dns: true
 
 project-with-eks-efs:
     description: project managing an EKS cluster with EFS support

--- a/src/tests/test_buildercore_project.py
+++ b/src/tests/test_buildercore_project.py
@@ -14,7 +14,7 @@ ALL_PROJECTS = [
     'project-with-db-params', 'project-with-rds-only', 'project-with-rds-encryption', 'project-with-rds-major-version-upgrade', 'project-with-rds-snapshot',
     'project-with-elasticache-redis', 'project-with-multiple-elasticaches', 'project-with-fully-overridden-elasticaches',
     'project-on-gcp', 'project-with-bigquery-datasets-only', 'project-with-bigquery', 'project-with-bigquery-remote-schemas',
-    'project-with-eks', 'project-with-eks-helm', 'project-with-eks-external-dns', 'project-with-eks-efs', 'project-with-eks-and-autoscaler-policy',
+    'project-with-eks', 'project-with-eks-external-dns', 'project-with-eks-efs', 'project-with-eks-and-autoscaler-policy',
     'project-with-eks-and-iam-oidc-provider', 'project-with-eks-and-irsa-external-dns-role', 'project-with-eks-and-irsa-kubernetes-autoscaler-role',
     'project-with-docdb', 'project-with-docdb-cluster',
     'project-with-unique-alt-config',


### PR DESCRIPTION
helm v3, released in 2019, doesn't use any of this, and we haven't been using it in any capacity since last year when we decommissioned `test` cluster.

PR removes all built-in support for Helm v2 in builder:
- Remove installation of helmv2, tiller, and related config and permissions. This, by nature needs to remove the general charts that would be installed too.
- Remove installation of `external-dns` chart, instead keeping the param as a boolean to grant permission to the worker nodes
- Remove docs for installing helm charts - we no longer expect that to be the deployment route
- Adjust remaining docs to make sense.

Tests pass, and there are no changes to be made when running `./bldr update_infrastructure:kubernetes-aws--flux-test` and `./bldr update_infrastructure:kubernetes-aws--flux-prod`