### PR TITLE
Undo .project.py changes

### DIFF
--- a/create-lima-dev-env
+++ b/create-lima-dev-env
@@ -30,12 +30,12 @@ if [ -z "$project" ]; then
   done
 fi
 
-if ! (PROJECT=$project ./bldr project.data:output_format=json 2>&1 >/dev/null); then
+if ! (./.project.py --format json --env=lima $project 2>&1 >/dev/null); then
   echo ""
   echo "project $project doesn't exist in builder project config"
   exit 1
 fi
-project_config="$(PROJECT=$project ./bldr project.data:output_format=json)"
+project_config="$(./.project.py --format json --env=lima $project)"
 
 dependant_formulas=$(echo "$project_config" | yq -o j  '(.["formula-dependencies"] // [])|map({"url": ., "name": .|split("/")[-1]})' | jq -c)
 project_formula=$(echo "$project_config" | yq -o j  '.["formula-repo"]|{"url": ., "name": .|split("/")[-1]}' | jq -c)

--- a/create-lima-dev-env
+++ b/create-lima-dev-env
@@ -23,7 +23,7 @@ source ./venv/bin/activate
 project=$1
 if [ -z "$project" ]; then
   PS3="Select a project: "
-  select project in $(./bldr project.list:output_format=json | jq -r '.|join(" ")')
+  select project in $(./.project.py --format json --env=lima | jq -r '.|join(" ")')
   do
     project=${project:-$REPLY}
     break;

--- a/src/buildercore/project/files.py
+++ b/src/buildercore/project/files.py
@@ -66,6 +66,7 @@ def project_data(pname, project_file):
 
     excluding = [
         'vagrant',
+        'lima',
         'aws-alt',
         'gcp-alt',
         {'aws': CLOUD_EXCLUDING_DEFAULTS_IF_NOT_PRESENT},

--- a/src/project.py
+++ b/src/project.py
@@ -5,12 +5,6 @@ from buildercore import cfngen, config, core, project
 from buildercore.command import local, settings
 from decorators import format_output, requires_project
 
-@format_output('yaml')
-def list(include_without_formula=False, output_format=None):
-    if include_without_formula:
-        return project.project_list()
-
-    return [*project.filtered_projects(lambda pname, pdata: 'formula-repo' in pdata and pdata['formula-repo'] is not None)]
 
 @requires_project
 @format_output('yaml')

--- a/src/taskrunner.py
+++ b/src/taskrunner.py
@@ -102,7 +102,6 @@ TASK_LIST = [
     # see: journal/Jenkinsfile.prod
     deploy.load_balancer_register_all,
 
-    project.list,
     project.data,
     project.context,
     project.new,


### PR DESCRIPTION
Turns out builder does keep 2 separate lists of projects, one that includes all config, and one that only includes the stacks (see `src/buildercore/project/__init__.py:project_map()` vs `src/buildercore/project/files.py:project_data()`).

Revert changes to use a single bldr command for this, and exclude lima from the stacks-only config