### PR TITLE
Upgrade terraform providers to latest of each used for cluster provision

### DIFF
--- a/projects/elife.yaml
+++ b/projects/elife.yaml
@@ -1905,7 +1905,7 @@ fastly-logs:
     domain: false
     intdomain: false
     terraform:
-        # lsh@2023-04-25: got an esoteric error about missing credentials attempting to use 
+        # lsh@2023-04-25: got an esoteric error about missing credentials attempting to use
         # "-/google" instead of "hashicorp/google".
         # fixing providers part is part of this ticket:
         # - https://github.com/elifesciences/issues/issues/8256
@@ -2048,6 +2048,17 @@ kubernetes-aws:
     description: project managing an EKS cluster
     domain: False
     intdomain: False
+    terraform:
+        version: "0.13.7" # next version is "0.14.11" see `install-terraform.sh`
+        provider-aws:
+            source: "hashicorp/aws"
+            version: "4.66.1"
+        provider-tls:
+            source: "hashicorp/tls"
+            version: "4.0.4"
+        provider-kubernetes:
+            source: "hashicorp/kubernetes"
+            version: "2.20.0"
     aws:
         ec2: false
     aws-alt:
@@ -2058,7 +2069,7 @@ kubernetes-aws:
                 worker:
                     type: t3.large
                     max-size: 18
-                    desired-capacity: 16
+                    desired-capacity: 15
                 iam-oidc-provider: true
                 iam-roles:
                     kubernetes-autoscaler:
@@ -2080,7 +2091,7 @@ kubernetes-aws:
                 worker:
                     type: t3.large
                     max-size: 6
-                    desired-capacity: 2
+                    desired-capacity: 3
                 iam-oidc-provider: true
                 iam-roles:
                     kubernetes-autoscaler:

--- a/projects/elife.yaml
+++ b/projects/elife.yaml
@@ -2069,7 +2069,7 @@ kubernetes-aws:
                 worker:
                     type: t3.large
                     max-size: 18
-                    desired-capacity: 15
+                    desired-capacity: 16
                 iam-oidc-provider: true
                 iam-roles:
                     kubernetes-autoscaler:
@@ -2091,7 +2091,7 @@ kubernetes-aws:
                 worker:
                     type: t3.large
                     max-size: 6
-                    desired-capacity: 3
+                    desired-capacity: 2
                 iam-oidc-provider: true
                 iam-roles:
                     kubernetes-autoscaler:

--- a/src/buildercore/terraform.py
+++ b/src/buildercore/terraform.py
@@ -1035,7 +1035,7 @@ set -o xtrace
         'max_size': context['eks']['worker']['max-size'],
         'desired_capacity': context['eks']['worker']['desired-capacity'],
         'vpc_zone_identifier': [context['eks']['worker-subnet-id'], context['eks']['worker-redundant-subnet-id']],
-        'tags': autoscaling_group_tags,
+        'tag': autoscaling_group_tags,
     })
 
 def _render_eks_workers_role(context, template):

--- a/src/tests/test_buildercore_terraform.py
+++ b/src/tests/test_buildercore_terraform.py
@@ -1161,7 +1161,7 @@ class TestBuildercoreTerraform(base.BaseCase):
                 'max_size': 3,
                 'desired_capacity': 3,
                 'vpc_zone_identifier': ['subnet-c3c3c3c3', 'subnet-d4d4d4d4'],
-                'tags': [
+                'tag': [
                     {
                         'key': 'Project',
                         'value': 'project-with-eks',


### PR DESCRIPTION
# Description

This change upgrades the providers used by flux clusters to their latest in preparation for https://github.com/elifesciences/issues/issues/7228

Also includes change to remove warning about deprecated properties (`tags` => `tag`) in `aws` provider