### PR TITLE
Retain fastly A records on deletion elifesciences/issues#9213

### DIFF
--- a/src/buildercore/trop.py
+++ b/src/buildercore/trop.py
@@ -1353,6 +1353,7 @@ def external_dns_fastly(context):
                 Type="A",
                 TTL="60",
                 ResourceRecords=ip_addresses,
+                DeletionPolicy="Retain", # To support a migration from builder
             )
 
         hostedzone = context['domain'] + "."


### PR DESCRIPTION
This allows migration away from cloudformation into to terraform

elifesciences/issues#9213