### PR TITLE
[experimental] Support for lima-based dev environments

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -14,3 +14,5 @@
 /.pytest_cache
 /custom-vagrant
 /stacks
+
+/dev-env

--- a/.gitignore
+++ b/.gitignore
@@ -37,3 +37,5 @@ tfenv.tar.gz
 .bin/
 
 projects/elife/.vproject
+
+/dev-env

--- a/create-dev-env
+++ b/create-dev-env
@@ -18,42 +18,43 @@ source ./venv/bin/activate
 PS3="Select a project: "
 select project in $(./.project.py --format json --env=lima | jq -r '.|join(" ")')
 do
-    project=${project:-$REPLY}
+  project=${project:-$REPLY}
 
-    if ! (./.project.py --format json --env=lima $project 2>&1 >/dev/null); then
-      echo ""
-      echo "project $project doesn't exist in builder project config"
-      exit 1
+  if ! (./.project.py --format json --env=lima $project 2>&1 >/dev/null); then
+    echo ""
+    echo "project $project doesn't exist in builder project config"
+    exit 1
+  fi
+  project_config="$(./.project.py --format json --env=lima $project)"
+break;
+
+dependant_formulas=$(echo "$project_config" | yq -o j  '(.["formula-dependencies"] // [])|map({"url": ., "name": .|split("/")[-1]})' | jq -c)
+project_formula=$(echo "$project_config" | yq -o j  '.["formula-repo"]|{"url": ., "name": .|split("/")[-1]}' | jq -c)
+all_formulas=$(echo "[$project_formula]$dependant_formulas" | jq -s 'add' | jq -c)
+first_dependant_formula=$(echo "$dependant_formulas" | jq -c '.[0]')
+all_the_rest_dependant_formula=$(echo "$dependant_formulas" | jq -c '.[1:]')
+
+readarray -t all_formulas_array < <(echo "$all_formulas" | jq -c '.[]')
+
+for formula in "${all_formulas_array[@]}"; do
+    formula_name=$(echo $formula | jq -r .name)
+    formula_url=$(echo $formula | jq -r .url)
+    formula_path="$DIR/cloned-projects/$formula_name"
+
+    if [ ! -d "$formula_path/.git" ]; then
+        echo "cloning $formula_name"
+        git clone "$formula_url" "$formula_path" 2>&1 > /dev/null
+    else
+        echo "updating $formula_name"
+        git -C "$formula_path" pull 2>&1 > /dev/null || echo "issue updating checkout"
     fi
-    project_config="$(./.project.py --format json --env=lima $project)"
+done
 
-    dependant_formulas=$(echo "$project_config" | yq -o j  '(.["formula-dependencies"] // [])|map({"url": ., "name": .|split("/")[-1]})' | jq -c)
-    project_formula=$(echo "$project_config" | yq -o j  '.["formula-repo"]|{"url": ., "name": .|split("/")[-1]}' | jq -c)
-    all_formulas=$(echo "[$project_formula]$dependant_formulas" | jq -s 'add' | jq -c)
-    first_dependant_formula=$(echo "$dependant_formulas" | jq -c '.[0]')
-    all_the_rest_dependant_formula=$(echo "$dependant_formulas" | jq -c '.[1:]')
+# Make directories for override salt formulas
+mkdir -p $DIR/dev-env/$project/salt
+mkdir -p $DIR/dev-env/$project/pillar
 
-    readarray -t all_formulas_array < <(echo "$all_formulas" | jq -c '.[]')
-
-    for formula in "${all_formulas_array[@]}"; do
-        formula_name=$(echo $formula | jq -r .name)
-        formula_url=$(echo $formula | jq -r .url)
-        formula_path="$DIR/cloned-projects/$formula_name"
-
-        if [ ! -d "$formula_path/.git" ]; then
-            echo "cloning $formula_name"
-            git clone "$formula_url" "$formula_path" 2>&1 > /dev/null
-        else
-            echo "updating $formula_name"
-            git -C "$formula_path" pull 2>&1 > /dev/null || echo "issue updating checkout"
-        fi
-    done
-
-    # Make directories for override salt formulas
-    mkdir -p $DIR/dev-env/$project/salt
-    mkdir -p $DIR/dev-env/$project/pillar
-
-    minion_config=$(cat << EOF
+minion_config=$(cat << EOF
 ---
 file_client: local
 log_level: info
@@ -77,14 +78,14 @@ $(echo "$all_formulas" | yq -P -o yaml '{"pillar_roots":{"base":["/builder/dev-e
 EOF
 )
 
-    minion_config_base64=$(echo "$minion_config" | base64)
+minion_config_base64=$(echo "$minion_config" | base64)
 
 
 
-    instance_name="$project--lima"
-    salt_version="$(echo $project_config | jq -r .salt)"
+instance_name="$project--lima"
+salt_version="$(echo $project_config | jq -r .salt)"
 
-    lima_config=$(cat << EOF
+lima_config=$(cat << EOF
 minimumLimaVersion: "1.0.0"
 # turn off containerd setup
 containerd:
@@ -122,9 +123,9 @@ EOF
 
 
 
-    vm_name="$project-lima"
-    echo "$lima_config" | limactl create --tty=false --name="$vm_name" -
-    limactl start $vm_name
+vm_name="$project-lima"
+echo "$lima_config" | limactl create --tty=false --name="$vm_name" -
+limactl start $vm_name
 
-    break;
+
 done

--- a/create-dev-env
+++ b/create-dev-env
@@ -26,7 +26,8 @@ do
     exit 1
   fi
   project_config="$(./.project.py --format json --env=lima $project)"
-break;
+  break;
+done
 
 dependant_formulas=$(echo "$project_config" | yq -o j  '(.["formula-dependencies"] // [])|map({"url": ., "name": .|split("/")[-1]})' | jq -c)
 project_formula=$(echo "$project_config" | yq -o j  '.["formula-repo"]|{"url": ., "name": .|split("/")[-1]}' | jq -c)
@@ -126,6 +127,3 @@ EOF
 vm_name="$project-lima"
 echo "$lima_config" | limactl create --tty=false --name="$vm_name" -
 limactl start $vm_name
-
-
-done

--- a/create-dev-env
+++ b/create-dev-env
@@ -16,13 +16,22 @@ fi
 source ./venv/bin/activate
 
 PS3="Select a project: "
-select project in $(./.project.py --format json --env=lima | jq '.|join(" ")')
+select project in $(./.project.py --format json --env=lima | jq -r '.|join(" ")')
 do
+    project=${project:-$REPLY}
+
+    if ! (./.project.py --format json --env=lima $project 2>&1 >/dev/null); then
+      echo ""
+      echo "project $project doesn't exist in builder project config"
+      exit 1
+    fi
     project_config="$(./.project.py --format json --env=lima $project)"
 
     dependant_formulas=$(echo "$project_config" | yq -o j  '(.["formula-dependencies"] // [])|map({"url": ., "name": .|split("/")[-1]})' | jq -c)
     project_formula=$(echo "$project_config" | yq -o j  '.["formula-repo"]|{"url": ., "name": .|split("/")[-1]}' | jq -c)
-    all_formulas=$(echo "$project_config" | yq -o j  '(.["formula-dependencies"] // []) + [.["formula-repo"]]|map({"url": ., "name": .|split("/")[-1]})' | jq -c)
+    all_formulas=$(echo "[$project_formula]$dependant_formulas" | jq -s 'add' | jq -c)
+    first_dependant_formula=$(echo "$dependant_formulas" | jq -c '.[0]')
+    all_the_rest_dependant_formula=$(echo "$dependant_formulas" | jq -c '.[1:]')
 
     readarray -t all_formulas_array < <(echo "$all_formulas" | jq -c '.[]')
 
@@ -40,6 +49,10 @@ do
         fi
     done
 
+    # Make directories for override salt formulas
+    mkdir -p $DIR/dev-env/$project/salt
+    mkdir -p $DIR/dev-env/$project/pillar
+
     minion_config=$(cat << EOF
 ---
 file_client: local
@@ -47,12 +60,23 @@ log_level: info
 fileserver_backend:
 - roots
 
-$(echo "$dependant_formulas" | yq -P -o yaml '{"file_roots":{"base":["/builder/dev-env/salt/"] + (.|map("/builder/cloned-projects/" + .name + "/salt/")) + ["/project/salt/"]}}')
+# Expected order:
+# The dev-env override salt formulas
+# The first dependant salt formula (usually builder-base-formula)
+# The project salt formulas
+# The rest of the dependant salt formulas
+$(echo "[$first_dependant_formula] [$project_formula] $all_the_rest_dependant_formula" | jq -s "add" | yq -P -o yaml '{"file_roots":{"base":["/builder/dev-env/$project/salt/"] + (.|map("/builder/cloned-projects/" + .name + "/salt/"))}}')
 
-$(echo "$dependant_formulas" | yq -P -o yaml '{"pillar_roots":{"base":["/builder/dev-env/pillar/", "/project/salt/pillar/"] + (.|map("/builder/cloned-projects/" + .name + "/salt/pillar"))}}')
+# Expected order:
+# The dev-env override formula pillar data
+# The project formula pillar data
+# The dependant formula pillar data
+
+$(echo "$all_formulas" | yq -P -o yaml '{"pillar_roots":{"base":["/builder/dev-env/$project/pillar/"] + (.|map("/builder/cloned-projects/" + .name + "/salt/pillar"))}}')
 
 EOF
 )
+
     minion_config_base64=$(echo "$minion_config" | base64)
 
 
@@ -69,14 +93,8 @@ containerd:
 
 # Mount script directory in the VM
 mounts:
-- location: "$DIR/scripts"
-  mountPoint: /scripts
-  writable: false
 - location: "$DIR"
   mountPoint: /builder
-  writable: false
-- location: "$DIR/cloned-projects/$(echo "$project_formula" | jq -r .name)"
-  mountPoint: /project
   writable: false
 
 ## Provision
@@ -88,7 +106,7 @@ provision:
 - mode: system
   script: |
     #!/bin/bash
-    bash /scripts/bootstrap.sh "$salt_version" "$instance_name" "false"
+    bash /builder/scripts/bootstrap.sh "$salt_version" "$instance_name" "false"
 # Setup new dev env
 - mode: system
   script: |

--- a/create-dev-env
+++ b/create-dev-env
@@ -1,0 +1,112 @@
+#!/usr/bin/env bash
+set -e
+
+if ! [ -x "$(command -v limactl)" ]; then
+    echo "no lima"
+    exit 1
+fi
+
+DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+cd $DIR
+
+if [ ! -d venv ]; then
+    ./update.sh
+fi
+
+source ./venv/bin/activate
+
+PS3="Select a project: "
+select project in $(./.project.py --format json --env=lima | jq '.|join(" ")')
+do
+    project_config="$(./.project.py --format json --env=lima $project)"
+
+    dependant_formulas=$(echo "$project_config" | yq -o j  '(.["formula-dependencies"] // [])|map({"url": ., "name": .|split("/")[-1]})' | jq -c)
+    project_formula=$(echo "$project_config" | yq -o j  '.["formula-repo"]|{"url": ., "name": .|split("/")[-1]}' | jq -c)
+    all_formulas=$(echo "$project_config" | yq -o j  '(.["formula-dependencies"] // []) + [.["formula-repo"]]|map({"url": ., "name": .|split("/")[-1]})' | jq -c)
+
+    readarray -t all_formulas_array < <(echo "$all_formulas" | jq -c '.[]')
+
+    for formula in "${all_formulas_array[@]}"; do
+        formula_name=$(echo $formula | jq -r .name)
+        formula_url=$(echo $formula | jq -r .url)
+        formula_path="$DIR/cloned-projects/$formula_name"
+
+        if [ ! -d "$formula_path/.git" ]; then
+            echo "cloning $formula_name"
+            git clone "$formula_url" "$formula_path" 2>&1 > /dev/null
+        else
+            echo "updating $formula_name"
+            git -C "$formula_path" pull 2>&1 > /dev/null || echo "issue updating checkout"
+        fi
+    done
+
+    minion_config=$(cat << EOF
+---
+file_client: local
+log_level: info
+fileserver_backend:
+- roots
+
+$(echo "$dependant_formulas" | yq -P -o yaml '{"file_roots":{"base":["/builder/dev-env/salt/"] + (.|map("/builder/cloned-projects/" + .name + "/salt/")) + ["/project/salt/"]}}')
+
+$(echo "$dependant_formulas" | yq -P -o yaml '{"pillar_roots":{"base":["/builder/dev-env/pillar/", "/project/salt/pillar/"] + (.|map("/builder/cloned-projects/" + .name + "/salt/pillar"))}}')
+
+EOF
+)
+    minion_config_base64=$(echo "$minion_config" | base64)
+
+
+
+    instance_name="$project--lima"
+    salt_version="$(echo $project_config | jq -r .salt)"
+
+    lima_config=$(cat << EOF
+minimumLimaVersion: "1.0.0"
+# turn off containerd setup
+containerd:
+  system: false
+  user: false
+
+# Mount script directory in the VM
+mounts:
+- location: "$DIR/scripts"
+  mountPoint: /scripts
+  writable: false
+- location: "$DIR"
+  mountPoint: /builder
+  writable: false
+- location: "$DIR/cloned-projects/$(echo "$project_formula" | jq -r .name)"
+  mountPoint: /project
+  writable: false
+
+## Provision
+# Update system before anything else
+upgradePackages: true
+
+provision:
+# Do bootstrap
+- mode: system
+  script: |
+    #!/bin/bash
+    bash /scripts/bootstrap.sh "$salt_version" "$instance_name" "false"
+# Setup new dev env
+- mode: system
+  script: |
+    #!/bin/bash
+    echo $minion_config_base64 | base64 -d > /etc/salt/minion
+
+
+# Embed entire project lima config here
+$(echo $project_config | jq .lima | yq -P --output-format yaml '.')
+# End project config
+EOF
+)
+
+
+
+    vm_name="$project-lima"
+    echo "$lima_config" | limactl create --tty=false --name="$vm_name" -
+    limactl start $vm_name
+
+    break;
+done

--- a/create-dev-env
+++ b/create-dev-env
@@ -15,19 +15,22 @@ fi
 
 source ./venv/bin/activate
 
-PS3="Select a project: "
-select project in $(./.project.py --format json --env=lima | jq -r '.|join(" ")')
-do
-  project=${project:-$REPLY}
+project=$1
+if [ -z "$project" ]; then
+  PS3="Select a project: "
+  select project in $(./.project.py --format json --env=lima | jq -r '.|join(" ")')
+  do
+    project=${project:-$REPLY}
+    break;
+  done
+fi
 
-  if ! (./.project.py --format json --env=lima $project 2>&1 >/dev/null); then
-    echo ""
-    echo "project $project doesn't exist in builder project config"
-    exit 1
-  fi
-  project_config="$(./.project.py --format json --env=lima $project)"
-  break;
-done
+if ! (./.project.py --format json --env=lima $project 2>&1 >/dev/null); then
+  echo ""
+  echo "project $project doesn't exist in builder project config"
+  exit 1
+fi
+project_config="$(./.project.py --format json --env=lima $project)"
 
 dependant_formulas=$(echo "$project_config" | yq -o j  '(.["formula-dependencies"] // [])|map({"url": ., "name": .|split("/")[-1]})' | jq -c)
 project_formula=$(echo "$project_config" | yq -o j  '.["formula-repo"]|{"url": ., "name": .|split("/")[-1]}' | jq -c)

--- a/dev-env/README.md
+++ b/dev-env/README.md
@@ -1,0 +1,9 @@
+# dev-salt
+
+This directory is used to allow overriding of the salt dev environments created and used by the ./create-dev-env
+
+When a project dev env is created using that script, a corresponding set of directories are created here under the name of the project.
+
+For example, if you are created a dev environment for a project called `iiif`, there would be a directory here called `iiif`, with a `pillar` and `salt` diretory that would take precendence over the project, dependant and base formulas within that environments. This allows you to experiment with alternative configs, pillar data, etc without having to make those in the clone-project formulas and risk committing them accidentally.
+
+This whole directory is gitignored and beyond the creation of the directories as described above, you should manage its contents yourself.

--- a/projects/elife.yaml
+++ b/projects/elife.yaml
@@ -431,6 +431,14 @@ defaults:
         #ports:
         #    1239: 80
         #    1240: 8001
+    lima:
+        images:
+            - location: "https://cloud-images.ubuntu.com/releases/20.04/release/ubuntu-20.04-server-cloudimg-amd64.img"
+              arch: "x86_64"
+            - location: "https://cloud-images.ubuntu.com/releases/20.04/release/ubuntu-20.04-server-cloudimg-arm64.img"
+              arch: "aarch64"
+        cpus: 2
+        memory: 2GiB
 
 basebox:
     formula-repo: https://github.com/elifesciences/basebox-formula


### PR DESCRIPTION
This is to overcome issues with compatiblity of vagrant and virtualbox. Using lima, we can create environments based on qemu and various host environments. These are based on real ubuntu cloud images, extremely close to the AMIs that ubuntu publish. Anecdotally, they also seem to be a bit more responsive.

In addition, using lima and qemu this way give opportunity to use emulation and test with ARM architecture either ARM->intel or intel->ARM. 

The implemetation itself is a self-container bash script that gathers the needed config from builder and pipes it in as config to `limactl`. This config includes auto provisioning for salt, relevant formula mount points and highstate. After the creation script is done, you can control the dev environment using standard limactl commandline.

There are a few known issues:
- [ ] the abandoned support for IPv6 aggressively decides what the network environment should look like, and disables the network in lima VMs. [I proposed we remove it](https://github.com/elifesciences/builder-base-formula/pull/429)
- [ ] when logging in with `limactl shell`, it shows errors from trying to change into the host directory. This is because we **don't** mount that directory, but I've not yet found where and how to disable that behaviour

We should test this out on as many configurations as we can before merging, but I'd like it to sit alongside vagrant initially.