### PR TITLE
Change the EKS access control to `API_AND_CONFIG_MAP`

### DIFF
--- a/src/buildercore/terraform.py
+++ b/src/buildercore/terraform.py
@@ -982,7 +982,20 @@ def _render_eks_user_access(context, template):
     template.populate_resource('aws_eks_access_entry', 'user', block={
         'cluster_name': '${aws_eks_cluster.main.name}',
         'principal_arn': '${aws_iam_role.user.arn}',
-        'kubernetes_groups': ['system:masters'],
+    })
+
+    template.populate_resource('aws_eks_access_entry', 'user', block={
+        'cluster_name': '${aws_eks_cluster.main.name}',
+        'principal_arn': '${aws_iam_role.user.arn}',
+    })
+
+    template.populate_resource('aws_eks_access_policy_association', 'user', block={
+        'cluster_name': '${aws_eks_cluster.main.name}',
+        'principal_arn': '${aws_iam_role.user.arn}',
+        'policy_arn': 'arn:aws:eks::aws:cluster-access-policy/AmazonEKSClusterAdminPolicy',
+        'access_scope': {
+            'type': 'cluster',
+        },
     })
 
     template.populate_local('config_map_aws_auth', """

--- a/src/buildercore/terraform.py
+++ b/src/buildercore/terraform.py
@@ -1199,6 +1199,9 @@ def _render_eks_master(context, template):
             'security_group_ids': ['${aws_security_group.master.id}'],
             'subnet_ids': [context['eks']['subnet-id'], context['eks']['redundant-subnet-id']],
         },
+        'access_config': {
+            'authentication_mode': "API_AND_CONFIG_MAP",
+        },
         'depends_on': [
             "aws_iam_role_policy_attachment.master_kubernetes",
             "aws_iam_role_policy_attachment.master_ecs",

--- a/src/buildercore/terraform.py
+++ b/src/buildercore/terraform.py
@@ -979,6 +979,12 @@ def _render_eks_user_access(context, template):
         }),
     })
 
+    template.populate_resource('aws_eks_access_entry', 'user', block={
+        'cluster_name': '${aws_eks_cluster.main.name}',
+        'principal_arn': '${aws_iam_role.user.arn}',
+        'kubernetes_groups': ['system:masters'],
+    })
+
     template.populate_local('config_map_aws_auth', """
 - rolearn: ${aws_iam_role.worker.arn}
   username: system:node:{{EC2PrivateDNSName}}

--- a/src/tests/test_buildercore_terraform.py
+++ b/src/tests/test_buildercore_terraform.py
@@ -1244,6 +1244,16 @@ class TestBuildercoreTerraform(base.BaseCase):
             }
         )
 
+        self.assertIn('user', terraform_template['resource']['aws_eks_access_entry'])
+        self.assertEqual(
+            terraform_template['resource']['aws_eks_access_entry']['user'],
+            {
+                'cluster_name': '${aws_eks_cluster.main.name}',
+                'principal_arn': '${aws_iam_role.user.arn}',
+                'kubernetes_groups': ['system:masters'],
+            }
+        )
+
         self.assertIn('config_map_aws_auth', terraform_template['locals'])
         self.assertIn('aws_iam_role.worker.arn', terraform_template['locals']['config_map_aws_auth'])
         self.assertIn('aws_auth', terraform_template['resource']['kubernetes_config_map'])

--- a/src/tests/test_buildercore_terraform.py
+++ b/src/tests/test_buildercore_terraform.py
@@ -941,6 +941,9 @@ class TestBuildercoreTerraform(base.BaseCase):
                     'security_group_ids': ['${aws_security_group.master.id}'],
                     'subnet_ids': ['subnet-a1a1a1a1', 'subnet-b2b2b2b2'],
                 },
+                'access_config': {
+                    'authentication_mode': "API_AND_CONFIG_MAP",
+                },
                 'depends_on': [
                     "aws_iam_role_policy_attachment.master_kubernetes",
                     "aws_iam_role_policy_attachment.master_ecs",

--- a/src/tests/test_buildercore_terraform.py
+++ b/src/tests/test_buildercore_terraform.py
@@ -1244,13 +1244,27 @@ class TestBuildercoreTerraform(base.BaseCase):
             }
         )
 
+        self.assertIn('aws_eks_access_entry', terraform_template['resource'])
         self.assertIn('user', terraform_template['resource']['aws_eks_access_entry'])
         self.assertEqual(
             terraform_template['resource']['aws_eks_access_entry']['user'],
             {
                 'cluster_name': '${aws_eks_cluster.main.name}',
                 'principal_arn': '${aws_iam_role.user.arn}',
-                'kubernetes_groups': ['system:masters'],
+            }
+        )
+
+        self.assertIn('aws_eks_access_policy_association', terraform_template['resource'])
+        self.assertIn('user', terraform_template['resource']['aws_eks_access_policy_association'])
+        self.assertEqual(
+            terraform_template['resource']['aws_eks_access_policy_association']['user'],
+            {
+               'cluster_name': '${aws_eks_cluster.main.name}',
+                'principal_arn': '${aws_iam_role.user.arn}',
+                'policy_arn': 'arn:aws:eks::aws:cluster-access-policy/AmazonEKSClusterAdminPolicy',
+                'access_scope': {
+                    'type': 'cluster',
+                },
             }
         )
 


### PR DESCRIPTION
Change the EKS access control to use API and CONFIGMAP so we can start to build access control into builder, and remove the configmap handling with terraform