### PR TITLE
cfngen, too-long s3 bucket names fail early.

### DIFF
--- a/src/buildercore/cfngen.py
+++ b/src/buildercore/cfngen.py
@@ -59,8 +59,10 @@ def instance_alias(instance_id):
     Used in cases where the resource names generated with the `instance_id` are too long!
     for example, the `instance_id`:
         "pr-100-base-update"
+        "pr-65-fresh-snsalt"
     may generate an S3 bucket name of:
         "pr-100-base-update-elife-bot-accepted-submission-cleaning-output"
+        "pr-65-fresh-snsalt-elife-bot-accepted-submission-cleaning-output"
     that is 64 characters long when the maximum is 63.
     with an alias we can shorten that at the expense of this extra indirection."""
     if not isinstance(instance_id, str):
@@ -73,6 +75,14 @@ def instance_alias(instance_id):
         alias = "bu"
         pr_num = match.group('pr')
         return "pr-%s-%s" % (pr_num, alias) # "pr-123-bu"
+
+    # pr-*-fresh-snsalt
+    fresh_snsalt_alias_regex = re.compile(r"pr-(?P<pr>\d+)-fresh-snsalt")
+    match = re.match(fresh_snsalt_alias_regex, instance_id)
+    if match:
+        alias = "fs"
+        pr_num = match.group('pr')
+        return "pr-%s-%s" % (pr_num, alias) # "pr-123-fs"
 
     # add further aliases here
     # ...
@@ -338,7 +348,6 @@ def build_context_aws(pdata, context):
     return context
 
 def build_context_s3(pdata, context):
-    # future: build what is necessary for buildercore.bootstrap.setup_s3()
     default_bucket_configuration = {
         'sqs-notifications': {},
         'deletion-policy': 'delete',
@@ -351,6 +360,7 @@ def build_context_s3(pdata, context):
         for bucket_template_name in pdata['aws']['s3']:
             configuration = pdata['aws']['s3'][bucket_template_name]
             bucket_name = parameterize(context)(bucket_template_name)
+            ensure(len(bucket_name) <= 63, "bucket name %r from template %r is longer than 63 characters: %s" % (bucket_name, bucket_template_name, len(bucket_name)))
             context['s3'][bucket_name] = default_bucket_configuration.copy()
             context['s3'][bucket_name].update(configuration if configuration else {})
     return context

--- a/src/tests/test_buildercore_cfngen.py
+++ b/src/tests/test_buildercore_cfngen.py
@@ -317,6 +317,12 @@ def test_instance_alias():
         ("pr-abc-base-update", None),
         ("pr-base-update", None),
 
+        # pr-*-fresh-snsalt'
+        ("pr-0-fresh-snsalt", "pr-0-fs"),
+        ("pr-123-fresh-snsalt", "pr-123-fs"),
+        ("pr-abc-base-update", None),
+        ("pr-base-update", None),
+
         # ...
     ]
     for given, expected in cases:


### PR DESCRIPTION
cfngen, adds 'fresh-snsalt' to list of instance-or-instance-aliases.