### PR TITLE
Use the cluster name as the value for addons cluster_name

### DIFF
--- a/src/buildercore/terraform.py
+++ b/src/buildercore/terraform.py
@@ -1242,7 +1242,7 @@ def _render_eks_addon(context, template, addon):
         )
 
     resource_block = {
-        'cluster_name': '${data.aws_eks_cluster.main.id}',
+        'cluster_name': '${data.aws_eks_cluster.main.name}',
         'addon_name': name,
         'addon_version': version if version != 'latest' else '${data.aws_eks_addon_version.eks_addon_%s.version}' % label,
         'tags': aws.generic_tags(context),


### PR DESCRIPTION
This fixes spurious need to recreate cluster addons for no reason