### PR TITLE
switch box to a multi-arch, multi-provider base box

### DIFF
--- a/projects/elife.yaml
+++ b/projects/elife.yaml
@@ -422,7 +422,7 @@ defaults:
     gcp:
         bigquery: false
     vagrant:
-        box: ubuntu/focal64 # 20.04
+        box: bento/ubuntu-20.04
         ip: 192.168.56.44
         ram: 2048
         cpus: 2


### PR DESCRIPTION
This allows for virtualbox and vmware as providers.

I've tested this on vmware/mac/arm64 and virtualbox/linux/amd64