### PR TITLE
Retain fastly records on deletion elifesciences/issues#9213

### DIFF
--- a/src/buildercore/trop.py
+++ b/src/buildercore/trop.py
@@ -1364,6 +1364,7 @@ def external_dns_fastly(context):
             Type="CNAME",
             TTL="60",
             ResourceRecords=[cname],
+            DeletionPolicy="Retain", # To support a migration from builder
         )
     return [entry(hostname, i) for i, hostname in enumerate(context['fastly']['subdomains'])]
 


### PR DESCRIPTION
This allows migration away from cloudformation into to terraform

elifesciences/issues#9213