### PR TITLE
Setup IAM OIDC provider for flux-prod

### DIFF
--- a/projects/elife.yaml
+++ b/projects/elife.yaml
@@ -1986,6 +1986,7 @@ kubernetes-aws:
                     desired-capacity: 12
                 external-dns: true
                 autoscaler-policy: true
+                iam-oidc-provider: true
         flux-test:
             ec2: false
             eks:


### PR DESCRIPTION
Continuing rollout of OIDC specific permissions over cluster-wide permissions