### PR TITLE
command.py, fix for broken network error retry logic

### DIFF
--- a/src/buildercore/command.py
+++ b/src/buildercore/command.py
@@ -34,13 +34,15 @@ class CommandException(Exception):
     pass
 
 if BACKEND == FABRIC:
+    NetworkError = fab_exceptions.NetworkError
+
     # no un-catchable errors from Fabric
     fab_api.env['abort_exception'] = CommandException
 else:
+    NetworkError = threadbare.operations.NetworkError
+
     threadbare.state.set_defaults({"abort_exception": CommandException,
                                    "key_filename": os.path.expanduser("~/.ssh/id_rsa")})
-
-NetworkError = fab_exceptions.NetworkError
 
 #
 # api

--- a/src/buildercore/context_handler.py
+++ b/src/buildercore/context_handler.py
@@ -47,7 +47,6 @@ def _load_context_from_s3(stackname):
 def load_context(stackname):
     """Returns the store context data structure for 'stackname'.
     Downloads from S3 if missing on the local builder instance"""
-    #path = local_context_file(stackname)
 
     # giorgio@2018-11-03: "Current situation is you may have a old context around on your local disk.
     # This applies to `elife-alfred--prod` as well. Making the context always downloaded from S3 avoids this stale copy
@@ -61,6 +60,8 @@ def load_context(stackname):
     #
     # if not download_from_s3(stackname, refresh=True):
     #    raise MissingContextFile("We are missing the context file for %s, even on S3. Does the stack exist?" % stackname)
+
+    #path = local_context_file(stackname)
     #contents = json.load(open(path, 'r'))
 
     # lsh@2021-06-22: broke the above logic into two parts so I can swap out s3 during testing

--- a/src/buildercore/core.py
+++ b/src/buildercore/core.py
@@ -418,8 +418,8 @@ def stack_all_ec2_nodes(stackname, workfn, username=config.DEPLOY_USER, concurre
                 if str(err).startswith('Low level socket error connecting to host'):
                     LOG.info("Cannot connect to a %s node (%s) during attempt %s, retrying on this node", stackname, err, attempt)
                     continue
-                else:
-                    raise err
+
+                raise err
             except CommandException as err:
                 LOG.error(str(err).replace("\n", "    "))
                 # available as 'results' to fabric.tasks.error

--- a/src/buildercore/core.py
+++ b/src/buildercore/core.py
@@ -370,8 +370,8 @@ def all_node_params(stackname):
     return params
 
 def stack_all_ec2_nodes(stackname, workfn, username=config.DEPLOY_USER, concurrency=None, node=None, instance_ids=None, **kwargs):
-    """Executes work on all the EC2 nodes of stackname.
-    Optionally connects with the specified username"""
+    """Executes `workfn` on all EC2 nodes of `stackname`.
+    Optionally connects with the specified `username`."""
     work_kwargs = {}
     if isinstance(workfn, tuple):
         workfn, work_kwargs = workfn
@@ -387,6 +387,11 @@ def stack_all_ec2_nodes(stackname, workfn, username=config.DEPLOY_USER, concurre
         nodes = {k: v for k, v in nodes.items() if k in instance_ids}
         public_ips = {k: v for k, v in public_ips.items() if k in nodes.keys()}
 
+    if not public_ips:
+        LOG.info("No EC2 nodes to execute on")
+        # should be a dictionary mapping ip address to result
+        return {}
+
     params = _ec2_connection_params(stackname, username)
     params.update(kwargs)
 
@@ -396,11 +401,6 @@ def stack_all_ec2_nodes(stackname, workfn, username=config.DEPLOY_USER, concurre
         'public_ips': public_ips,
         'nodes': nodes
     })
-
-    if not public_ips:
-        LOG.info("No EC2 nodes to execute on")
-        # should be a dictionary mapping ip address to result
-        return {}
 
     LOG.info("Executing on ec2 nodes (%s), concurrency %s", public_ips, concurrency)
 

--- a/src/cfn.py
+++ b/src/cfn.py
@@ -404,7 +404,3 @@ def cmd(stackname, command=None, username=DEPLOY_USER, clean_output=False, concu
     except CommandException as e:
         LOG.error(e)
         exit(2)
-
-def dev(*args, **kwargs):
-    "hook for any development work, don't commit body."
-    pass

--- a/src/taskrunner.py
+++ b/src/taskrunner.py
@@ -29,7 +29,7 @@ def echo(msg, *args, **kwargs):
 # NOTE: a task's function signature constitutes it's API, check twice before changing it.
 # the 'see: ...' references below are *not* comprehensive.
 UNQUALIFIED_TASK_LIST = [
-    ping, echo, cfn.dev,
+    ping, echo,
 
     cfn.destroy,
     # see: elife-jenkins-workflow-libs/vars/elifeFormula.groovy


### PR DESCRIPTION
* command.py, bugfix, the NetworkError being imported by the rest of th…e system was the Fabric NetworkError and not the Threadbare NetworkError.
this meant NetworkError instances were not being caught in the retry logic in buildercore.core. grr.