### PR TITLE
Revert "separate out the addons kubernetes versions from the cluster version (#1240)"

### DIFF
--- a/projects/elife.yaml
+++ b/projects/elife.yaml
@@ -2145,7 +2145,6 @@ kubernetes-aws:
             ec2: false
             eks:
                 version: '1.27'
-                addons_version: '1.27'
                 worker:
                     type: t3.large
                     max-size: 34
@@ -2165,7 +2164,6 @@ kubernetes-aws:
             ec2: false
             eks:
                 version: '1.27'
-                addons_version: '1.27'
                 worker:
                     type: t3.large
                     max-size: 6

--- a/src/buildercore/cfngen.py
+++ b/src/buildercore/cfngen.py
@@ -726,7 +726,6 @@ def build_context_eks(pdata, context):
             'name': data.get('name', label), # name of the addon returned from DescribeAddonVersions API request, e.g. kube-proxy
             'label': data.get('label', label), # local label for terraform resource e.g. "kube_proxy"
             'version': data.get('version', 'latest'),
-            'kubernetes_version': context['eks'].get('addons_version', context['eks'].get('version')),
             'configuration-values': data.get('configuration-values', None),
             'resolve-conflicts-on-create': 'OVERWRITE',
             'resolve-conflicts-on-update': 'PRESERVE'

--- a/src/buildercore/terraform.py
+++ b/src/buildercore/terraform.py
@@ -1228,7 +1228,6 @@ def _render_eks_addon(context, template, addon):
     name = addon['name'] # "kube-proxy"
     label = addon['label'] # "kube_proxy"
     version = addon['version']
-    kubernetes_version = addon['kubernetes_version']
 
     if version == 'latest':
         template.populate_data(
@@ -1236,7 +1235,7 @@ def _render_eks_addon(context, template, addon):
             'eks_addon_%s' % label,
             block={
                 'addon_name': name,
-                'kubernetes_version': kubernetes_version,
+                'kubernetes_version': '${data.aws_eks_cluster.main.version}',
                 'most_recent': True,
             }
         )

--- a/src/buildercore/terraform.py
+++ b/src/buildercore/terraform.py
@@ -1235,7 +1235,7 @@ def _render_eks_addon(context, template, addon):
             'eks_addon_%s' % label,
             block={
                 'addon_name': name,
-                'kubernetes_version': '${data.aws_eks_cluster.main.version}',
+                'kubernetes_version': '${resource.aws_eks_cluster.main.version}',
                 'most_recent': True,
             }
         )

--- a/src/tests/test_buildercore_terraform.py
+++ b/src/tests/test_buildercore_terraform.py
@@ -1358,8 +1358,6 @@ class TestBuildercoreTerraform(base.BaseCase):
         self.assertIn('eks_addon_coredns', terraform_template['data']['aws_eks_addon_version'])
         self.assertTrue(terraform_template['data']['aws_eks_addon_version']['eks_addon_kube_proxy']['most_recent'])
         self.assertTrue(terraform_template['data']['aws_eks_addon_version']['eks_addon_coredns']['most_recent'])
-        self.assertEqual('1.11', terraform_template['data']['aws_eks_addon_version']['eks_addon_kube_proxy']['kubernetes_version'])
-        self.assertEqual('1.11', terraform_template['data']['aws_eks_addon_version']['eks_addon_coredns']['kubernetes_version'])
         self.assertEqual('${data.aws_eks_addon_version.eks_addon_kube_proxy.version}', terraform_template['resource']['aws_eks_addon']['eks_addon_kube_proxy']['addon_version'])
         self.assertEqual('${data.aws_eks_addon_version.eks_addon_coredns.version}', terraform_template['resource']['aws_eks_addon']['eks_addon_coredns']['addon_version'])
 


### PR DESCRIPTION
This reverts commit f7b4f6625d04570bee6826a33f7588ba1054a7ca.

Turns out this wasn't the real cause, and this makes upgrades a two step process unnecessarily 