### PR TITLE
Increase disk space allocated to elife-libraries--spectrum to 20gb

### DIFF
--- a/projects/elife.yaml
+++ b/projects/elife.yaml
@@ -1216,7 +1216,7 @@ elife-libraries:
             ec2:
                 type: t3.medium # 2 core, 8 GB of memory
             ext:
-                size: 10 # GB
+                size: 20 # GB
         powerful3:
             description: speeding up bot-lax-adaptor tests even more
             ec2:

--- a/projects/elife.yaml
+++ b/projects/elife.yaml
@@ -1216,7 +1216,7 @@ elife-libraries:
             ec2:
                 type: t3.medium # 2 core, 8 GB of memory
             ext:
-                size: 20 # GB
+                size: 50 # GB
         powerful3:
             description: speeding up bot-lax-adaptor tests even more
             ec2:


### PR DESCRIPTION
We tried to deploy a change to elife-spectrum recently and it ran out of disk space. We cleared out the `/ext/tmp-spectrum` folder which freed up 2GB but it filled up again in the next run.

It's evident that it needs more disk space as 5GB roughly is taken up with the cached-repositories as the elife-articles-xml is ever increasing.

This is preventing necessary changes to elife-spectrum being deployed and it is causing end2end tests to fail.

Related to: https://github.com/elifesciences/elife-spectrum/pull/330