### PR TITLE
projects, bumps salt version to 3006.

### DIFF
--- a/projects/elife.yaml
+++ b/projects/elife.yaml
@@ -4,7 +4,7 @@ defaults:
         # distinguishes this data from other types and versions of configuration data
         type: project
         version: 1
-    salt: "3004" # the version of Salt to install on ec2 instances
+    salt: "3006" # the version of Salt to install on ec2 instances
     terraform:
         # the version of Terraform this project requires
         version: "0.13.7" # next version is "0.14.11" see `install-terraform.sh`

--- a/scripts/init-master.sh
+++ b/scripts/init-master.sh
@@ -82,8 +82,9 @@ The elife-master-builder Github user should already have access to these formula
     }
 else
     cd /opt/builder-private
-    git clean -d --force # in vagrant, destroys any rsync'd files
+    git clean -d --force # in vagrant, destroys any uncommitted rsync'd files
     git reset --hard
+    git checkout master
     git pull
 fi
 cp /opt/builder-private/etc-salt-master /etc/salt/master.template
@@ -97,8 +98,9 @@ if [ ! -d /opt/builder-configuration ]; then
     git clone "$configuration_repo" builder-configuration --quiet
 else
     cd /opt/builder-configuration
-    #git clean -d --force # in vagrant, destroys any rsync'd files
+    git clean -d --force # in vagrant, destroys any uncommitted rsync'd files
     git reset --hard
+    git checkout master
     git pull
 fi
 
@@ -123,24 +125,17 @@ do
     fi
 done
 
-
-# install/update builder
-# the master server will need to install project formulas. 
-
-# install builder dependencies for Ubuntu not covered by bootstrap.sh
-apt-get install libffi-dev libssl-dev -y
-python3 -m pip install virtualenv
-
-rm -rf /opt/builder
-
 # some vagrant wrangling for convenient development
 if [ -d /vagrant ]; then
     # we're inside Vagrant!
-    # if there is a directory called builder-private, then use it's contents 
+    # if there is a host directory called builder-private, then use it's contents 
     if [ -d /vagrant/builder-private ]; then
         rsync -av /vagrant/builder-private/ /opt/builder-private/
     fi
 fi
+
+# installed during bootstrap, the salt-minion is probably unhappy at this point. reboot it.
+systemctl restart salt-minion 2> /dev/null
 
 echo "master server configured"
 

--- a/scripts/update-master.sh
+++ b/scripts/update-master.sh
@@ -8,10 +8,12 @@ set -xv  # output the scripts and interpolated steps
 
 cd /opt/builder-private
 git reset --hard
+git checkout master
 git pull --rebase
 
 cd /opt/builder-configuration
 git reset --hard
+git checkout master
 git pull --rebase
 
 # ... then clone/pull all formula repos and update master config
@@ -42,3 +44,4 @@ fi
 killall -9 salt-master || true
 
 systemctl start salt-master 2> /dev/null
+


### PR DESCRIPTION
init-master.sh, removes some old builder installation deps no longer required. init-master.sh, reboots salt-minion after salt-master configured and formulas checked out. init-master.sh, update-master.sh, checks out 'master' branch on builder-private and builder-configuration. this fixes an issue where a ref that was present locally is absent within the guest.