### PR TITLE
EKS managed node groups to replace autoscale groups and AWS launch configurations

### DIFF
--- a/projects/elife.yaml
+++ b/projects/elife.yaml
@@ -236,8 +236,10 @@ defaults:
             worker-subnet-id: subnet-07e912335040a0866
             worker-redundant-subnet-id: subnet-0110e7685debdb5eb
             worker:
-                # Whether to use managed node groups, or an ASG
+                # Whether to use managed node groups
                 managed: false
+                # What to use a self-managed ASG
+                self-managed: true
 
                 type: t2.small
                 # autoscaling group will never have fewer than these EC2 nodes
@@ -2150,6 +2152,8 @@ kubernetes-aws:
             eks:
                 version: '1.27'
                 worker:
+                    managed: false
+                    self-managed: true
                     type: t3.large
                     max-size: 34
                     desired-capacity: 16
@@ -2170,6 +2174,7 @@ kubernetes-aws:
                 version: '1.27'
                 worker:
                     managed: true
+                    self-managed: true
                     type: t3.large
                     max-size: 6
                     desired-capacity: 2

--- a/projects/elife.yaml
+++ b/projects/elife.yaml
@@ -236,6 +236,9 @@ defaults:
             worker-subnet-id: subnet-07e912335040a0866
             worker-redundant-subnet-id: subnet-0110e7685debdb5eb
             worker:
+                # Whether to use managed node groups, or an ASG
+                managed: false
+
                 type: t2.small
                 # autoscaling group will never have fewer than these EC2 nodes
                 min-size: 1
@@ -2166,6 +2169,7 @@ kubernetes-aws:
             eks:
                 version: '1.27'
                 worker:
+                    managed: true
                     type: t3.large
                     max-size: 6
                     desired-capacity: 2

--- a/src/buildercore/terraform.py
+++ b/src/buildercore/terraform.py
@@ -1099,10 +1099,10 @@ def _render_eks_managed_node_group(context, template):
         # Ensure that IAM Role permissions are created before and deleted after EKS Node Group handling.
         # Otherwise, EKS will not be able to properly delete EC2 Instances and Elastic Network Interfaces.
         'depends_on': [
-            '${aws_iam_role_policy_attachment.worker_connect',
-            '${aws_iam_role_policy_attachment.worker_cni',
-            '${aws_iam_role_policy_attachment.worker_ecr',
-            '${aws_iam_role_policy_attachment.worker_efs',
+            '${aws_iam_role_policy_attachment.worker_connect}',
+            '${aws_iam_role_policy_attachment.worker_cni}',
+            '${aws_iam_role_policy_attachment.worker_ecr}',
+            '${aws_iam_role_policy_attachment.worker_efs}',
         ],
 
         'lifecycle': {'ignore_changes': ['scaling_config[0].desired_size'] if lookup(context, 'eks.worker.ignore-desired-capacity-drift', False) is True else []},

--- a/src/buildercore/terraform.py
+++ b/src/buildercore/terraform.py
@@ -1063,24 +1063,14 @@ set -o xtrace
     })
 
 def _render_eks_managed_node_group(context, template):
-    autoscaling_group_tags = [
-        {
-            'key': k,
-            'value': v,
-            'propagate_at_launch': True,
-        }
-        for k, v in aws.generic_tags(context).items()
-    ]
-    autoscaling_group_tags.append({
-        'key': 'kubernetes.io/cluster/%s' % context['stackname'],
-        'value': 'owned',
-        'propagate_at_launch': True,
-    })
+    managed_node_tags = {
+        k: v for k, v in aws.generic_tags(context).items()
+    }
 
     worker = {
         'cluster_name': '${aws_eks_cluster.main.name}',
         'node_group_name': '%s--worker' % context['stackname'],
-        'tag': autoscaling_group_tags,
+        'tags': managed_node_tags,
 
         'node_role_arn': '${aws_iam_role.worker.name}',
 

--- a/src/buildercore/terraform.py
+++ b/src/buildercore/terraform.py
@@ -112,19 +112,36 @@ IRSA_POLICY_TEMPLATES = {
                     "autoscaling:DescribeLaunchConfigurations",
                     "autoscaling:DescribeTags",
                     "ec2:DescribeInstanceTypes",
-                    "ec2:DescribeLaunchTemplateVersions"
+                    "ec2:DescribeLaunchTemplateVersions",
+                    "ec2:DescribeImages",
+                    "ec2:GetInstanceTypesFromInstanceRequirements",
+                    "eks:DescribeNodegroup",
                 ],
-                "Resource": ["*"]
+                "Resource": "*"
             },
             {
                 "Effect": "Allow",
                 "Action": [
                     "autoscaling:SetDesiredCapacity",
-                    "autoscaling:TerminateInstanceInAutoScalingGroup"
+                    "autoscaling:TerminateInstanceInAutoScalingGroup",
                 ],
                 "Resource": [
                     "${aws_autoscaling_group.worker.arn}",
                 ],
+            },
+            {
+                "Effect": "Allow",
+                "Action": [
+                    "autoscaling:SetDesiredCapacity",
+                    "autoscaling:TerminateInstanceInAutoScalingGroup",
+                ],
+                "Resource": "*",
+                "Condition": {
+                    "StringEquals": {
+                        "aws:ResourceTag/k8s.io/cluster-autoscaler/enabled": "true",
+                        "aws:ResourceTag/k8s.io/cluster-autoscaler/%s" % stackname: "owned"
+                    }
+                }
             },
         ],
     },

--- a/src/buildercore/terraform.py
+++ b/src/buildercore/terraform.py
@@ -1090,7 +1090,7 @@ def _render_eks_managed_node_group(context, template):
         'scaling_config':  {
             'min_size': context['eks']['worker']['min-size'],
             'max_size': context['eks']['worker']['max-size'],
-            'desired_capacity': context['eks']['worker']['desired-capacity'],
+            'desired_size': context['eks']['worker']['desired-capacity'],
         },
         'update_config': {
             'max_unavailable': 1,

--- a/src/buildercore/terraform.py
+++ b/src/buildercore/terraform.py
@@ -1367,10 +1367,9 @@ def render_eks(context, template):
     _render_eks_master(context, template)
     _render_eks_workers_security_group(context, template)
     _render_eks_workers_role(context, template)
+    _render_eks_workers_autoscaling_group(context, template)
     if lookup(context, 'eks.worker.managed', False):
         _render_eks_managed_node_group(context, template)
-    else:
-        _render_eks_workers_autoscaling_group(context, template)
     _render_eks_user_access(context, template)
     if lookup(context, 'eks.iam-oidc-provider', False):
         _render_eks_iam_access(context, template)

--- a/src/buildercore/terraform.py
+++ b/src/buildercore/terraform.py
@@ -1072,7 +1072,7 @@ def _render_eks_managed_node_group(context, template):
         'node_group_name': '%s--worker' % context['stackname'],
         'tags': managed_node_tags,
 
-        'node_role_arn': '${aws_iam_role.worker.name}',
+        'node_role_arn': '${aws_iam_role.worker.arn}',
 
         'subnet_ids': [context['eks']['worker-subnet-id'], context['eks']['worker-redundant-subnet-id']],
 

--- a/src/buildercore/terraform.py
+++ b/src/buildercore/terraform.py
@@ -1099,14 +1099,16 @@ def _render_eks_managed_node_group(context, template):
         # Ensure that IAM Role permissions are created before and deleted after EKS Node Group handling.
         # Otherwise, EKS will not be able to properly delete EC2 Instances and Elastic Network Interfaces.
         'depends_on': [
-            '${aws_iam_role_policy_attachment.worker_connect}',
-            '${aws_iam_role_policy_attachment.worker_cni}',
-            '${aws_iam_role_policy_attachment.worker_ecr}',
-            '${aws_iam_role_policy_attachment.worker_efs}',
+            'aws_iam_role_policy_attachment.worker_connect',
+            'aws_iam_role_policy_attachment.worker_cni',
+            'aws_iam_role_policy_attachment.worker_ecr',
         ],
 
         'lifecycle': {'ignore_changes': ['scaling_config[0].desired_size'] if lookup(context, 'eks.worker.ignore-desired-capacity-drift', False) is True else []},
     }
+
+    if context['eks']['efs']:
+        worker['depends_on'].push('aws_iam_role_policy_attachment.worker_efs')
 
 
     root_volume_size = lookup(context, 'eks.worker.root.size', None)

--- a/src/buildercore/terraform.py
+++ b/src/buildercore/terraform.py
@@ -1367,7 +1367,8 @@ def render_eks(context, template):
     _render_eks_master(context, template)
     _render_eks_workers_security_group(context, template)
     _render_eks_workers_role(context, template)
-    _render_eks_workers_autoscaling_group(context, template)
+    if lookup(context, 'eks.worker.self-mamaged', False):
+        _render_eks_workers_autoscaling_group(context, template)
     if lookup(context, 'eks.worker.managed', False):
         _render_eks_managed_node_group(context, template)
     _render_eks_user_access(context, template)

--- a/src/buildercore/terraform.py
+++ b/src/buildercore/terraform.py
@@ -125,16 +125,6 @@ IRSA_POLICY_TEMPLATES = {
                     "autoscaling:SetDesiredCapacity",
                     "autoscaling:TerminateInstanceInAutoScalingGroup",
                 ],
-                "Resource": [
-                    "${aws_autoscaling_group.worker.arn}",
-                ],
-            },
-            {
-                "Effect": "Allow",
-                "Action": [
-                    "autoscaling:SetDesiredCapacity",
-                    "autoscaling:TerminateInstanceInAutoScalingGroup",
-                ],
                 "Resource": "*",
                 "Condition": {
                     "StringEquals": {

--- a/src/buildercore/terraform.py
+++ b/src/buildercore/terraform.py
@@ -1140,7 +1140,7 @@ def _render_eks_managed_node_group(context, template):
     }
 
     if context['eks']['efs']:
-        worker['depends_on'].push('aws_iam_role_policy_attachment.worker_efs')
+        node_group['depends_on'].push('aws_iam_role_policy_attachment.worker_efs')
 
     template.populate_resource('aws_eks_node_group', 'worker', block=node_group)
 

--- a/src/buildercore/terraform.py
+++ b/src/buildercore/terraform.py
@@ -1068,6 +1068,16 @@ set -o xtrace
         'value': 'owned',
         'propagate_at_launch': True,
     })
+    autoscaling_group_tags.append({
+        'key': 'k8s.io/cluster-autoscaler/enabled',
+        'value': 'true',
+        'propagate_at_launch': True,
+    })
+    autoscaling_group_tags.append({
+        'key': 'k8s.io/cluster-autoscaler/%s' % context['stackname'],
+        'value': 'owned',
+        'propagate_at_launch': True,
+    })
     template.populate_resource('aws_autoscaling_group', 'worker', block={
         'name': '%s--worker' % context['stackname'],
         'launch_configuration': '${aws_launch_configuration.worker.id}',

--- a/src/buildercore/terraform.py
+++ b/src/buildercore/terraform.py
@@ -1369,7 +1369,7 @@ def render_eks(context, template):
     _render_eks_master(context, template)
     _render_eks_workers_security_group(context, template)
     _render_eks_workers_role(context, template)
-    if lookup(context, 'eks.worker.self-mamaged', False):
+    if lookup(context, 'eks.worker.self-managed', False):
         _render_eks_workers_autoscaling_group(context, template)
     if lookup(context, 'eks.worker.managed', False):
         _render_eks_managed_node_group(context, template)

--- a/src/buildercore/terraform.py
+++ b/src/buildercore/terraform.py
@@ -1100,9 +1100,7 @@ def _render_eks_managed_node_group(context, template):
 
     template.populate_resource('aws_launch_template', 'worker', block=launch_template)
 
-    managed_node_tags = {
-        k: v for k, v in aws.generic_tags(context).items()
-    }
+    managed_node_tags = dict(aws.generic_tags(context).items())
 
     worker = {
         'cluster_name': '${aws_eks_cluster.main.name}',

--- a/src/buildercore/terraform.py
+++ b/src/buildercore/terraform.py
@@ -1399,7 +1399,7 @@ def render_eks(context, template):
     _render_eks_master(context, template)
     _render_eks_workers_security_group(context, template)
     _render_eks_workers_role(context, template)
-    if lookup(context, 'eks.worker.self-managed', False):
+    if lookup(context, 'eks.worker.self-managed', True):
         _render_eks_workers_autoscaling_group(context, template)
     if lookup(context, 'eks.worker.managed', False):
         _render_eks_managed_node_group(context, template)

--- a/src/buildercore/terraform.py
+++ b/src/buildercore/terraform.py
@@ -1093,14 +1093,10 @@ def _render_eks_managed_node_group(context, template):
                 'volume_type': 'gp3',
                 'iops': 3000,
                 'throughput': 125,
-                'volume_size': 20,
+                'volume_size': lookup(context, 'eks.worker.root.size', 20),
             }
         }
     }
-
-    root_volume_size = lookup(context, 'eks.worker.root.size', None)
-    if root_volume_size:
-        launch_template['block_device_mappings']['volume_size'] = root_volume_size
 
     template.populate_resource('aws_launch_template', 'worker', block=launch_template)
 

--- a/src/tests/fixtures/projects/dummy-project.yaml
+++ b/src/tests/fixtures/projects/dummy-project.yaml
@@ -963,6 +963,8 @@ project-with-eks:
             worker-subnet-id: subnet-c3c3c3c3
             worker-redundant-subnet-id: subnet-d4d4d4d4
             worker:
+                managed: true
+                self-managed: true
                 type: t2.small
                 desired-capacity: 3
                 min-size: 1

--- a/src/tests/test_buildercore_terraform.py
+++ b/src/tests/test_buildercore_terraform.py
@@ -1232,6 +1232,16 @@ class TestBuildercoreTerraform(base.BaseCase):
                         'value': 'owned',
                         'propagate_at_launch': True,
                     },
+                    {
+                        'key': 'k8s.io/cluster-autoscaler/enabled',
+                        'value': 'true',
+                        'propagate_at_launch': True,
+                    },
+                    {
+                        'key': 'k8s.io/cluster-autoscaler/project-with-eks--%s' % self.environment,
+                        'value': 'owned',
+                        'propagate_at_launch': True,
+                    },
                 ],
                 'lifecycle': {'ignore_changes': []},
             }

--- a/src/tests/test_buildercore_terraform.py
+++ b/src/tests/test_buildercore_terraform.py
@@ -929,6 +929,8 @@ class TestBuildercoreTerraform(base.BaseCase):
         self.assertIn('aws_iam_role_policy_attachment', terraform_template['resource'].keys())
         self.assertIn('aws_launch_configuration', terraform_template['resource'].keys())
         self.assertIn('aws_autoscaling_group', terraform_template['resource'].keys())
+        self.assertIn('aws_launch_template', terraform_template['resource'].keys())
+        self.assertIn('aws_eks_node_group', terraform_template['resource'].keys())
         self.assertIn('kubernetes_config_map', terraform_template['resource'].keys())
         self.assertIn('data', terraform_template.keys())
         self.assertIn('aws_ami', terraform_template['data'].keys())
@@ -1231,6 +1233,72 @@ class TestBuildercoreTerraform(base.BaseCase):
                         'propagate_at_launch': True,
                     },
                 ],
+                'lifecycle': {'ignore_changes': []},
+            }
+        )
+
+
+        self.assertIn('worker', terraform_template['resource']['aws_launch_template'])
+        self.assertEqual(
+            terraform_template['resource']['aws_launch_template']['worker'],
+            {
+                'network_interfaces': {
+                    'associate_public_ip_address': True,
+                    'security_groups': ['${aws_security_group.worker.id}'],
+                },
+                'name_prefix': 'project-with-eks--%s--worker' % self.environment,
+                'block_device_mappings': {
+                    'device_name': '/dev/xvda',
+                    'ebs': {
+                        'volume_type': 'gp3',
+                        'iops': 3000,
+                        'throughput': 125,
+                        'volume_size': 40,
+                    }
+                }
+            }
+        )
+
+        self.assertIn('worker', terraform_template['resource']['aws_eks_node_group'])
+        self.assertEqual(
+            terraform_template['resource']['aws_eks_node_group']['worker'],
+            {
+
+                'cluster_name': '${aws_eks_cluster.main.name}',
+                'node_group_name': "project-with-eks--%s--worker" % self.environment,
+                'tags': {
+                    'Project': 'project-with-eks',
+                    'Environment': self.environment,
+                    'Name': 'project-with-eks--%s' % self.environment,
+                    'Cluster': 'project-with-eks--%s' % self.environment,
+                },
+
+                'node_role_arn': '${aws_iam_role.worker.arn}',
+
+                'subnet_ids': ['subnet-c3c3c3c3', 'subnet-d4d4d4d4'],
+
+                'instance_types': ['t2.small'],
+                'scaling_config':  {
+                    'min_size': 1,
+                    'max_size': 3,
+                    'desired_size': 3,
+                },
+                'update_config': {
+                    'max_unavailable': 1,
+                },
+                'launch_template': {
+                    'id': "${aws_launch_template.worker.id}",
+                    'version': "${aws_launch_template.worker.latest_version}"
+                },
+
+                # Ensure that IAM Role permissions are created before and deleted after EKS Node Group handling.
+                # Otherwise, EKS will not be able to properly delete EC2 Instances and Elastic Network Interfaces.
+                'depends_on': [
+                    'aws_iam_role_policy_attachment.worker_connect',
+                    'aws_iam_role_policy_attachment.worker_cni',
+                    'aws_iam_role_policy_attachment.worker_ecr',
+                ],
+
                 'lifecycle': {'ignore_changes': []},
             }
         )

--- a/src/tests/test_buildercore_terraform.py
+++ b/src/tests/test_buildercore_terraform.py
@@ -1265,6 +1265,15 @@ class TestBuildercoreTerraform(base.BaseCase):
                         'throughput': 125,
                         'volume_size': 40,
                     }
+                },
+                'tag_specifications': {
+                    'resource_type': 'instance',
+                    'tags': {
+                        'Cluster': 'project-with-eks--%s' % self.environment,
+                        'Environment': self.environment,
+                        'Name': 'project-with-eks--%s' % self.environment,
+                        'Project': 'project-with-eks'
+                    }
                 }
             }
         )


### PR DESCRIPTION
Add the ability to optionally create managed node groups, and optionally remove the self-managed auto scaling group for EKS clusters

relates to https://github.com/elifesciences/issues/issues/8300

Plan to migrate a cluster (e.g. `flux-test`)
1. Set `managed: true` to create the MNG nodes for the cluster
2. drain the ASG nodes on the cluster
3. Set `self-managed: false` to remove the ASG nodes from cluster. (This is step that we can't back out from)

Eventually https://github.com/elifesciences/issues/issues/8300 will remove the ASG code, and the optionality of a managed node group will disappear too.