### PR TITLE
core.stack_all_ec2_nodes, drops retry attempts from 5 to 6.

### DIFF
--- a/src/buildercore/core.py
+++ b/src/buildercore/core.py
@@ -373,7 +373,7 @@ def all_node_params(stackname):
 
     return params
 
-def stack_all_ec2_nodes(stackname, workfn, username=config.DEPLOY_USER, concurrency=None, node=None, instance_ids=None, **kwargs):
+def stack_all_ec2_nodes(stackname, workfn, username=config.DEPLOY_USER, concurrency=None, node=None, instance_ids=None, num_attempts=5, **kwargs):
     """Executes `workfn` on all EC2 nodes of `stackname`.
     Optionally connects with the specified `username`."""
     work_kwargs = {}
@@ -412,7 +412,7 @@ def stack_all_ec2_nodes(stackname, workfn, username=config.DEPLOY_USER, concurre
 
     def single_node_work_fn():
         last_exc = None
-        for attempt in range(0, 6):
+        for attempt in range(0, num_attempts):
             time.sleep(attempt / 2)
             try:
                 return workfn(**work_kwargs)

--- a/src/buildercore/lifecycle.py
+++ b/src/buildercore/lifecycle.py
@@ -158,7 +158,9 @@ def _some_node_is_not_ready(stackname, **kwargs):
 def wait_for_ec2_steady_state(stackname, ec2_to_be_checked):
     _wait_ec2_all_in_state(stackname, 'running', ec2_to_be_checked)
     call_while(
-        lambda: _some_node_is_not_ready(stackname, instance_ids=ec2_to_be_checked),
+        # lsh@2023-05-22: added `num_attempts=1` after getting 60 minutes of polling:
+        # - https://github.com/elifesciences/issues/issues/8314
+        lambda: _some_node_is_not_ready(stackname, instance_ids=ec2_to_be_checked, num_attempts=1),
         interval=config.AWS_POLLING_INTERVAL,
         timeout=config.BUILDER_TIMEOUT,
         update_msg="waiting for nodes to complete boot",

--- a/src/tests/test_buildercore_core.py
+++ b/src/tests/test_buildercore_core.py
@@ -296,7 +296,7 @@ def test_find_rds_instances__replacement(test_projects):
 ])
 def test_stack_all_ec2_nodes__network_retry_logic(_):
     "NetworkErrors are caught and retried N times before finally failing with the last raised exception"
-    expected = 5
+    expected = 3
     retried = 0
 
     exc = ConnectionRefusedError("foo")
@@ -317,7 +317,8 @@ def test_stack_all_ec2_nodes__network_retry_logic(_):
                 (command.remote, {'command': "echo 'hello world'"}),
                 abort_on_prompts=True,
                 # 'retried' isn't updated on our thread when run using 'parallel'
-                concurrency='serial'
+                concurrency='serial',
+                num_attempts=3
             )
             assert last_exc == expected_exc
         assert retried == expected

--- a/src/tests/test_buildercore_core.py
+++ b/src/tests/test_buildercore_core.py
@@ -296,7 +296,7 @@ def test_find_rds_instances__replacement(test_projects):
 ])
 def test_stack_all_ec2_nodes__network_retry_logic(_):
     "NetworkErrors are caught and retried N times before finally failing with the last raised exception"
-    expected = 6
+    expected = 5
     retried = 0
 
     exc = ConnectionRefusedError("foo")


### PR DESCRIPTION
adds num_attempts parameter with a default of 5.
core.lifecycle.wait_for_ec2_steady_state, attempts node check once, polling is handled in it's own 'call_while'