### PR TITLE
replace `terraform plan` with plan input with `terraform show` for the explain step

### DIFF
--- a/src/buildercore/terraform.py
+++ b/src/buildercore/terraform.py
@@ -1312,7 +1312,7 @@ def plan(context):
         return 'out.plan'
 
     def _explain_plan(plan_filename):
-        return_code, stdout, stderr = terraform.show(plan_filename, no_color=IsFlagged)
+        return_code, stdout, stderr = terraform.show(plan_filename, input=False, no_color=IsFlagged, raise_on_error=True, detailed_exitcode=IsNotFlagged)
         ensure(return_code == 0, "Exit code of `terraform show out.plan` should be 0, not %s" % return_code)
         # TODO: may not be empty if TF_LOG is used
         ensure(stderr == '', "Stderr of `terraform show out.plan` should be empty:\n%s" % stderr)

--- a/src/buildercore/terraform.py
+++ b/src/buildercore/terraform.py
@@ -1312,10 +1312,10 @@ def plan(context):
         return 'out.plan'
 
     def _explain_plan(plan_filename):
-        return_code, stdout, stderr = terraform.plan(plan_filename, input=False, no_color=IsFlagged, raise_on_error=True, detailed_exitcode=IsNotFlagged)
-        ensure(return_code == 0, "Exit code of `terraform plan out.plan` should be 0, not %s" % return_code)
+        return_code, stdout, stderr = terraform.show(plan_filename, no_color=IsFlagged)
+        ensure(return_code == 0, "Exit code of `terraform show out.plan` should be 0, not %s" % return_code)
         # TODO: may not be empty if TF_LOG is used
-        ensure(stderr == '', "Stderr of `terraform plan out.plan` should be empty:\n%s" % stderr)
+        ensure(stderr == '', "Stderr of `terraform show out.plan` should be empty:\n%s" % stderr)
         return _clean_stdout(stdout)
 
     return TerraformDelta(_explain_plan(_generate_plan()))

--- a/src/tests/test_buildercore_terraform.py
+++ b/src/tests/test_buildercore_terraform.py
@@ -293,7 +293,7 @@ class TestBuildercoreTerraform(base.BaseCase):
     def test_delta(self, Terraform):
         terraform_binary = MagicMock()
         Terraform.return_value = terraform_binary
-        terraform_binary.plan.return_value = (0, 'Plan output: ...', '')
+        terraform_binary.show.return_value = (0, 'Plan output: ...', '')
         stackname = 'project-with-fastly-minimal--%s' % self.environment
         context = cfngen.build_context('project-with-fastly-minimal', stackname=stackname)
         terraform.init(stackname, context)


### PR DESCRIPTION
Running `bldr update_infrastructure:kubernetes-aws--flux-test` on [this branch](https://github.com/elifesciences/builder/pull/1101) results in:

```
WARNING - python_terraform - error: b"\nError: Invalid configuration directory\n\nCannot pass a saved plan file to the 'terraform plan' command. To apply a\nsaved plan, use: terraform apply out.plan\n\n"
exception while executing task 'update_infrastructure': Command '/Volumes/Sources/elife/builder/.tfenv/bin/terraform plan -var-file=/var/folders/5r/tq80kwfs53scy4z8km792jvh0000gn/T/tmp6kkh1lgt.tfvars.json -no-color -input=false out.plan' returned non-zero exit status 1.

Traceback (most recent call last):
  File "src/taskrunner.py", line 282, in exec_task
    return_map['result'] = task_map['fn'](*task_args, **task_kwargs)
  File "/Volumes/Sources/elife/builder/src/decorators.py", line 19, in wrap
    result = fn(*args, **kw)
  File "/Volumes/Sources/elife/builder/src/cfn.py", line 80, in update_infrastructure
    context, delta, current_context = cfngen.regenerate_stack(stackname, **more_context)
  File "/Volumes/Sources/elife/builder/src/buildercore/cfngen.py", line 1079, in regenerate_stack
    delta = template_delta(context)
  File "/Volumes/Sources/elife/builder/src/buildercore/cfngen.py", line 1041, in template_delta
    terraform.generate_delta(context)
  File "/Volumes/Sources/elife/builder/src/buildercore/terraform.py", line 1328, in generate_delta
    return plan(new_context)
  File "/Volumes/Sources/elife/builder/src/buildercore/terraform.py", line 1344, in plan
    return TerraformDelta(_explain_plan(_generate_plan()))
  File "/Volumes/Sources/elife/builder/src/buildercore/terraform.py", line 1338, in _explain_plan
    return_code, stdout, stderr = terraform.plan(plan_filename, input=False, no_color=IsFlagged, raise_on_error=True, detailed_exitcode=IsNotFlagged)
  File "/Volumes/Sources/elife/builder/venv/lib/python3.8/site-packages/python_terraform/__init__.py", line 154, in plan
    return self.cmd('plan', *args, **options)
  File "/Volumes/Sources/elife/builder/venv/lib/python3.8/site-packages/python_terraform/__init__.py", line 317, in cmd
    raise TerraformCommandError(
python_terraform.TerraformCommandError: Command '/Volumes/Sources/elife/builder/.tfenv/bin/terraform plan -var-file=/var/folders/5r/tq80kwfs53scy4z8km792jvh0000gn/T/tmp6kkh1lgt.tfvars.json -no-color -input=false out.plan' returned non-zero exit status 1.
```

Seemingly [Terraform stopped `terraform plan ${inputPlanFile}` displaying the output of an existing plan](https://github.com/hashicorp/terraform/issues/22873) in v0.12, replacing it with `terraform show`. 

This branch replaces our use of `terraform plan` in `_explain_plan` with `terraform show`