### PR TITLE
fix: Add a username into aws-auth config-map so that metrics server does not break

### DIFF
--- a/src/buildercore/terraform.py
+++ b/src/buildercore/terraform.py
@@ -976,6 +976,7 @@ def _render_eks_user_access(context, template):
     - system:bootstrappers
     - system:nodes
 - rolearn: ${aws_iam_role.user.arn}
+  username: ${aws_iam_role.user.name}:{{SessionName}}
   groups:
     - system:masters
 """)


### PR DESCRIPTION
relates to https://github.com/elifesciences/issues/issues/8250