### PR TITLE
reintroduce public ips for flux-test cluster nodes

### DIFF
--- a/projects/elife.yaml
+++ b/projects/elife.yaml
@@ -2156,7 +2156,7 @@ kubernetes-aws:
                     max-size: 6
                     desired-capacity: 2
                     ignore-desired-capacity-drift: true
-                    assign-public-ip: false
+                    assign-public-ip: true
                 iam-oidc-provider: true
                 iam-roles:
                     kubernetes-autoscaler:


### PR DESCRIPTION
The experiment didn't work - new nodes didn't connect to cluster.

Need to investigate why the nodes connecting is reliant on having a public address:
```
[  198.350195] cloud-init[2494]: Connect timeout on endpoint URL: "https://ec2.us-east-1.amazonaws.com/"
```