### PR TITLE
firewall, add support for x-forwarded-for

### DIFF
--- a/projects/elife.yaml
+++ b/projects/elife.yaml
@@ -2182,7 +2182,11 @@ firewall:
                     - elife-Blacklist.json # priority 15
                     # lsh@2022-04-08: disabled, aws bot rules were ineffective, undermining this rule.
                     #- elife-DistributedSlowBot.json
-                    - elife-RateLimitExcessiveBotTraffic.json
+                    # lsh@2023-06-28: same intent, different ingress - via CDN and via prod--journal
+                    # using aggregate key to consolidate rules not possible as rule passes when any key in aggregate is absent.
+                    # - https://docs.aws.amazon.com/waf/latest/APIReference/API_RateBasedStatementCustomKey.html
+                    - elife-RateLimitExcessiveBotTrafficCDN.json # priority 19
+                    - elife-RateLimitExcessiveBotTraffic.json # priority 20
                 managed-rules:
                     AWS/AWSManagedRulesBotControlRuleSet:
                         priority: 5

--- a/src/buildercore/trop.py
+++ b/src/buildercore/trop.py
@@ -1561,7 +1561,7 @@ def render_waf_associations(context):
 def render_waf_ipsets(context):
     """returns a list of IPSet objects. These can be used in WAF rules to affect groups of IP addresses.
     we use them to whitelist traffic."""
-    def ipsuffix(ip_address):
+    def withsuffix(ip_address):
         if not '/' in ip_address:
             return ip_address + "/32"
         return ip_address
@@ -1572,7 +1572,7 @@ def render_waf_ipsets(context):
             'Name': "%s--%s" % (context['stackname'], ip_list_key), # "firewall--prod--whitelist"
             # "whitelist of IP addresses for firewall--prod"
             'Description': "%s of IPs for %s" % (ip_list_key, context['stackname']),
-            'Addresses': [ipsuffix(ip_address) for ip_address in ip_list_values],
+            'Addresses': [withsuffix(ip_address) for ip_address in ip_list_values],
             'IPAddressVersion': 'IPV4',
             'Scope': 'REGIONAL',
         })

--- a/src/buildercore/waf/elife-RateLimitExcessiveBotTrafficCDN.json
+++ b/src/buildercore/waf/elife-RateLimitExcessiveBotTrafficCDN.json
@@ -1,10 +1,14 @@
 {
-  "Name": "elife-RateLimitExcessiveBotTraffic",
-  "Priority": 20,
+  "Name": "elife-RateLimitExcessiveBotTrafficCDN",
+  "Priority": 19,
   "Statement": {
     "RateBasedStatement": {
       "Limit": 100,
-      "AggregateKeyType": "IP",
+      "AggregateKeyType": "FORWARDED_IP",
+      "ForwardedIPConfig": {
+        "HeaderName": "X-Forwarded-For",
+        "FallbackBehavior": "NO_MATCH"
+      },
       "ScopeDownStatement": {
         "OrStatement": {
           "Statements": [

--- a/src/buildercore/waf/elife-Whitelist.json
+++ b/src/buildercore/waf/elife-Whitelist.json
@@ -61,6 +61,13 @@
                   "FallbackBehavior": "NO_MATCH"
                 }
               }
+            },
+            {
+              "IPSetReferenceStatement": {
+                "Arn": {
+                  "Fn::GetAtt": ["WAFIPSetWhitelist", "Arn"]
+                }
+              }
             }
           ]
         }


### PR DESCRIPTION
* firewall, whitelist, added vpc subnet IP cidr for internal traffic.
* trop.py, added support for suffixed IP addresses in IP sets.
* firewall, disabled the AWS/AWSManagedRulesAmazonIpReputationList rule. it doesn't work when client IP is forwarded by a CDN.
* firewall, whitelist, uses x-forwarded-for IP instead of IP it should work now :P
* firewall, ExcessiveBotTraffic rule now uses x-forwarded-for IP instead of IP. it should work now :P

changes to infrastructure have already been applied

- [x] review