### PR TITLE
project complexity scoring

### DIFF
--- a/src/taskrunner.py
+++ b/src/taskrunner.py
@@ -150,6 +150,7 @@ TASK_LIST = [
     # see: https://alfred.elifesciences.org/job/process/job/process-project-security-updates/
     report.process_project_security_updates,
     report.ri_recommendations,
+    report.complexity_score,
 
     checks.stack_exists,
     tasks.delete_all_amis_to_prune,


### PR DESCRIPTION
adds a `report.complexity_score` function.

it aims to give each project instance a 'complexity score' to gauge. a database gets 1 point, an s3 bucket gets 1 point, an lb gets 1 point etc.

the purpose is to measure, very roughly, the changing complexity of the infrastructure. 

output for `journal`:

```json
{
    "journal": {
        "ci": {
            "ec2": 1,
            "db": 0,
            "other-db": 0,
            "s3": 0,
            "sqs/sns": 0,
            "lb": 0,
            "cdn": 0,
            "domain-name": 0,
            "score": 1
        },
        "end2end": {
            "ec2": 2,
            "db": 0,
            "other-db": 4,
            "s3": 0,
            "sqs/sns": 0,
            "lb": 0,
            "cdn": 0,
            "domain-name": 0,
            "score": 6
        },
        "continuumtest": {
            "ec2": 1,
            "db": 0,
            "other-db": 4,
            "s3": 0,
            "sqs/sns": 0,
            "lb": 0,
            "cdn": 0,
            "domain-name": 0,
            "score": 5
        },
        "prod": {
            "ec2": 4,
            "db": 0,
            "other-db": 4,
            "s3": 0,
            "sqs/sns": 0,
            "lb": 0,
            "cdn": 0,
            "domain-name": 0,
            "score": 8
        },
        "score": 20
    }
}
```

- [ ] add gcs resources
- [ ] add github repos
- [ ] add configuration (builder-config, builder-private, formula)
- [ ] add any web servers
- [ ] add any unmanaged resources (elife-bot uses simpledb for example)
- [ ] review