### PR TITLE
projects, pins salt to version 3006.3

### DIFF
--- a/projects/elife.yaml
+++ b/projects/elife.yaml
@@ -4,7 +4,7 @@ defaults:
         # distinguishes this data from other types and versions of configuration data
         type: project
         version: 1
-    salt: "3006" # the version of Salt to install on ec2 instances
+    salt: "3006.3" # the version of Salt to install on ec2 instances
     terraform:
         # the version of Terraform this project requires
         version: "1.1.9"


### PR DESCRIPTION
version 3006.6, the latest as of today, has a serious bug preventing bootstrap. the most recently installed version we have deployed is 3006.3 (Sept '23), so pinning to that.