### PR TITLE
Enable IRSA roles for autoscaler and external-dns for flux-prod

### DIFF
--- a/projects/elife.yaml
+++ b/projects/elife.yaml
@@ -1987,6 +1987,15 @@ kubernetes-aws:
                 external-dns: true
                 autoscaler-policy: true
                 iam-oidc-provider: true
+                iam-roles:
+                    kubernetes-autoscaler:
+                        policy-template: kubernetes-autoscaler
+                        service-account: cluster-autoscaler-aws-cluster-autoscaler
+                        namespace: autoscaler
+                    external-dns:
+                        policy-template: external-dns
+                        service-account: infra-external-dns
+                        namespace: infra
         flux-test:
             ec2: false
             eks:


### PR DESCRIPTION
Continuing rollout of IRSA specific permissions over cluster-wide permissions