### PR TITLE
restructure to run multiple version checks separately

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -10,20 +10,18 @@ elifePipeline {
     pythonVersions.each { pythonVersion ->
         versionActions['Python ' + pythonVersion] = {
             lock('builder') {
-                stage 'Python ' + pythonVersion + ': Update', {
-                    sh 'mise exec python@${pythonVersion} -- ./update.sh --exclude virtualbox vagrant ssh-credentials ssh-agent vault'
+                stage "Python ${pythonVersion}: Update", {
+                    sh "mise exec python@${pythonVersion} -- ./update.sh --exclude virtualbox vagrant ssh-credentials ssh-agent vault"
                 }
 
-                stage 'Python ' + pythonVersion + ': .ci/ checks', {
-                    def checkActions = [:]
-                    checkActions['lint'] = elifeLocalTests('mise exec python@${pythonVersion} -- ./.ci/lint')
-                    checkActions['projects-smoke'] = elifeLocalTests('mise exec python@${pythonVersion} -- ./.ci/projects-smoke')
-                    checkActions['scrub'] = elifeLocalTests('mise exec python@${pythonVersion} -- ./.ci/scrub')
-                    checkActions['shell-checking'] = elifeLocalTests('mise exec python@${pythonVersion} -- ./.ci/shell-checking')
-                    parallel checkActions
-                }
+                def checkActions = [:]
+                checkActions["Python ${pythonVersion}: lint"] = elifeLocalTests("mise exec python@${pythonVersion} -- ./.ci/lint")
+                checkActions["Python ${pythonVersion}: projects-smoke"] = elifeLocalTests("mise exec python@${pythonVersion} -- ./.ci/projects-smoke")
+                checkActions["Python ${pythonVersion}: scrub"] = elifeLocalTests("mise exec python@${pythonVersion} -- ./.ci/scrub")
+                checkActions["Python ${pythonVersion}: shell-checking"] = elifeLocalTests("mise exec python@${pythonVersion} -- ./.ci/shell-checking")
+                parallel checkActions
 
-                stage 'Python ' + pythonVersion + ': Project tests', {
+                stage "Python ${pythonVersion}: Project tests", {
                     withCommitStatus({
                         try {
                             sh "BUILDER_INTEGRATION_TESTS=1 JUNIT_OUTPUT_ID=py${pythonVersion} mise exec python@${pythonVersion} -- ./test.sh"

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,36 +1,43 @@
 elifePipeline {
-
+    def pythonVersions = ['3.8', '3.9', '3.10']
     def commit
     stage 'Checkout', {
         checkout scm
         commit = elifeGitRevision()
     }
 
-    stage 'Update', {
-        sh './update.sh --exclude virtualbox vagrant ssh-credentials ssh-agent vault'
-    }
+    def versionActions = [:]
+    pythonVersions.each { pythonVersion ->
+        versionActions['Python ' + pythonVersion] = {
+            lock('builder') {
+                stage 'Python ' + pythonVersion + ': Update', {
+                    sh 'mise exec python@${pythonVersion} -- ./update.sh --exclude virtualbox vagrant ssh-credentials ssh-agent vault'
+                }
 
-    stage '.ci/ checks', {
-        elifeLocalTests()
-    }
+                stage 'Python ' + pythonVersion + ': .ci/ checks', {
+                    def checkActions = [:]
+                    checkActions['lint'] = elifeLocalTests('mise exec python@${pythonVersion} -- ./.ci/lint')
+                    checkActions['projects-smoke'] = elifeLocalTests('mise exec python@${pythonVersion} -- ./.ci/projects-smoke')
+                    checkActions['scrub'] = elifeLocalTests('mise exec python@${pythonVersion} -- ./.ci/scrub')
+                    checkActions['shell-checking'] = elifeLocalTests('mise exec python@${pythonVersion} -- ./.ci/shell-checking')
+                    parallel checkActions
+                }
 
-    lock('builder') {
-        def actions = [:]
-        def pythonVersions = ['3.8', '3.9', '3.10']
-
-        pythonVersions.each { pythonVersion ->
-            stage 'Project tests python ' + pythonVersion, {
-                withCommitStatus({
-                    try {
-                        sh "BUILDER_INTEGRATION_TESTS=1 JUNIT_OUTPUT_ID=py${pythonVersion} mise exec python@${pythonVersion} -- ./test.sh"
-                    } finally {
-                        // https://issues.jenkins-ci.org/browse/JENKINS-27395?focusedCommentId=345589&page=com.atlassian.jira.plugin.system.issuetabpanels%3Acomment-tabpanel#comment-345589
-                        junit testResults: "build/pytest-py${pythonVersion}.xml"
-                    }
-                }, "py" + pythonVersion, commit)
+                stage 'Python ' + pythonVersion + ': Project tests', {
+                    withCommitStatus({
+                        try {
+                            sh "BUILDER_INTEGRATION_TESTS=1 JUNIT_OUTPUT_ID=py${pythonVersion} mise exec python@${pythonVersion} -- ./test.sh"
+                        } finally {
+                            // https://issues.jenkins-ci.org/browse/JENKINS-27395?focusedCommentId=345589&page=com.atlassian.jira.plugin.system.issuetabpanels%3Acomment-tabpanel#comment-345589
+                            junit testResults: "build/pytest-py${pythonVersion}.xml"
+                        }
+                    }, "py" + pythonVersion, commit)
+                }
             }
         }
     }
+
+    parallel versionActions
 
     stage 'Downstream', {
         elifeMainlineOnly {

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -14,28 +14,9 @@ elifePipeline {
                     sh "mise exec python@${pythonVersion} -- ./update.sh --exclude virtualbox vagrant ssh-credentials ssh-agent vault"
                 }
 
-                def checkActions = [:]
-                checkActions["Python ${pythonVersion}: lint"] = {
-                    withCommitStatus({
-                        sh "mise exec python@${pythonVersion} -- ./.ci/lint"
-                    }, "Python ${pythonVersion}: lint", commit)
+                stage "Python ${pythonVersion}: .ci/ checks", {
+                    elifeLocalTests()
                 }
-                checkActions["Python ${pythonVersion}: projects-smoke"] = {
-                    withCommitStatus({
-                        sh "mise exec python@${pythonVersion} -- ./.ci/projects-smoke"
-                    }, "Python ${pythonVersion}: projects", commit)
-                }
-                checkActions["Python ${pythonVersion}: scrub"] = {
-                    withCommitStatus({
-                        sh "mise exec python@${pythonVersion} -- ./.ci/scrub"
-                    }, "Python ${pythonVersion}: scrub", commit)
-                }
-                checkActions["Python ${pythonVersion}: shell-checking"] = {
-                    withCommitStatus({
-                        sh "mise exec python@${pythonVersion} -- ./.ci/shell-checking"
-                    }, "Python ${pythonVersion}: shell", commit)
-                }
-                parallel checkActions
 
                 stage "Python ${pythonVersion}: Project tests", {
                     withCommitStatus({

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -7,11 +7,11 @@ elifePipeline {
         commit = elifeGitRevision()
     }
 
-    stage "Update", {
+    stage 'Update', {
         sh "mise exec python@${defaultPythonVersion} -- ./update.sh --exclude virtualbox vagrant ssh-credentials ssh-agent vault"
     }
 
-    stage ".ci/ checks", {
+    stage '.ci/ checks', {
         elifeLocalTests()
     }
 

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,9 +1,18 @@
 elifePipeline {
+    def defaultPythonVersion = '3.8'
     def pythonVersions = ['3.8', '3.9', '3.10']
     def commit
     stage 'Checkout', {
         checkout scm
         commit = elifeGitRevision()
+    }
+
+    stage "Update", {
+        sh "mise exec python@${defaultPythonVersion} -- ./update.sh --exclude virtualbox vagrant ssh-credentials ssh-agent vault"
+    }
+
+    stage ".ci/ checks", {
+        elifeLocalTests()
     }
 
     def versionActions = [:]
@@ -12,10 +21,6 @@ elifePipeline {
             lock('builder') {
                 stage "Python ${pythonVersion}: Update", {
                     sh "mise exec python@${pythonVersion} -- ./update.sh --exclude virtualbox vagrant ssh-credentials ssh-agent vault"
-                }
-
-                stage "Python ${pythonVersion}: .ci/ checks", {
-                    elifeLocalTests()
                 }
 
                 stage "Python ${pythonVersion}: Project tests", {

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -15,10 +15,26 @@ elifePipeline {
                 }
 
                 def checkActions = [:]
-                checkActions["Python ${pythonVersion}: lint"] = elifeLocalTests("mise exec python@${pythonVersion} -- ./.ci/lint")
-                checkActions["Python ${pythonVersion}: projects-smoke"] = elifeLocalTests("mise exec python@${pythonVersion} -- ./.ci/projects-smoke")
-                checkActions["Python ${pythonVersion}: scrub"] = elifeLocalTests("mise exec python@${pythonVersion} -- ./.ci/scrub")
-                checkActions["Python ${pythonVersion}: shell-checking"] = elifeLocalTests("mise exec python@${pythonVersion} -- ./.ci/shell-checking")
+                checkActions["Python ${pythonVersion}: lint"] = {
+                    withCommitStatus({
+                        sh "mise exec python@${pythonVersion} -- ./.ci/lint"
+                    }, "Python ${pythonVersion}: lint", commit)
+                }
+                checkActions["Python ${pythonVersion}: projects-smoke"] = {
+                    withCommitStatus({
+                        sh "mise exec python@${pythonVersion} -- ./.ci/projects-smoke"
+                    }, "Python ${pythonVersion}: projects", commit)
+                }
+                checkActions["Python ${pythonVersion}: scrub"] = {
+                    withCommitStatus({
+                        sh "mise exec python@${pythonVersion} -- ./.ci/scrub"
+                    }, "Python ${pythonVersion}: scrub", commit)
+                }
+                checkActions["Python ${pythonVersion}: shell-checking"] = {
+                    withCommitStatus({
+                        sh "mise exec python@${pythonVersion} -- ./.ci/shell-checking"
+                    }, "Python ${pythonVersion}: shell", commit)
+                }
                 parallel checkActions
 
                 stage "Python ${pythonVersion}: Project tests", {

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,5 +1,5 @@
 elifePipeline {
-    def defaultPythonVersion = '3.8'
+    def defaultPythonVersion = '3.10'
     def pythonVersions = ['3.8', '3.9', '3.10']
     def commit
     stage 'Checkout', {


### PR DESCRIPTION
Restructure pipeline to run multiple version checks in parallel (but with a lock serialising the runs).

The idea is to get clearer feedback about which python version is failing 

elifesciences/issues#9243