### PR TITLE
Add support for EKS addons with IAM roles

### DIFF
--- a/projects/elife.yaml
+++ b/projects/elife.yaml
@@ -2076,6 +2076,19 @@ kubernetes-aws:
         flux-test:
             ec2: false
             eks:
+                addons:
+                    aws-ebs-csi-driver:
+                        label: aws_ebs_csi_driver
+                        irsa-role:
+                            policy-template: aws-ebs-csi-driver
+                            service-account: ebs-csi-controller-sa
+                            namespace: kube-system
+                    vpc-cni:
+                        label: vpc_cni
+                        irsa-role:
+                            managed-policy: arn:aws:iam::aws:policy/AmazonEKS_CNI_Policy
+                            service-account: aws-node
+                            namespace: kube-system
                 version: '1.25'
                 worker:
                     type: t3.large

--- a/src/buildercore/cfngen.py
+++ b/src/buildercore/cfngen.py
@@ -728,7 +728,9 @@ def build_context_eks(pdata, context):
         }
 
         # Check if this addons needs additional permissions granting to a kubernetes service account via IRSA
-        addons[label]['irsa-role'] = _build_addon_policy(label, data.get('irsa-role')) if data.get('irsa-role', False) != False else False
+        irsa_role = data.get('irsa-role')
+        if irsa_role:
+            addons[label]['irsa-role'] = _build_addon_policy(label, irsa_role)
 
     context['eks']['addons'] = addons
     return context

--- a/src/buildercore/terraform.py
+++ b/src/buildercore/terraform.py
@@ -1270,7 +1270,7 @@ def _render_eks_addon(context, template, addon):
     if addon['irsa-role']:
         serviceaccount = addon['irsa-role']['service-account']
         namespace = addon['irsa-role']['namespace']
-        role_name = label
+        role_name = 'eks-addon-%s' % name
 
         if addon['irsa-role']['policy-template']:
             template_name = addon['irsa-role']['policy-template']

--- a/src/buildercore/terraform.py
+++ b/src/buildercore/terraform.py
@@ -911,7 +911,7 @@ def _render_eks_iam_policy_template_and_role(context, template, role_name, assum
     })
 
     policy_reference = "${aws_iam_policy.%s.arn}" % role_name
-    _render_eks_iam_role(context, template, role_name, assume_serviceaccount, assume_namespace,  policy_reference)
+    _render_eks_iam_role(context, template, role_name, assume_serviceaccount, assume_namespace, policy_reference)
 
 
 def _render_eks_iam_access(context, template):

--- a/src/buildercore/terraform.py
+++ b/src/buildercore/terraform.py
@@ -868,6 +868,51 @@ def render_bigquery(context, template):
     return template.to_dict()
 
 # EKS
+def _render_eks_iam_role(context, template, role_name, assume_serviceaccount, assume_namespace, policy_arn):
+    stackname = context['stackname']
+
+    assume_policy = json.dumps({
+        "Version": "2012-10-17",
+        "Statement": [
+            {
+                "Effect": "Allow",
+                "Principal": {
+                    "Federated": "${aws_iam_openid_connect_provider.default.arn}",
+                },
+                "Action": "sts:AssumeRoleWithWebIdentity",
+                "Condition": {
+                    "StringEquals": {
+                        "${aws_iam_openid_connect_provider.default.url}:sub": ["system:serviceaccount:%s:%s" % (assume_namespace, assume_serviceaccount)]
+                    }
+                }
+            }
+        ]
+    })
+
+    template.populate_resource('aws_iam_role', role_name, block={
+        'name': '%s--%s' % (stackname, role_name),
+        'assume_role_policy': assume_policy,
+    })
+
+    template.populate_resource('aws_iam_role_policy_attachment', role_name, block={
+        'policy_arn': policy_arn,
+        'role': "${aws_iam_role.%s.name}" % role_name,
+    })
+
+def _render_eks_iam_policy_template_and_role(context, template, role_name, assume_serviceaccount, assume_namespace, template_name):
+    stackname = context['stackname']
+    accountid = context['aws']['account-id']
+
+    policy_name = '%s--%s' % (stackname, role_name)
+    template.populate_resource('aws_iam_policy', role_name, block={
+        'name': policy_name,
+        'path': '/',
+        'policy': json.dumps(IRSA_POLICY_TEMPLATES[template_name](stackname, accountid)),
+    })
+
+    policy_reference = "${aws_iam_policy.%s.arn}" % role_name
+    _render_eks_iam_role(context, template, role_name, assume_serviceaccount, assume_namespace,  policy_reference)
+
 
 def _render_eks_iam_access(context, template):
     template.populate_data("tls_certificate", "oidc_cert", {
@@ -881,7 +926,7 @@ def _render_eks_iam_access(context, template):
     })
 
     if 'iam-roles' in context['eks'] and isinstance(context['eks']['iam-roles'], OrderedDict):
-        for rolename, role_definition in context['eks']['iam-roles'].items():
+        for role_name, role_definition in context['eks']['iam-roles'].items():
             if 'policy-template' not in role_definition:
                 raise RuntimeError("Please provide a valid policy-template from %s" % IRSA_POLICY_TEMPLATES.keys())
 
@@ -891,46 +936,11 @@ def _render_eks_iam_access(context, template):
             if 'service-account' not in role_definition or 'namespace' not in role_definition:
                 raise RuntimeError("Please provide both a service-account and namespace in the iam-roles definition")
 
-            stackname = context['stackname']
-            accountid = context['aws']['account-id']
             serviceaccount = role_definition['service-account']
             namespace = role_definition['namespace']
+            template_name = role_definition['policy-template']
 
-            policy = json.dumps(IRSA_POLICY_TEMPLATES[role_definition['policy-template']](stackname, accountid))
-
-            assume_policy = json.dumps({
-                "Version": "2012-10-17",
-                "Statement": [
-                    {
-                        "Effect": "Allow",
-                        "Principal": {
-                            "Federated": "${aws_iam_openid_connect_provider.default.arn}",
-                        },
-                        "Action": "sts:AssumeRoleWithWebIdentity",
-                        "Condition": {
-                            "StringEquals": {
-                                "${aws_iam_openid_connect_provider.default.url}:sub": ["system:serviceaccount:%s:%s" % (namespace, serviceaccount)]
-                            }
-                        }
-                    }
-                ]
-            })
-
-            template.populate_resource('aws_iam_role', rolename, block={
-                'name': '%s--%s' % (stackname, rolename),
-                'assume_role_policy': assume_policy,
-            })
-
-            template.populate_resource('aws_iam_policy', rolename, block={
-                'name': '%s--%s' % (stackname, rolename),
-                'path': '/',
-                'policy': policy,
-            })
-
-            template.populate_resource('aws_iam_role_policy_attachment', rolename, block={
-                'policy_arn': "${aws_iam_policy.%s.arn}" % rolename,
-                'role': "${aws_iam_role.%s.name}" % rolename,
-            })
+            _render_eks_iam_policy_template_and_role(context, template, role_name, serviceaccount, namespace, template_name)
 
 def _render_eks_user_access(context, template):
     template.populate_resource('aws_iam_role', 'user', block={
@@ -1250,14 +1260,26 @@ def _render_eks_addon(context, template, addon):
         'addon_name': name,
         'addon_version': version if version != 'latest' else '${data.aws_eks_addon_version.eks_addon_%s.version}' % label,
         'tags': aws.generic_tags(context),
-        'resolve_conflicts': addon['resolve_conflicts'],
+        'resolve_conflicts': addon['resolve-conflicts'],
     }
 
-    if addon['configuration_values']:
-        resource_block['configuration_values'] = addon['configuration_values']
+    if addon['configuration-values']:
+        resource_block['configuration_values'] = addon['configuration-values']
 
-    if addon['service_account_role_arn']:
-        resource_block['service_account_role_arn'] = addon['service_account_role_arn']
+    # Create additional IAM policy and role either from POLICY_TEMPLATES or AWS managed policy
+    if addon['irsa-role']:
+        serviceaccount = addon['irsa-role']['service-account']
+        namespace = addon['irsa-role']['namespace']
+        role_name = label
+
+        if addon['irsa-role']['policy-template']:
+            template_name = addon['irsa-role']['policy-template']
+            _render_eks_iam_policy_template_and_role(context, template, role_name, serviceaccount, namespace, template_name)
+        elif addon['irsa-role']['managed-policy']:
+            policy_name = addon['irsa-role']['managed-policy']
+            _render_eks_iam_role(context, template, role_name, serviceaccount, namespace, policy_name)
+
+        resource_block['service_account_role_arn'] = '${aws_iam_role.%s.arn}' % role_name
 
     template.populate_resource(
         'aws_eks_addon',

--- a/src/buildercore/terraform.py
+++ b/src/buildercore/terraform.py
@@ -1270,7 +1270,7 @@ def _render_eks_addon(context, template, addon):
     if addon['irsa-role']:
         serviceaccount = addon['irsa-role']['service-account']
         namespace = addon['irsa-role']['namespace']
-        role_name = 'eks-addon-%s' % name
+        role_name = 'eks_addon_%s' % label
 
         if addon['irsa-role']['policy-template']:
             template_name = addon['irsa-role']['policy-template']

--- a/src/buildercore/terraform.py
+++ b/src/buildercore/terraform.py
@@ -1267,7 +1267,7 @@ def _render_eks_addon(context, template, addon):
         resource_block['configuration_values'] = addon['configuration-values']
 
     # Create additional IAM policy and role either from POLICY_TEMPLATES or AWS managed policy
-    if addon['irsa-role']:
+    if 'irsa-role' in addon:
         serviceaccount = addon['irsa-role']['service-account']
         namespace = addon['irsa-role']['namespace']
         role_name = 'eks_addon_%s' % label

--- a/src/tests/fixtures/projects/dummy-project.yaml
+++ b/src/tests/fixtures/projects/dummy-project.yaml
@@ -1044,6 +1044,35 @@ project-with-eks-and-simple-addons-latest:
                     version: latest
                 coredns:
                     version: latest
+
+project-with-eks-and-addon-with-irsa-managed-policy-role:
+    description: project managing an EKS cluster with an addon with IRSA with a managed policy
+    domain: False
+    intdomain: False
+    aws:
+        eks:
+            addons:
+                vpc-cni:
+                    label: vpc_cni
+                    irsa-role:
+                        managed-policy: arn:aws:iam::aws:policy/AmazonEKS_CNI_Policy
+                        service-account: aws-node
+                        namespace: kube-system
+
+project-with-eks-and-addon-with-irsa-policy-template-role:
+    description: project managing an EKS cluster with an addon with IRSA with a policy template
+    domain: False
+    intdomain: False
+    aws:
+        eks:
+            addons:
+                aws-ebs-csi-driver:
+                    label: aws_ebs_csi_driver
+                    irsa-role:
+                        policy-template: aws-ebs-csi-driver
+                        service-account: ebs-csi-controller-sa
+                        namespace: kube-system
+
 project-with-docdb:
     description: project managing a single DocumentDB instance
     aws:

--- a/src/tests/test_buildercore_project.py
+++ b/src/tests/test_buildercore_project.py
@@ -16,7 +16,7 @@ ALL_PROJECTS = [
     'project-on-gcp', 'project-with-bigquery-datasets-only', 'project-with-bigquery', 'project-with-bigquery-remote-schemas',
     'project-with-eks', 'project-with-eks-efs',
     'project-with-eks-and-iam-oidc-provider', 'project-with-eks-and-irsa-external-dns-role', 'project-with-eks-and-irsa-kubernetes-autoscaler-role', 'project-with-eks-and-irsa-csi-ebs-role',
-    'project-with-eks-and-simple-addons', 'project-with-eks-and-simple-addons-latest',
+    'project-with-eks-and-simple-addons', 'project-with-eks-and-simple-addons-latest', 'project-with-eks-and-addon-with-irsa-managed-policy-role', 'project-with-eks-and-addon-with-irsa-policy-template-role',
     'project-with-docdb', 'project-with-docdb-cluster',
     'project-with-unique-alt-config',
     'project-with-waf',

--- a/src/tests/test_buildercore_terraform.py
+++ b/src/tests/test_buildercore_terraform.py
@@ -1420,7 +1420,7 @@ class TestBuildercoreTerraform(base.BaseCase):
         self.assertIn('eks_addon_vpc_cni', terraform_template['resource']['aws_eks_addon'])
         self.assertEqual('${aws_iam_role.eks_addon_vpc_cni.arn}', terraform_template['resource']['aws_eks_addon']['eks_addon_vpc_cni']['service_account_role_arn'])
 
-    def test_eks_simple_addons_latest(self):
+    def test_eks_simple_addons_with_irsa_policy_template_role(self):
         pname = 'project-with-eks-and-addon-with-irsa-policy-template-role'
         iid = pname + '--%s' % self.environment
         context = cfngen.build_context(pname, stackname=iid)

--- a/src/tests/test_buildercore_terraform.py
+++ b/src/tests/test_buildercore_terraform.py
@@ -1403,6 +1403,43 @@ class TestBuildercoreTerraform(base.BaseCase):
         self.assertEqual('${data.aws_eks_addon_version.eks_addon_kube_proxy.version}', terraform_template['resource']['aws_eks_addon']['eks_addon_kube_proxy']['addon_version'])
         self.assertEqual('${data.aws_eks_addon_version.eks_addon_coredns.version}', terraform_template['resource']['aws_eks_addon']['eks_addon_coredns']['addon_version'])
 
+    def test_eks_simple_addons_with_irsa_managed_policy_role(self):
+        pname = 'project-with-eks-and-addon-with-irsa-managed-policy-role'
+        iid = pname + '--%s' % self.environment
+        context = cfngen.build_context(pname, stackname=iid)
+        terraform_template = json.loads(terraform.render(context))
+
+        self.assertIn('eks_addon_vpc_cni', terraform_template['resource']['aws_iam_role'])
+        self.assertIn('kube-system', terraform_template['resource']['aws_iam_role']['eks_addon_vpc_cni']['assume_role_policy'])
+        self.assertIn('aws-node', terraform_template['resource']['aws_iam_role']['eks_addon_vpc_cni']['assume_role_policy'])
+
+        self.assertIn('eks_addon_vpc_cni', terraform_template['resource']['aws_iam_role_policy_attachment'])
+        self.assertEqual('arn:aws:iam::aws:policy/AmazonEKS_CNI_Policy', terraform_template['resource']['aws_iam_role_policy_attachment']['eks_addon_vpc_cni']['policy_arn'])
+        self.assertEqual('${aws_iam_role.eks_addon_vpc_cni.name}', terraform_template['resource']['aws_iam_role_policy_attachment']['eks_addon_vpc_cni']['role'])
+
+        self.assertIn('eks_addon_vpc_cni', terraform_template['resource']['aws_eks_addon'])
+        self.assertEqual('${aws_iam_role.eks_addon_vpc_cni.arn}', terraform_template['resource']['aws_eks_addon']['eks_addon_vpc_cni']['service_account_role_arn'])
+
+    def test_eks_simple_addons_latest(self):
+        pname = 'project-with-eks-and-addon-with-irsa-policy-template-role'
+        iid = pname + '--%s' % self.environment
+        context = cfngen.build_context(pname, stackname=iid)
+        terraform_template = json.loads(terraform.render(context))
+
+        self.assertIn('eks_addon_aws_ebs_csi_driver', terraform_template['resource']['aws_iam_policy'])
+        self.assertIn('name', terraform_template['resource']['aws_iam_policy']['eks_addon_aws_ebs_csi_driver'])
+
+        self.assertIn('eks_addon_aws_ebs_csi_driver', terraform_template['resource']['aws_iam_role'])
+        self.assertIn('kube-system', terraform_template['resource']['aws_iam_role']['eks_addon_aws_ebs_csi_driver']['assume_role_policy'])
+        self.assertIn('ebs-csi-controller-sa', terraform_template['resource']['aws_iam_role']['eks_addon_aws_ebs_csi_driver']['assume_role_policy'])
+
+        self.assertIn('eks_addon_aws_ebs_csi_driver', terraform_template['resource']['aws_iam_role_policy_attachment'])
+        self.assertEqual('${aws_iam_policy.eks_addon_aws_ebs_csi_driver.arn}', terraform_template['resource']['aws_iam_role_policy_attachment']['eks_addon_aws_ebs_csi_driver']['policy_arn'])
+        self.assertEqual('${aws_iam_role.eks_addon_aws_ebs_csi_driver.name}', terraform_template['resource']['aws_iam_role_policy_attachment']['eks_addon_aws_ebs_csi_driver']['role'])
+
+        self.assertIn('eks_addon_aws_ebs_csi_driver', terraform_template['resource']['aws_eks_addon'])
+        self.assertEqual('${aws_iam_role.eks_addon_aws_ebs_csi_driver.arn}', terraform_template['resource']['aws_eks_addon']['eks_addon_aws_ebs_csi_driver']['service_account_role_arn'])
+
     def test_sanity_of_rendered_log_format(self):
         def _render_log_format_with_dummy_template():
             return re.sub(


### PR DESCRIPTION
This enables EKS addons to be optionally connected with IAM permissions, either via an existing policy template, or via pre-created managed policies.

This covers the last of the use cases needed to enable all currently manually managed addons and migrate to managed addons in EKS clusters.

Task under https://github.com/elifesciences/issues/issues/7228