### PR TITLE
terraform.py, drops 'source' from required providers if not present

### DIFF
--- a/src/buildercore/terraform.py
+++ b/src/buildercore/terraform.py
@@ -1508,8 +1508,10 @@ def init(stackname, context):
         def provider_to_required_provider(provider_dict):
             provider_name = list(provider_dict.keys())[0] # {'fastly': {'version': ..., ...}, ...} => 'fastly'
             provider_context_key = "provider-" + provider_name # "provider-aws", "provider-vault"
-            default_source = '-/' + provider_name # "-/aws", "-/vault"
-            source = context['terraform'][provider_context_key].get('source', default_source)
+            source = context['terraform'][provider_context_key].get('source')
+            if not source:
+                return (provider_name, {'version': provider_dict[provider_name]['version']})
+
             return (provider_name, {'source': source,
                                     # TODO: can we/should we exclude 'version' from 'providers' now?
                                     'version': provider_dict[provider_name]['version']})


### PR DESCRIPTION
@scottaubrey , the change I suggested on the phone. I haven't tested it but think it should work:

![Screenshot at 2023-04-11 15-09-18](https://user-images.githubusercontent.com/2142748/231094503-2cfe6f03-4d71-450a-9aeb-4c1cc1ca6324.png)

https://developer.hashicorp.com/terraform/language/v1.1.x/providers/requirements