### PR TITLE
Upgrade to latest aws provider v4

### DIFF
--- a/projects/elife.yaml
+++ b/projects/elife.yaml
@@ -11,7 +11,7 @@ defaults:
         # the version of Terraform providers (plugins) required.
         provider-aws:
             source: "hashicorp/aws"
-            version: "4.66.1"
+            version: "4.67.0"
         provider-tls:
             source: "hashicorp/tls"
             version: "4.0.4"


### PR DESCRIPTION
A step on the way for https://github.com/elifesciences/issues/issues/8622

FYI @lsh-0 - you've previously said only the clusters use the aws resources in builder, so I've done it globally.