### PR TITLE
attempt to support selecting containerd runtime on EKS v1.23

### DIFF
--- a/src/buildercore/terraform.py
+++ b/src/buildercore/terraform.py
@@ -940,7 +940,7 @@ def _render_eks_workers_autoscaling_group(context, template):
     template.populate_local('worker_userdata', """
 #!/bin/bash
 set -o xtrace
-/etc/eks/bootstrap.sh --apiserver-endpoint '${aws_eks_cluster.main.endpoint}' --b64-cluster-ca '${aws_eks_cluster.main.certificate_authority.0.data}' ${container_runtime_flag} '${aws_eks_cluster.main.name}'""")
+/etc/eks/bootstrap.sh --apiserver-endpoint '${aws_eks_cluster.main.endpoint}' --b64-cluster-ca '${aws_eks_cluster.main.certificate_authority.0.data}' %s '${aws_eks_cluster.main.name}'""" % container_runtime_flag)
 
     worker = {
         'associate_public_ip_address': True,

--- a/src/buildercore/terraform.py
+++ b/src/buildercore/terraform.py
@@ -934,10 +934,13 @@ def _render_eks_workers_autoscaling_group(context, template):
     # We utilize a Terraform local here to simplify Base64 encoding this
     # information into the AutoScaling Launch Configuration.
     # More information: https://docs.aws.amazon.com/eks/latest/userguide/launch-workers.html
+    #
+    # SA: Update prior to the dockershim removal: optionally add the container runtime flag
+    container_runtime_flag = " --container-runtime containerd" if context['eks']['version'] == "1.23" else ""
     template.populate_local('worker_userdata', """
 #!/bin/bash
 set -o xtrace
-/etc/eks/bootstrap.sh --apiserver-endpoint '${aws_eks_cluster.main.endpoint}' --b64-cluster-ca '${aws_eks_cluster.main.certificate_authority.0.data}' '${aws_eks_cluster.main.name}'""")
+/etc/eks/bootstrap.sh --apiserver-endpoint '${aws_eks_cluster.main.endpoint}' --b64-cluster-ca '${aws_eks_cluster.main.certificate_authority.0.data}' ${container_runtime_flag} '${aws_eks_cluster.main.name}'""")
 
     worker = {
         'associate_public_ip_address': True,

--- a/src/tests/fixtures/projects/dummy-project.yaml
+++ b/src/tests/fixtures/projects/dummy-project.yaml
@@ -956,7 +956,7 @@ project-with-v1.23-select-container-runtime:
     intdomain: False
     aws:
         eks:
-            version: 1.23
+            version: '1.23'
 
 project-with-v1.24-default-runtime:
     description: Project using EKS 1.24 that uses default runtime (no flag)
@@ -964,7 +964,7 @@ project-with-v1.24-default-runtime:
     intdomain: False
     aws:
         eks:
-            version: 1.24
+            version: '1.24'
 
 project-with-eks-and-iam-oidc-provider:
     description: project managing an EKS cluster with it's IAM OIDC provisioned for IRSA

--- a/src/tests/fixtures/projects/dummy-project.yaml
+++ b/src/tests/fixtures/projects/dummy-project.yaml
@@ -942,6 +942,22 @@ project-with-eks:
                 root:
                     size: 40
 
+project-with-v1.23-select-container-runtime:
+    description: Project using EKS 1.23 that switches to using containerd
+    domain: False
+    intdomain: False
+    aws:
+        eks:
+            version: 1.23
+
+project-with-v1.24-default-runtime:
+    description: Project using EKS 1.24 that uses default runtime (no flag)
+    domain: False
+    intdomain: False
+    aws:
+        eks:
+            version: 1.24
+
 project-with-eks-efs:
     description: project managing an EKS cluster with EFS support
     domain: False

--- a/src/tests/fixtures/projects/dummy-project.yaml
+++ b/src/tests/fixtures/projects/dummy-project.yaml
@@ -942,6 +942,14 @@ project-with-eks:
                 root:
                     size: 40
 
+project-with-eks-efs:
+    description: project managing an EKS cluster with EFS support
+    domain: False
+    intdomain: False
+    aws:
+        eks:
+            efs: true
+
 project-with-v1.23-select-container-runtime:
     description: Project using EKS 1.23 that switches to using containerd
     domain: False
@@ -957,14 +965,6 @@ project-with-v1.24-default-runtime:
     aws:
         eks:
             version: 1.24
-
-project-with-eks-efs:
-    description: project managing an EKS cluster with EFS support
-    domain: False
-    intdomain: False
-    aws:
-        eks:
-            efs: true
 
 project-with-eks-and-iam-oidc-provider:
     description: project managing an EKS cluster with it's IAM OIDC provisioned for IRSA

--- a/src/tests/test_buildercore_project.py
+++ b/src/tests/test_buildercore_project.py
@@ -15,7 +15,7 @@ ALL_PROJECTS = [
     'project-with-elasticache-redis', 'project-with-multiple-elasticaches', 'project-with-fully-overridden-elasticaches',
     'project-on-gcp', 'project-with-bigquery-datasets-only', 'project-with-bigquery', 'project-with-bigquery-remote-schemas',
     'project-with-eks', 'project-with-eks-efs',
-    'project-with-eks-and-iam-oidc-provider', 'project-with-eks-and-irsa-external-dns-role', 'project-with-eks-and-irsa-kubernetes-autoscaler-role', 'project-with-eks-and-irsa-csi-ebs-role',
+    'project-with-eks-and-iam-oidc-provider', 'project-with-eks-and-irsa-external-dns-role', 'project-with-eks-and-irsa-kubernetes-autoscaler-role', 'project-with-eks-and-irsa-csi-ebs-role', 'project-with-v1.23-select-container-runtime', 'project-with-v1.24-default-runtime'
     'project-with-docdb', 'project-with-docdb-cluster',
     'project-with-unique-alt-config',
     'project-with-waf',

--- a/src/tests/test_buildercore_project.py
+++ b/src/tests/test_buildercore_project.py
@@ -14,8 +14,8 @@ ALL_PROJECTS = [
     'project-with-db-params', 'project-with-rds-only', 'project-with-rds-encryption', 'project-with-rds-major-version-upgrade', 'project-with-rds-snapshot',
     'project-with-elasticache-redis', 'project-with-multiple-elasticaches', 'project-with-fully-overridden-elasticaches',
     'project-on-gcp', 'project-with-bigquery-datasets-only', 'project-with-bigquery', 'project-with-bigquery-remote-schemas',
-    'project-with-eks', 'project-with-eks-efs',
-    'project-with-eks-and-iam-oidc-provider', 'project-with-eks-and-irsa-external-dns-role', 'project-with-eks-and-irsa-kubernetes-autoscaler-role', 'project-with-eks-and-irsa-csi-ebs-role', 'project-with-v1.23-select-container-runtime', 'project-with-v1.24-default-runtime'
+    'project-with-eks', 'project-with-eks-efs', 'project-with-v1.23-select-container-runtime', 'project-with-v1.24-default-runtime',
+    'project-with-eks-and-iam-oidc-provider', 'project-with-eks-and-irsa-external-dns-role', 'project-with-eks-and-irsa-kubernetes-autoscaler-role', 'project-with-eks-and-irsa-csi-ebs-role',
     'project-with-docdb', 'project-with-docdb-cluster',
     'project-with-unique-alt-config',
     'project-with-waf',

--- a/src/tests/test_buildercore_terraform.py
+++ b/src/tests/test_buildercore_terraform.py
@@ -1315,8 +1315,8 @@ class TestBuildercoreTerraform(base.BaseCase):
         context_v1_24 = cfngen.build_context(pname_v1_24, stackname=iid_v1_24)
         terraform_template_v1_24 = json.loads(terraform.render(context_v1_24))
 
-        self.assertIn('--container-runtime containerd', base64.b64decode(terraform_template_v1_23['locals']['worker_userdata']).decode("utf-8"))
-        self.assertNotIn('--container-runtime containerd', base64.b64decode(terraform_template_v1_24['locals']['worker_userdata']).decode("utf-8"))
+        self.assertIn('--container-runtime containerd', base64.b64decode(terraform_template_v1_23['locals']['worker_userdata']).decode("ascii"))
+        self.assertNotIn('--container-runtime containerd', base64.b64decode(terraform_template_v1_24['locals']['worker_userdata']).decode("ascii"))
 
     def test_irsa_ebs_csi_permissions(self):
         pname = 'project-with-eks-and-irsa-csi-ebs-role'

--- a/src/tests/test_buildercore_terraform.py
+++ b/src/tests/test_buildercore_terraform.py
@@ -1315,8 +1315,8 @@ class TestBuildercoreTerraform(base.BaseCase):
         context_v1_24 = cfngen.build_context(pname_v1_24, stackname=iid_v1_24)
         terraform_template_v1_24 = json.loads(terraform.render(context_v1_24))
 
-        self.assertIn('--container-runtime containerd', base64.b64decode(terraform_template_v1_23['local']['worker_userdata']))
-        self.assertNotIn('--container-runtime containerd', base64.b64decode(terraform_template_v1_24['local']['worker_userdata']))
+        self.assertIn('--container-runtime containerd', base64.b64decode(terraform_template_v1_23['locals']['worker_userdata']))
+        self.assertNotIn('--container-runtime containerd', base64.b64decode(terraform_template_v1_24['locals']['worker_userdata']))
 
     def test_irsa_ebs_csi_permissions(self):
         pname = 'project-with-eks-and-irsa-csi-ebs-role'

--- a/src/tests/test_buildercore_terraform.py
+++ b/src/tests/test_buildercore_terraform.py
@@ -1315,8 +1315,8 @@ class TestBuildercoreTerraform(base.BaseCase):
         context_v1_24 = cfngen.build_context(pname_v1_24, stackname=iid_v1_24)
         terraform_template_v1_24 = json.loads(terraform.render(context_v1_24))
 
-        self.assertIn('--container-runtime containerd', base64.b64decode(terraform_template_v1_23['locals']['worker_userdata']))
-        self.assertNotIn('--container-runtime containerd', base64.b64decode(terraform_template_v1_24['locals']['worker_userdata']))
+        self.assertIn('--container-runtime containerd', base64.b64decode(terraform_template_v1_23['locals']['worker_userdata']).encode("utf-8"))
+        self.assertNotIn('--container-runtime containerd', base64.b64decode(terraform_template_v1_24['locals']['worker_userdata']).encode("utf-8"))
 
     def test_irsa_ebs_csi_permissions(self):
         pname = 'project-with-eks-and-irsa-csi-ebs-role'

--- a/src/tests/test_buildercore_terraform.py
+++ b/src/tests/test_buildercore_terraform.py
@@ -1306,12 +1306,12 @@ class TestBuildercoreTerraform(base.BaseCase):
 
     def test_eks_runtime_selector(self):
         pname_v1_23 = 'project-with-v1.23-select-container-runtime'
-        iid_v1_23 = pname + '--%s' % self.environment
+        iid_v1_23 = pname_v1_23 + '--%s' % self.environment
         context_v1_23 = cfngen.build_context(pname_v1_23, stackname=iid_v1_23)
         terraform_template_v1_23 = json.loads(terraform.render(context_v1_23))
 
         pname_v1_24 = 'project-with-v1.24-default-runtime'
-        iid_v1_24 = pname + '--%s' % self.environment
+        iid_v1_24 = pname_v1_24 + '--%s' % self.environment
         context_v1_24 = cfngen.build_context(pname_v1_24, stackname=iid_v1_24)
         terraform_template_v1_24 = json.loads(terraform.render(context_v1_24))
 

--- a/src/tests/test_buildercore_terraform.py
+++ b/src/tests/test_buildercore_terraform.py
@@ -1304,7 +1304,6 @@ class TestBuildercoreTerraform(base.BaseCase):
         self.assertEqual('${aws_iam_policy.dummy-kubernetes-autoscaler.arn}', aws_iam_role_policy_attachment['policy_arn'])
         self.assertEqual('${aws_iam_role.dummy-kubernetes-autoscaler.name}', aws_iam_role_policy_attachment['role'])
 
-
     def test_eks_runtime_selector(self):
         pname_v1_23 = 'project-with-v1.23-select-container-runtime'
         iid_v1_23 = pname + '--%s' % self.environment

--- a/src/tests/test_buildercore_terraform.py
+++ b/src/tests/test_buildercore_terraform.py
@@ -1315,8 +1315,8 @@ class TestBuildercoreTerraform(base.BaseCase):
         context_v1_24 = cfngen.build_context(pname_v1_24, stackname=iid_v1_24)
         terraform_template_v1_24 = json.loads(terraform.render(context_v1_24))
 
-        self.assertIn('--container-runtime containerd', base64.b64decode(terraform_template_v1_23['locals']['worker_userdata']).decode("ascii"))
-        self.assertNotIn('--container-runtime containerd', base64.b64decode(terraform_template_v1_24['locals']['worker_userdata']).decode("ascii"))
+        self.assertIn('--container-runtime containerd', terraform_template_v1_23['locals']['worker_userdata'])
+        self.assertNotIn('--container-runtime containerd', terraform_template_v1_24['locals']['worker_userdata'])
 
     def test_irsa_ebs_csi_permissions(self):
         pname = 'project-with-eks-and-irsa-csi-ebs-role'

--- a/src/tests/test_buildercore_terraform.py
+++ b/src/tests/test_buildercore_terraform.py
@@ -1315,8 +1315,8 @@ class TestBuildercoreTerraform(base.BaseCase):
         context_v1_24 = cfngen.build_context(pname_v1_24, stackname=iid_v1_24)
         terraform_template_v1_24 = json.loads(terraform.render(context_v1_24))
 
-        self.assertIn('--container-runtime containerd', base64.b64decode(terraform_template_v1_23['locals']['worker_userdata']).encode("utf-8"))
-        self.assertNotIn('--container-runtime containerd', base64.b64decode(terraform_template_v1_24['locals']['worker_userdata']).encode("utf-8"))
+        self.assertIn('--container-runtime containerd', base64.b64decode(terraform_template_v1_23['locals']['worker_userdata']).decode("utf-8"))
+        self.assertNotIn('--container-runtime containerd', base64.b64decode(terraform_template_v1_24['locals']['worker_userdata']).decode("utf-8"))
 
     def test_irsa_ebs_csi_permissions(self):
         pname = 'project-with-eks-and-irsa-csi-ebs-role'

--- a/src/tests/test_buildercore_terraform.py
+++ b/src/tests/test_buildercore_terraform.py
@@ -3,7 +3,6 @@ import json
 import re
 import shutil
 import yaml
-import base64
 from os.path import exists, join
 from unittest.mock import patch, MagicMock
 from unittest import TestCase


### PR DESCRIPTION
relates to https://github.com/elifesciences/issues/issues/8199