### PR TITLE
Remove dependance on a context for observer--end2end existing in s3 elifesciences/issues#9044

### DIFF
--- a/src/tests/test_buildercore_bootstrap.py
+++ b/src/tests/test_buildercore_bootstrap.py
@@ -36,27 +36,29 @@ pillar_roots:
     def test_unsub_sqs(self):
         stackname = 'observer--end2end'
         with open(join(self.fixtures_dir, 'sns_subscriptions.json')) as fh:
-            fixture = json.load(fh)
-        with mock.patch('buildercore.core._all_sns_subscriptions', return_value=fixture):
-            # observer no longer wants to subscribe to metrics
-            context = {stackname: ['bus-articles--end2end', 'bus-metrics--end2end']}
-            del context[stackname][1]
+            subs_fixture = json.load(fh)
+        with mock.patch('buildercore.core._all_sns_subscriptions', return_value=subs_fixture):
+            old_context = {'sqs':{stackname: ['bus-articles--end2end', 'bus-metrics--end2end']}}
+            with mock.patch('buildercore.context_handler.load_context', return_value=old_context):
+                # observer no longer wants to subscribe to metrics
+                new_context = dict(old_context)
+                del new_context['sqs'][stackname][1]
 
-            actual = bootstrap.unsub_sqs(stackname, context, 'someregion', dry_run=True)
-            expected = (
-                {
-                    stackname: [{'Endpoint': 'arn:aws:sqs:us-east-1:512686554592:observer--end2end',
-                                 'Owner': '512686554592',
-                                 'Protocol': 'sqs',
-                                 'SubscriptionArn': 'arn:aws:sns:us-east-1:512686554592:bus-metrics--end2end:71f61023-3905-40bb-9f7c-0ce710175212',
-                                 'Topic': 'bus-metrics--end2end',
-                                 'TopicArn': 'arn:aws:sns:us-east-1:512686554592:bus-metrics--end2end'}]
-                },
-                {
-                    'observer--end2end': ['arn:aws:sns:us-east-1:512686554592:bus-metrics--end2end'],
-                },
-            )
-            self.assertEqual(expected, actual)
+                actual = bootstrap.unsub_sqs(stackname, new_context['sqs'], 'someregion', dry_run=True)
+                expected = (
+                    {
+                        stackname: [{'Endpoint': 'arn:aws:sqs:us-east-1:512686554592:observer--end2end',
+                                    'Owner': '512686554592',
+                                    'Protocol': 'sqs',
+                                    'SubscriptionArn': 'arn:aws:sns:us-east-1:512686554592:bus-metrics--end2end:71f61023-3905-40bb-9f7c-0ce710175212',
+                                    'Topic': 'bus-metrics--end2end',
+                                    'TopicArn': 'arn:aws:sns:us-east-1:512686554592:bus-metrics--end2end'}]
+                    },
+                    {
+                        stackname: ['arn:aws:sns:us-east-1:512686554592:bus-metrics--end2end'],
+                    },
+                )
+                self.assertEqual(expected, actual)
 
     def test_unsub_sqs_detect_multiple_subs(self):
         "when multiple subscriptions to a single topic exist, unsusbscribe from them"
@@ -77,20 +79,21 @@ pillar_roots:
         fixture.append(multiple_sub_same_topic)
 
         with mock.patch('buildercore.core._all_sns_subscriptions', return_value=fixture):
-            context = {stackname: ['bus-articles--end2end', 'bus-metrics--end2end']}
-            actual = bootstrap.unsub_sqs(stackname, context, 'someregion', dry_run=True)
-            expected_unsub_map = {
-                stackname: [
-                    {'Endpoint': 'arn:aws:sqs:us-east-1:512686554592:observer--end2end',
-                     'Owner': '512686554592',
-                     'Protocol': 'sqs',
-                     'SubscriptionArn': 'arn:aws:sns:us-east-1:512686554592:bus-articles--end2end:foobar',
-                     'Topic': 'bus-articles--end2end',
-                     'TopicArn': 'arn:aws:sns:us-east-1:512686554592:bus-articles--end2end'}]}
-            expected_perm_map = {
-                'observer--end2end': ['arn:aws:sns:us-east-1:512686554592:bus-articles--end2end']}
-            expected = (expected_unsub_map, expected_perm_map)
-            assert expected == actual
+            context = {'sqs': {stackname: ['bus-articles--end2end', 'bus-metrics--end2end']}}
+            with mock.patch('buildercore.context_handler.load_context', return_value=context):
+                actual = bootstrap.unsub_sqs(stackname, context['sqs'], 'someregion', dry_run=True)
+                expected_unsub_map = {
+                    stackname: [
+                        {'Endpoint': 'arn:aws:sqs:us-east-1:512686554592:observer--end2end',
+                        'Owner': '512686554592',
+                        'Protocol': 'sqs',
+                        'SubscriptionArn': 'arn:aws:sns:us-east-1:512686554592:bus-articles--end2end:foobar',
+                        'Topic': 'bus-articles--end2end',
+                        'TopicArn': 'arn:aws:sns:us-east-1:512686554592:bus-articles--end2end'}]}
+                expected_perm_map = {
+                    'observer--end2end': ['arn:aws:sns:us-east-1:512686554592:bus-articles--end2end']}
+                expected = (expected_unsub_map, expected_perm_map)
+                assert expected == actual
 
     def test_remove_topics_from_sqs_policy(self):
         original = {


### PR DESCRIPTION
Relates to: elifesciences/issues#9044