### PR TITLE
EKS: Add builder configuration to ask terraform not to update `desired-capacity` when it doesn't match config.

### DIFF
--- a/projects/elife.yaml
+++ b/projects/elife.yaml
@@ -243,6 +243,8 @@ defaults:
                 max-size: 3
                 # (currently fixed) number of EC2 nodes
                 desired-capacity: 1
+                # Whether to ignore drift in desired-capacity (due to f.e. the autoscaler taking control)
+                ignore-desired-capacity-drift: false
                 #root:
                 #   size: 20 # GiB, default
             efs: false
@@ -2059,6 +2061,7 @@ kubernetes-aws:
                     type: t3.large
                     max-size: 18
                     desired-capacity: 16
+                    ignore-desired-capacity-drift: true
                 iam-oidc-provider: true
                 iam-roles:
                     kubernetes-autoscaler:
@@ -2081,6 +2084,7 @@ kubernetes-aws:
                     type: t3.large
                     max-size: 6
                     desired-capacity: 2
+                    ignore-desired-capacity-drift: true
                 iam-oidc-provider: true
                 iam-roles:
                     kubernetes-autoscaler:

--- a/src/buildercore/terraform.py
+++ b/src/buildercore/terraform.py
@@ -1036,7 +1036,7 @@ set -o xtrace
         'desired_capacity': context['eks']['worker']['desired-capacity'],
         'vpc_zone_identifier': [context['eks']['worker-subnet-id'], context['eks']['worker-redundant-subnet-id']],
         'tags': autoscaling_group_tags,
-        'lifecycle': {'ignore_changes': ['desired_capacity'] if context['eks']['worker']['ignore-desired-capacity-drift'] == True else []},
+        'lifecycle': {'ignore_changes': ['desired_capacity'] if lookup(context, 'eks.worker.ignore-desired-capacity-drift', False) == True else []},
     })
 
 def _render_eks_workers_role(context, template):

--- a/src/buildercore/terraform.py
+++ b/src/buildercore/terraform.py
@@ -1036,7 +1036,7 @@ set -o xtrace
         'desired_capacity': context['eks']['worker']['desired-capacity'],
         'vpc_zone_identifier': [context['eks']['worker-subnet-id'], context['eks']['worker-redundant-subnet-id']],
         'tags': autoscaling_group_tags,
-        'lifecycle': {'ignore_changes': ['desired_capacity'] if context['eks']['worker']['ignore-desired-capacity-drift'] == True else [] },
+        'lifecycle': {'ignore_changes': ['desired_capacity'] if context['eks']['worker']['ignore-desired-capacity-drift'] == True else []},
     })
 
 def _render_eks_workers_role(context, template):

--- a/src/buildercore/terraform.py
+++ b/src/buildercore/terraform.py
@@ -1036,6 +1036,7 @@ set -o xtrace
         'desired_capacity': context['eks']['worker']['desired-capacity'],
         'vpc_zone_identifier': [context['eks']['worker-subnet-id'], context['eks']['worker-redundant-subnet-id']],
         'tags': autoscaling_group_tags,
+        'lifecycle': {'ignore_changes': ['desired_capacity'] if context['eks']['worker']['ignore-desired-capacity-drift'] == True else [] },
     })
 
 def _render_eks_workers_role(context, template):

--- a/src/tests/test_buildercore_terraform.py
+++ b/src/tests/test_buildercore_terraform.py
@@ -1188,6 +1188,7 @@ class TestBuildercoreTerraform(base.BaseCase):
                         'propagate_at_launch': True,
                     },
                 ],
+                'lifecycle': {},
             }
         )
 

--- a/src/tests/test_buildercore_terraform.py
+++ b/src/tests/test_buildercore_terraform.py
@@ -1188,7 +1188,7 @@ class TestBuildercoreTerraform(base.BaseCase):
                         'propagate_at_launch': True,
                     },
                 ],
-                'lifecycle': {},
+                'lifecycle': {'ignore_changes': []},
             }
         )
 


### PR DESCRIPTION
Useful for when the k8s autoscaler is updating this dynamically, but still allow provisioning