### PR TITLE
Remove EKS EFS support

### DIFF
--- a/projects/elife.yaml
+++ b/projects/elife.yaml
@@ -249,7 +249,6 @@ defaults:
                 #   size: 20 # GiB, default
                 # Assign public ip addresses to worker nodes. Default is true
                 assign-public-ip: true
-            efs: false
             addons:
                 coredns: {}
                 kube-proxy:

--- a/src/buildercore/terraform.py
+++ b/src/buildercore/terraform.py
@@ -1061,9 +1061,6 @@ def _render_eks_managed_node_group(context, template):
         'lifecycle': {'ignore_changes': ['scaling_config[0].desired_size'] if lookup(context, 'eks.worker.ignore-desired-capacity-drift', False) is True else []},
     }
 
-    if context['eks']['efs']:
-        node_group['depends_on'].append('aws_iam_role_policy_attachment.worker_efs')
-
     template.populate_resource('aws_eks_node_group', 'worker', block=node_group)
 
 def _render_eks_workers_role(context, template):
@@ -1097,35 +1094,6 @@ def _render_eks_workers_role(context, template):
         'policy_arn': "arn:aws:iam::aws:policy/AmazonEC2ContainerRegistryReadOnly",
         'role': "${aws_iam_role.worker.name}",
     })
-
-    if context['eks']['efs']:
-        template.populate_resource('aws_iam_policy', 'kubernetes_efs', block={
-            'name': '%s--AmazonEFSKubernetes' % context['stackname'],
-            'path': '/',
-            'description': 'Allows management of EFS resources',
-            'policy': json.dumps({
-                "Version": "2012-10-17",
-                "Statement": [
-                    {
-                        "Effect": "Allow",
-                        "Action": [
-                            "elasticfilesystem:DescribeFileSystems",
-                            "elasticfilesystem:DescribeMountTargets",
-                            "elasticfilesystem:DescribeMountTargetSecurityGroups",
-                            "elasticfilesystem:DescribeTags",
-                        ],
-                        "Resource": [
-                            "*",
-                        ],
-                    },
-                ],
-            }),
-        })
-
-        template.populate_resource('aws_iam_role_policy_attachment', 'worker_efs', block={
-            'policy_arn': "${aws_iam_policy.kubernetes_efs.arn}",
-            'role': "${aws_iam_role.worker.name}",
-        })
 
 def _render_eks_workers_security_group(context, template):
     template.populate_resource('aws_security_group_rule', 'worker_to_master', block={

--- a/src/tests/fixtures/projects/dummy-project.yaml
+++ b/src/tests/fixtures/projects/dummy-project.yaml
@@ -241,7 +241,6 @@ defaults:
                 #   size: 20 # GiB, default
                 # Assign public ip addresses to worker nodes. Default is true
                 assign-public-ip: true
-            efs: false
         cloudfront:
             # cloudfront defaults only used if a 'cloudfront' section present in project
             #subdomains: [] # todo: enable

--- a/src/tests/fixtures/projects/dummy-project.yaml
+++ b/src/tests/fixtures/projects/dummy-project.yaml
@@ -972,14 +972,6 @@ project-with-eks:
                 root:
                     size: 40
 
-project-with-eks-efs:
-    description: project managing an EKS cluster with EFS support
-    domain: False
-    intdomain: False
-    aws:
-        eks:
-            efs: true
-
 project-with-eks-and-iam-oidc-provider:
     description: project managing an EKS cluster with it's IAM OIDC provisioned for IRSA
     domain: False

--- a/src/tests/test_buildercore_project.py
+++ b/src/tests/test_buildercore_project.py
@@ -16,7 +16,7 @@ ALL_PROJECTS = [
     'project-with-db-params', 'project-with-rds-only', 'project-with-rds-encryption', 'project-with-rds-major-version-upgrade', 'project-with-rds-snapshot',
     'project-with-elasticache-redis', 'project-with-multiple-elasticaches', 'project-with-fully-overridden-elasticaches',
     'project-on-gcp', 'project-with-bigquery-datasets-only', 'project-with-bigquery', 'project-with-bigquery-remote-schemas',
-    'project-with-eks', 'project-with-eks-efs',
+    'project-with-eks',
     'project-with-eks-and-iam-oidc-provider', 'project-with-eks-and-irsa-external-dns-role', 'project-with-eks-and-irsa-kubernetes-autoscaler-role', 'project-with-eks-and-irsa-csi-ebs-role',
     'project-with-eks-and-simple-addons', 'project-with-eks-and-simple-addons-latest', 'project-with-eks-and-addon-with-irsa-managed-policy-role', 'project-with-eks-and-addon-with-irsa-policy-template-role',
     'project-with-docdb', 'project-with-docdb-cluster',

--- a/src/tests/test_buildercore_terraform.py
+++ b/src/tests/test_buildercore_terraform.py
@@ -1257,51 +1257,6 @@ class TestBuildercoreTerraform(base.BaseCase):
             }
         )
 
-    def test_eks_and_efs(self):
-        pname = 'project-with-eks-efs'
-        iid = pname + '--%s' % self.environment
-        context = cfngen.build_context(pname, stackname=iid)
-        terraform_template = json.loads(terraform.render(context))
-
-        self.assertIn('kubernetes_efs', terraform_template['resource']['aws_iam_policy'])
-        self.assertEqual(
-            '%s--AmazonEFSKubernetes' % context['stackname'],
-            terraform_template['resource']['aws_iam_policy']['kubernetes_efs']['name']
-        )
-        self.assertEqual(
-            '/',
-            terraform_template['resource']['aws_iam_policy']['kubernetes_efs']['path']
-        )
-        self.assertEqual(
-            {
-                "Version": "2012-10-17",
-                "Statement": [
-                    {
-                        "Effect": "Allow",
-                        "Action": [
-                            "elasticfilesystem:DescribeFileSystems",
-                            "elasticfilesystem:DescribeMountTargets",
-                            "elasticfilesystem:DescribeMountTargetSecurityGroups",
-                            "elasticfilesystem:DescribeTags",
-                        ],
-                        "Resource": [
-                            "*",
-                        ],
-                    },
-                ]
-            },
-            json.loads(terraform_template['resource']['aws_iam_policy']['kubernetes_efs']['policy'])
-        )
-
-        self.assertIn('worker_efs', terraform_template['resource']['aws_iam_role_policy_attachment'])
-        self.assertEqual(
-            {
-                'policy_arn': '${aws_iam_policy.kubernetes_efs.arn}',
-                'role': "${aws_iam_role.worker.name}",
-            },
-            terraform_template['resource']['aws_iam_role_policy_attachment']['worker_efs']
-        )
-
     def test_eks_and_iam_oidc_provider(self):
         pname = 'project-with-eks-and-iam-oidc-provider'
         iid = pname + '--%s' % self.environment


### PR DESCRIPTION
This feature isn't in use and isn't how we would do this, both on the cluster and from an AWS security policy perspective now.